### PR TITLE
Test/Stage- In edit invoice selecting the cancel button changes the local date range set earlier 

### DIFF
--- a/apps/web-giddh/src/app/invoice/preview/invoice.preview.component.html
+++ b/apps/web-giddh/src/app/invoice/preview/invoice.preview.component.html
@@ -399,6 +399,17 @@
 
         </tbody>
 
+      <tbody *ngIf="(isGetAllRequestInProcess$ | async)">
+        <tr>
+          <td colspan="8">
+          <!--loading-->
+          <div class="no-data mrT2 d-flex" style="justify-content: center;align-items: center;margin-top:125px;margin-bottom: 105px;">
+            <div class="giddh-spinner vertical-center-spinner"></div>
+          </div>
+          </td>
+        </tr>
+      </tbody>
+
     </table>
 
     <!--No Entry-->
@@ -413,10 +424,6 @@
         <h1>Do search with some other dates</h1>
     </div>
 
-    <!--loading-->
-    <div class="no-data mrT2 d-flex" *ngIf="(isGetAllRequestInProcess$ | async)" style="justify-content: center;align-items: center">
-        <div class="giddh-spinner vertical-center-spinner"></div>
-    </div>
 
     <!-- Delete invoice confirmation model -->
     <div bsModal #invoiceConfirmationModel="bs-modal" class="modal fade" role="dialog" [config]="{keyboard:true}" tabindex="-1">


### PR DESCRIPTION
…ocal date range set earlier

1. On invoices page, when we set the global date range as app date, then the local date range also sets to the same. Now edit an invoice and select cancel button. The local date range set earlier is changed to last one month date range. Please refer attached video "Issue no.1". : Done
2. Also one more issue related to invoice list page is that when we move from one page to another the loader appears out of table. Please refer attached video "Issue no.2". : Done

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)



* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Other information**:
