### PR TITLE
G0-324 : Inventory Allow to Apply Multiple GST tax

### DIFF
--- a/apps/web-giddh/src/app/inventory/components/add-stock-components/inventory.addstock.component.html
+++ b/apps/web-giddh/src/app/inventory/components/add-stock-components/inventory.addstock.component.html
@@ -94,12 +94,12 @@
                     <div class="btn-group btn-block" dropdown>
                       <button dropdownToggle type="button"
                               class="dropdown-toggle form-control text-left"> Selected
-                        ({{ addStockForm.get('taxes').value.length }}) <span
+                        ({{ taxTempArray.length }}) <span
                           class="pull-right"><span class="caret"></span></span></button>
                       <ul *dropdownMenu class="dropdown-menu dropdown-menu-right" role="menu">
-                        <li role="menuitem" *ngFor="let tax of (companyTaxesList$ | async)">
+                        <li role="menuitem" *ngFor="let tax of (companyTaxesList$ | async)" [ngClass]="{'opacity' : tax.isDisabled}">
                           <a class="dropdown-item" (click)="$event.stopPropagation()"><input
-                            type="checkbox" [checked]="tax.isChecked"
+                            type="checkbox" [disabled]="tax.isDisabled" [checked]="tax.isChecked"
                             (click)="selectTax($event, tax)"/> {{tax.name}}</a>
                         </li>
                         <li *ngIf="(companyTaxesList$ | async).length < 1">

--- a/apps/web-giddh/src/app/inventory/components/add-stock-components/inventory.addstock.component.scss
+++ b/apps/web-giddh/src/app/inventory/components/add-stock-components/inventory.addstock.component.scss
@@ -48,3 +48,7 @@
     color: #F80606;
   }
 }
+
+.opacity{
+  opacity: 0.5;
+}

--- a/apps/web-giddh/src/app/inventory/components/add-stock-components/inventory.addstock.component.ts
+++ b/apps/web-giddh/src/app/inventory/components/add-stock-components/inventory.addstock.component.ts
@@ -79,7 +79,7 @@ export class InventoryAddStockComponent implements OnInit, AfterViewInit, OnDest
 
   constructor(private store: Store<AppState>, private route: ActivatedRoute, private sideBarAction: SidebarAction,
     private _fb: FormBuilder, private inventoryAction: InventoryAction, private _accountService: AccountService,
-    private customStockActions: CustomStockUnitAction, private ref: ChangeDetectorRef, private _toasty: ToasterService, private _inventoryService: InventoryService, private companyActions: CompanyActions, private invoiceActions: InvoiceActions,
+    private customStockActions: CustomStockUnitAction, private _toasty: ToasterService, private _inventoryService: InventoryService, private companyActions: CompanyActions, private invoiceActions: InvoiceActions,
     private invViewService: InvViewService, private cdr:ChangeDetectorRef) {
     this.fetchingStockUniqueName$ = this.store.select(state => state.inventory.fetchingStockUniqueName).pipe(takeUntil(this.destroyed$));
     this.isStockNameAvailable$ = this.store.select(state => state.inventory.isStockNameAvailable).pipe(takeUntil(this.destroyed$));

--- a/apps/web-giddh/src/app/inventory/components/add-stock-components/inventory.addstock.component.ts
+++ b/apps/web-giddh/src/app/inventory/components/add-stock-components/inventory.addstock.component.ts
@@ -74,12 +74,13 @@ export class InventoryAddStockComponent implements OnInit, AfterViewInit, OnDest
   public isManageInventory$: Observable<boolean>;
   public invoiceSetting$: Observable<any>;
   public customFieldsArray: any[] = [];
+  public taxTempArray: any[] = [];
   private destroyed$: ReplaySubject<boolean> = new ReplaySubject(1);
 
   constructor(private store: Store<AppState>, private route: ActivatedRoute, private sideBarAction: SidebarAction,
     private _fb: FormBuilder, private inventoryAction: InventoryAction, private _accountService: AccountService,
     private customStockActions: CustomStockUnitAction, private ref: ChangeDetectorRef, private _toasty: ToasterService, private _inventoryService: InventoryService, private companyActions: CompanyActions, private invoiceActions: InvoiceActions,
-    private invViewService: InvViewService) {
+    private invViewService: InvViewService, private cdr:ChangeDetectorRef) {
     this.fetchingStockUniqueName$ = this.store.select(state => state.inventory.fetchingStockUniqueName).pipe(takeUntil(this.destroyed$));
     this.isStockNameAvailable$ = this.store.select(state => state.inventory.isStockNameAvailable).pipe(takeUntil(this.destroyed$));
     this.activeGroup$ = this.store.select(s => s.inventory.activeGroup).pipe(takeUntil(this.destroyed$));
@@ -184,8 +185,9 @@ export class InventoryAddStockComponent implements OnInit, AfterViewInit, OnDest
       parentGroup: [''],
       hsnNumber: [''],
       sacNumber: [''],
-      taxes: this._fb.array([])
+      taxes: [[]]
     });
+    this.taxTempArray=[];
 
     // subscribe isFsStock for disabling manufacturingDetails
     this.addStockForm.controls['isFsStock'].valueChanges.subscribe((v) => {
@@ -308,11 +310,12 @@ export class InventoryAddStockComponent implements OnInit, AfterViewInit, OnDest
         this.companyTaxesList$.subscribe((tax) => {
           _.forEach(tax, (o) => {
             o.isChecked = false;
+            o.isDisabled = false;
           });
         });
 
+        this.taxTempArray=[];
         if (a.taxes.length) {
-          this.addStockForm.get('taxes').patchValue([]);
           this.mapSavedTaxes(a.taxes);
         }
         this.store.dispatch(this.inventoryAction.hideLoaderForStock());
@@ -322,6 +325,14 @@ export class InventoryAddStockComponent implements OnInit, AfterViewInit, OnDest
       }
     });
 
+    this.companyTaxesList$.subscribe((tax) => {
+      _.forEach(tax, (o) => {
+        o.isChecked = false;
+        o.isDisabled = false;
+      });
+    });
+    this.cdr.detectChanges();
+
     // subscribe createStockSuccess for resting form
     this.createStockSuccess$.subscribe(s => {
       if (s) {
@@ -330,6 +341,14 @@ export class InventoryAddStockComponent implements OnInit, AfterViewInit, OnDest
         if (this.activeGroup) {
           this.addStockForm.get('parentGroup').patchValue(this.activeGroup.uniqueName);
         }
+        this.taxTempArray = [];
+        this.companyTaxesList$.subscribe((taxes) => {
+          _.forEach(taxes, (o) => {
+            o.isChecked = false;
+            o.isDisabled = false;
+          });
+        });
+        this.addStockForm.get('taxes').patchValue('');
       }
     });
 
@@ -966,15 +985,64 @@ export class InventoryAddStockComponent implements OnInit, AfterViewInit, OnDest
    * selectTax
    */
   public selectTax(e, tax) {
-    const taxesControls = this.addStockForm.controls['taxes']['value'] as any;
-    if (e.target.checked) {
-      tax.isChecked = true;
-      taxesControls.push(tax.uniqueName);
-    } else {
-      let idx = _.findIndex(taxesControls, (o) => o === tax.uniqueName);
-      taxesControls.splice(idx, 1);
-      tax.isChecked = false;
+    if(tax.taxType!=='gstcess') {
+      let index = _.findIndex(this.taxTempArray, (o) => o.taxType === tax.taxType);
+      if (index > -1 && e.target.checked) {
+        this.companyTaxesList$.subscribe((taxes) => {
+          _.forEach(taxes, (o) => {
+            if (o.taxType === tax.taxType) {
+              o.isChecked = false;
+              o.isDisabled = true;
+            }
+          });
+        });
+      }
+
+      if (index < 0 && e.target.checked) {
+        this.companyTaxesList$.subscribe((taxes) => {
+          _.forEach(taxes, (o) => {
+            if (o.taxType === tax.taxType) {
+              o.isChecked = false;
+              o.isDisabled = true;
+            }
+            if (o.uniqueName === tax.uniqueName) {
+              tax.isChecked = true;
+              tax.isDisabled = false;
+              this.taxTempArray.push(tax);
+            }
+          });
+        });
+      } else if (index > -1 && e.target.checked) {
+        tax.isChecked = true;
+        tax.isDisabled = false;
+        this.taxTempArray = this.taxTempArray.filter(ele => {
+          return tax.taxType !== ele.taxType;
+        });
+        this.taxTempArray.push(tax);
+      } else {
+        let idx = _.findIndex(this.taxTempArray, (o) => o.uniqueName === tax.uniqueName);
+        this.taxTempArray.splice(idx, 1);
+        tax.isChecked = false;
+        this.companyTaxesList$.subscribe((taxes) => {
+          _.forEach(taxes, (o) => {
+            if (o.taxType === tax.taxType) {
+              o.isDisabled = false;
+            }
+          });
+        });
+      }
+    }else {
+      if (e.target.checked) {
+        this.taxTempArray.push(tax);
+        tax.isChecked = true;
+      } else {
+        let idx = _.findIndex(this.taxTempArray, (o) => o.uniqueName === tax.uniqueName);
+        this.taxTempArray.splice(idx, 1);
+        tax.isChecked = false;
+      }
     }
+
+    this.addStockForm.get('taxes').patchValue(this.taxTempArray.map(m => m.uniqueName));
   }
 
   /**

--- a/apps/web-giddh/src/app/sales/create/sales.invoice.component.html
+++ b/apps/web-giddh/src/app/sales/create/sales.invoice.component.html
@@ -594,7 +594,7 @@
                         <td class="text-right">
                           <sales-tax-list class="salesTax" [showTaxPopup]="false" [taxListAutoRender]="entry.taxList"
                                           [applicableTaxes]="transaction.applicableTaxes"
-                                          [exceptTaxTypes]="['tdsrc', 'tdspay','tcspay', 'tcsrc']"
+                                          [exceptTaxTypes]="exceptTaxTypes"
                                           [allowedSelectionOfAType]="[{ type: ['GST', 'commongst', 'InputGST'], count:1 }]"
                                           (selectedTaxEvent)="selectedTaxEvent($event)"
                                           (closeOtherPopupEvent)="closeDiscountPopup()"


### PR DESCRIPTION
In Inventory module user should not be allowed to apply more than 1 GST tax at a time on a stock. So disable other GST taxes in dropdown when user select a GST tax.

In Inventory module user should not be allowed to apply more than 1 InputGST tax at a time on a stock. So disable other InputGST taxes in dropdown when user select an InputGST tax.

In Inventory module user can apply GST and InputGST simultaneously on a stock.

4. In Inventory module when user apply GST and InputGST simultaneously on a stock and:

a) In Sales invoice when user selects the same stock then only GST tax should be pre-applied and not InputGST.

b) In Purchase invoice when user selects the same stock then only InputGST tax should be pre-applied and not GST.

c) In Cash invoice when user selects the same stock then only GST tax should be pre-applied and not InputGST.