### PR TITLE
HOTFIX-G0-793-stage: Gstr 2 pagination issue solved

### DIFF
--- a/apps/web-giddh/src/app/services/apiurls/gstR.api.ts
+++ b/apps/web-giddh/src/app/services/apiurls/gstR.api.ts
@@ -3,7 +3,7 @@ const COMMON_V2 = 'v2/company/:companyUniqueName';
 
 export const GSTR_API = {
   GET_OVERVIEW: COMMON_V2 + '/:gstType-summary?gstin=:gstin&from=:from&to=:to',
-  GET_TRANSACTIONS: COMMON_V2 + '/:gstType-transactions?gstin=:gstin&entityType=:entityType&type=:type&status=:status&from=:from&to=:to',
+  GET_TRANSACTIONS: COMMON_V2 + '/:gstType-transactions?gstin=:gstin&entityType=:entityType&type=:type&page=:page&status=:status&from=:from&to=:to',
   GET_RETURN_SUMMARY: COMMON_URL_FOR_GSTR + '/:gstType-transactions/summary?page=:page&count=:count&gstin=:gstin&gstReturnType=:gstReturnType&from=:from&to=:to',
   GET_TRANSACTIONS_COUNTS: COMMON_URL_FOR_GSTR + '/gstr-transaction-count?gstin=:gstin&from=:from&to=:to',
   GET_DOCUMENT_ISSUED: COMMON_URL_FOR_GSTR + '/gstr1-transactions/documents-issued?gstin=:gstin&from=:from&to=:to',


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

passing page params in pagination for GSTR 2 in get Transactions API

* **What is the current behavior?** (You can also link to an open issue here)

Gstr 2 pagination page params was not passing in API

* **What is the new behavior (if this is a feature change)?**

Gstr 2 pagination page params is passing

* **Other information**:
