### PR TITLE
vendor tab updated

### DIFF
--- a/apps/web-giddh/src/app/contact/contact.component.html
+++ b/apps/web-giddh/src/app/contact/contact.component.html
@@ -161,13 +161,13 @@
                 <table  class="text-right">
                   <tr>
                     <td>
-                      <p *ngIf="activeTab == 'vendor'">Purchase</p>
-                      <p *ngIf="activeTab == 'customer'">Sales</p>
+                      <p *ngIf="activeTab === 'vendor'">Purchase</p>
+                      <p *ngIf="activeTab === 'customer'">Sales</p>
                       <h3>{{getTotalSales() |giddhCurrency }}/-</h3>
                     </td>
                     <td>
-                      <p *ngIf="activeTab == 'vendor'">Payment</p>
-                      <p *ngIf="activeTab == 'customer'">Receipt</p>
+                      <p *ngIf="activeTab === 'vendor'">Payment</p>
+                      <p *ngIf="activeTab === 'customer'">Receipt</p>
                       <h3>{{getTotalReceipts() | giddhCurrency}}/-</h3>
                     </td>
                     <td>

--- a/apps/web-giddh/src/app/contact/contact.component.html
+++ b/apps/web-giddh/src/app/contact/contact.component.html
@@ -158,14 +158,16 @@
 
             <div class="bg-white clearfix">
               <div class="customer-right clearfix" style="width: 100%;">
-                <table style="" class="text-right">
+                <table  class="text-right">
                   <tr>
                     <td>
-                      <p>Sales</p>
+                      <p *ngIf="activeTab == 'vendor'">Purchase</p>
+                      <p *ngIf="activeTab == 'customer'">Sales</p>
                       <h3>{{getTotalSales() |giddhCurrency }}/-</h3>
                     </td>
                     <td>
-                      <p>Receipts</p>
+                      <p *ngIf="activeTab == 'vendor'">Payment</p>
+                      <p *ngIf="activeTab == 'customer'">Receipt</p>
                       <h3>{{getTotalReceipts() | giddhCurrency}}/-</h3>
                     </td>
                     <td>


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

feature

* **What is the current behavior?** (You can also link to an open issue here)

In Vendor section the labels Sales and Receipt under Result total section were Sales and Receipt


* **What is the new behavior (if this is a feature change)?**
In Vendor section the labels Sales and Receipt under Result total section  renamed as Purchase and Payment


* **Other information**:
