### PR TITLE
BUG - 609 - Handled the Cash Invoice Scenario in Case of Page Change

### DIFF
--- a/apps/web-giddh/src/app/sales/create/sales.invoice.component.ts
+++ b/apps/web-giddh/src/app/sales/create/sales.invoice.component.ts
@@ -389,7 +389,7 @@ export class SalesInvoiceComponent implements OnInit, OnDestroy, AfterViewInit, 
         let voucherType = VOUCHER_TYPE_LIST.find(f => f.value.toLowerCase() === this.invoiceType);
         this.pageChanged(voucherType.value, voucherType.additional.label);
         this.isCashInvoice = this.accountUniqueName === 'cash';
-
+        this.isSalesInvoice =  !this.isCashInvoice;
         this.store.dispatch(this.invoiceReceiptActions.GetVoucherDetails(this.accountUniqueName, {
           invoiceNumber: this.invoiceNo,
           voucherType: this.invoiceType


### PR DESCRIPTION
In Case of Page Change Check event the isSales Invoice flag was getting set to true by Default and was never set to false if the IsCashInvoice is true

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fixes the Change in case if the sales invoice is enables when the case is cash invoice.


* **What is the current behavior?** (You can also link to an open issue here)
Right now the Balance amount was getting displayed in case of Cash Invoice


* **What is the new behavior (if this is a feature change)?**
Balance invoice can only be displayed in Case of SALE Invoice


* **Other information**:
