### PR TITLE
gst template a company address issue fixed in case of null address

### DIFF
--- a/apps/web-giddh/src/app/invoice/templates/edit-template/out-tempate/templates/gst-template-a/gst-template-a.component.html
+++ b/apps/web-giddh/src/app/invoice/templates/edit-template/out-tempate/templates/gst-template-a/gst-template-a.component.html
@@ -654,7 +654,7 @@
                 </p>
                 <p class="abc " [ngStyle]="{ 'font-size': inputTemplate.fontMedium + 'px', 'white-space' : 'pre-line'} "
                     *ngIf="fieldsAndVisibility.footer.companyAddress?.display ">
-                    {{fieldsAndVisibility.footer.companyAddress?.label ? fieldsAndVisibility.footer.companyAddress?.label : '405-406, Capt. C. S. Naydu Arcade, 10/2, Old Palasia, near Greater Kailash Hospital, Indore 452001(M. P.)'}}
+                    {{fieldsAndVisibility.footer.companyAddress?.label ? fieldsAndVisibility.footer.companyAddress?.label : ''}}
                 </p>
             </footer>
         </div>


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

In case of null company address will showing hard coded walkover address in template a

* **What is the current behavior?** (You can also link to an open issue here)

In case of null company address will showing hard coded walkover address in template a


* **What is the new behavior (if this is a feature change)?**
In case of null company address will showing null address in template a



* **Other information**:
