### PR TITLE
Lodash import issue on latest Typescript

### DIFF
--- a/apps/web-giddh/src/app/shared/helpers/pipes/ghSortByPipe/ghSortByPipe.pipe.ts
+++ b/apps/web-giddh/src/app/shared/helpers/pipes/ghSortByPipe/ghSortByPipe.pipe.ts
@@ -1,5 +1,5 @@
 import { Pipe, PipeTransform } from '@angular/core';
-import * as _ from 'lodash';
+import * as _ from '../../../../lodash-optimized';
 
 @Pipe({name: 'ghSortBy'})
 export class GhSortByPipePipe implements PipeTransform {


### PR DESCRIPTION
ERROR in apps/web-giddh/src/app/shared/helpers/pipes/ghSortByPipe/ghSortByPipe.pipe.ts(14,39): error TS2345: Argument of type 'string[]' is not assignable to parameter of type 'Many<boolean | "asc" | "desc">'.
  Type 'string[]' is not assignable to type 'ReadonlyArray<boolean | "asc" | "desc">'.
    Type 'string' is not assignable to type 'boolean | "asc" | "desc"'.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)



* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Other information**:
