### PR TITLE
Enter is not working in Slogan option of invoice template

### DIFF
--- a/src/app/invoice/templates/edit-template/out-tempate/templates/gst-template-a/gst-template-a.component.css
+++ b/src/app/invoice/templates/edit-template/out-tempate/templates/gst-template-a/gst-template-a.component.css
@@ -398,3 +398,9 @@ strong {
 footer p {
   font-size: 14px;
 }
+
+.slogan-pre-line{
+  display: block;
+  white-space: pre-line;
+  line-height: 1.1em;
+}

--- a/src/app/invoice/templates/edit-template/out-tempate/templates/gst-template-a/gst-template-a.component.html
+++ b/src/app/invoice/templates/edit-template/out-tempate/templates/gst-template-a/gst-template-a.component.html
@@ -341,15 +341,13 @@
                                 <hr />                            
                               
                                     <ng-container *ngIf="fieldsAndVisibility.footer.slogan?.display">
-                                          <strong><small *ngIf="fieldsAndVisibility.footer.slogan?.label">
+                                          <strong class="slogan-pre-line"><small *ngIf="fieldsAndVisibility.footer.slogan?.label">
                                                     {{fieldsAndVisibility.footer.slogan?.label }}
-                                                     
                                         </small> </strong>
                                            
                                              <strong> <small *ngIf="fieldsAndVisibility.footer.slogan?.label =='' ">
                                                     {{fieldsAndVisibility.header.companyName?.label}} 
                                                        (Signature)
-                                                      
                                                </small></strong> 
                                            
                                     </ng-container>


### PR DESCRIPTION
Go to the Invoice Templateclick on editselect content go to the third partselect slogan option and type company name and then press enter and type anything in the bracket and save it.

it will show in the same line enter will not work in this case.

For more details BUG-328

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)



* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Other information**:
