### PR TITLE
inventory : create stock default selected is main group fixed

### DIFF
--- a/apps/web-giddh/src/app/sales/aside-menu-product-service/components/create-stock/sales.create.stock.component.ts
+++ b/apps/web-giddh/src/app/sales/aside-menu-product-service/components/create-stock/sales.create.stock.component.ts
@@ -138,6 +138,7 @@ export class SalesAddStockComponent implements OnInit, OnDestroy {
   public ngOnDestroy() {
     this.destroyed$.next(true);
     this.destroyed$.complete();
+    this.selectedGroupUniqueName = '';
   }
 
   // initial unitandRates controls

--- a/apps/web-giddh/src/app/sales/aside-menu-product-service/components/create-stock/sales.create.stock.component.ts
+++ b/apps/web-giddh/src/app/sales/aside-menu-product-service/components/create-stock/sales.create.stock.component.ts
@@ -8,7 +8,6 @@ import { ChangeDetectorRef, Component, EventEmitter, OnDestroy, OnInit, Output }
 import { FormArray, FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { decimalDigits, digitsOnly } from '../../../../shared/helpers/customValidationHelper';
 import { CreateStockRequest, INameUniqueName, StockDetailResponse, StockUnitResponse } from '../../../../models/api-models/Inventory';
-import { Select2OptionData } from '../../../../shared/theme/select2/select2.interface';
 import { InventoryAction } from '../../../../actions/inventory/inventory.actions';
 import { AccountService } from '../../../../services/account.service';
 import { CustomStockUnitAction } from '../../../../actions/inventory/customStockUnit.actions';
@@ -118,6 +117,8 @@ export class SalesAddStockComponent implements OnInit, OnDestroy {
     this.newlyGroupCreated$.pipe(takeUntil(this.destroyed$)).subscribe((o: INameUniqueName) => {
       if (o) {
         this.selectedGroupUniqueName = o.uniqueName;
+      } else{
+      this.selectedGroupUniqueName = 'maingroup';
       }
     });
 
@@ -202,6 +203,9 @@ export class SalesAddStockComponent implements OnInit, OnDestroy {
 
   // submit form
   public addStockFormSubmit() {
+    if(!this.selectedGroupUniqueName) {
+      this.selectedGroupUniqueName = 'maingroup';
+    }
     this.stockCreationInProcess = true;
     let formObj = this.addStockForm.value;
     formObj.manufacturingDetails = null;


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

when create new sock from sales invoice no need to create group. Main group will selected default. 

* **What is the current behavior?** (You can also link to an open issue here)

need to create group first then able to create stock under that group

* **What is the new behavior (if this is a feature change)?**

no need to create group. Default main group will be selected

* **Other information**:
