### PR TITLE
additional charges in red

### DIFF
--- a/apps/web-giddh/src/app/userDetails/components/subscriptions/subscriptions.component.html
+++ b/apps/web-giddh/src/app/userDetails/components/subscriptions/subscriptions.component.html
@@ -98,7 +98,7 @@
                                         <td>{{ seletedUserPlans?.totalTransactions ? seletedUserPlans?.totalTransactions : 0 }}</td>
                                         <!-- <span class="text-light ml-05">({{transaction.previousTransactionCount}}+{{transaction.currentTransactionCount}})</span> -->
                                         <td>{{ seletedUserPlans?.balance? seletedUserPlans?.balance: 0 }}</td>
-                                        <td>{{ seletedUserPlans?.additionalCharges? seletedUserPlans?.additionalCharges: 0 }}</td>
+                                        <td class="text-danger">{{ seletedUserPlans?.additionalCharges? seletedUserPlans?.additionalCharges: 0 }}</td>
                                     </tr>
                                 </tbody>
                             </table>


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix


* **What is the current behavior?** (You can also link to an open issue here)
Additional amount is not displaying in red in color.


* **What is the new behavior (if this is a feature change)?**

Additional amount is now displaying in red in color.


* **Other information**:
