### PR TITLE
Linked account tax list

### DIFF
--- a/apps/web-giddh/src/app/shared/aside-menu-create-tax/aside-menu-create-tax.component.ts
+++ b/apps/web-giddh/src/app/shared/aside-menu-create-tax/aside-menu-create-tax.component.ts
@@ -10,6 +10,8 @@ import * as moment from 'moment/moment';
 import { SettingsTaxesActions } from '../../actions/settings/taxes/settings.taxes.action';
 import { ToasterService } from '../../services/toaster.service';
 import { uniqueNameInvalidStringReplace } from '../helpers/helperFunctions';
+import { group } from '@angular/animations';
+import { GroupsAccountSidebarComponent } from '../header/components';
 
 @Component({
   selector: 'aside-menu-create-tax-component',
@@ -61,12 +63,28 @@ export class AsideMenuCreateTaxComponent implements OnInit, OnChanges {
 
   ngOnInit() {
     this.store
-      .pipe(select(p => p.general.flattenAccounts), takeUntil(this.destroyed$))
+      .pipe(select(p => p.general.groupswithaccounts), takeUntil(this.destroyed$))
       .subscribe(data => {
-        if (data && data.length) {
+        if (data) {
           let arr: IOption[] = [];
           data.forEach(f => {
-            arr.push({label: `${f.name} - (${f.uniqueName})`, value: f.uniqueName});
+            if(f.uniqueName === "currentliabilities")
+            {
+              if(f.groups)
+              {
+               f.groups.forEach(f => { 
+               if(f.uniqueName === "dutiestaxes")
+               {
+                if(f.groups)
+                {
+                  f.groups.forEach(f => { 
+                  arr.push({label: `${f.name} - (${f.uniqueName})`, value: f.uniqueName});
+                  });
+                }
+              }
+              });
+              }
+           }
           });
           this.flattenAccountsOptions = arr;
         }

--- a/apps/web-giddh/src/app/shared/aside-menu-create-tax/aside-menu-create-tax.component.ts
+++ b/apps/web-giddh/src/app/shared/aside-menu-create-tax/aside-menu-create-tax.component.ts
@@ -10,8 +10,6 @@ import * as moment from 'moment/moment';
 import { SettingsTaxesActions } from '../../actions/settings/taxes/settings.taxes.action';
 import { ToasterService } from '../../services/toaster.service';
 import { uniqueNameInvalidStringReplace } from '../helpers/helperFunctions';
-import { group } from '@angular/animations';
-import { GroupsAccountSidebarComponent } from '../header/components';
 
 @Component({
   selector: 'aside-menu-create-tax-component',
@@ -67,18 +65,18 @@ export class AsideMenuCreateTaxComponent implements OnInit, OnChanges {
       .subscribe(data => {
         if (data) {
           let arr: IOption[] = [];
-          data.forEach(f => {
-            if(f.uniqueName === "currentliabilities")
+          data.forEach(acc => {
+            if(acc.uniqueName === "currentliabilities")
             {
-              if(f.groups)
+              if(acc.groups)
               {
-               f.groups.forEach(f => { 
-               if(f.uniqueName === "dutiestaxes")
+               acc.groups.forEach(grp => { 
+               if(grp.uniqueName === "dutiestaxes")
                {
-                if(f.groups)
+                if(grp.groups)
                 {
-                  f.groups.forEach(f => { 
-                  arr.push({label: `${f.name} - (${f.uniqueName})`, value: f.uniqueName});
+                  grp.groups.forEach(subgrp => { 
+                  arr.push({label: `${subgrp.name} - (${subgrp.uniqueName})`, value: subgrp.uniqueName});
                   });
                 }
               }


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix


* **What is the current behavior?** (You can also link to an open issue here)
If other tax is selected then, in linked account drop-down duties and taxes should be displayed


* **What is the new behavior (if this is a feature change)?**
If other tax is selected then, in linked account drop-down duties and taxes are displayed


* **Other information**:
