### PR TITLE
BUG 578 : Ledger copy pest for special character issue has been resolved

### DIFF
--- a/apps/web-giddh/src/app/shared/helpers/directives/decimalDigits/decimalDigits.directive.ts
+++ b/apps/web-giddh/src/app/shared/helpers/directives/decimalDigits/decimalDigits.directive.ts
@@ -122,8 +122,15 @@ export class DecimalDigitsDirective implements OnDestroy {
   public onPaste(event) {
     if ('decimaldigitsdirective' in event.target.attributes) {
       let cl = event.clipboardData.getData('text/plain');
-      if (!new RegExp('^(\\d+)((\\.)\\d{1,' + this.giddhDecimalPlaces + '})?$', 'g').test(cl)) {
-        cl = 0;
+      if (cl.includes('\'') || cl.includes(',') || cl.includes(' ')) {
+        cl = cl.replace(/\'/g, '');
+        cl = cl.replace(/,/g, '');
+        cl = cl.replace(/ /g, '');
+
+      } else {
+        if (!new RegExp('^(\\d+)((\\.)\\d{1,' + this.giddhDecimalPlaces + '})?$', 'g').test(cl)) {
+          cl = 0;
+        }
       }
       let evt = new Event('input');
       event.target.value = cl;


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

In ledger copy with special character will be able to pest for make Tx

* **What is the current behavior?** (You can also link to an open issue here)

In ledger copy with special character amt will not be able to pest and return 0
* **What is the new behavior (if this is a feature change)?**

In ledger copy with special character amt will be able to pest and return clipboard copy content with removed special char

* **Other information**:
