### PR TITLE
added app-login-success route for electron success call back,

### DIFF
--- a/apps/web-giddh/src/app/app-login-success/app-login-success.html
+++ b/apps/web-giddh/src/app/app-login-success/app-login-success.html
@@ -1,0 +1,7 @@
+<div class="flex-col">
+    <div class="inner">
+        <img src="../assets/images/giddh-big-logo.svg" alt="">
+        <span>Congrats!</span>
+        <p>You are successfully logged in. You can close this tab now. 😉</p>
+    </div>
+</div>

--- a/apps/web-giddh/src/app/app-login-success/app-login-success.scss
+++ b/apps/web-giddh/src/app/app-login-success/app-login-success.scss
@@ -1,0 +1,31 @@
+.flex-col {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    flex-direction: column;
+    height: 100vh;
+    .inner {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        flex-direction: column;
+    }
+    img {
+        width: 400px;
+        opacity: 0.3;
+    }
+    span {
+        font-size: 40px;
+        font-weight: bold;
+        display: block;
+        margin-top: 20px;
+    }
+    p {
+        color: #7b7c7d;
+        line-height: 30px;
+        margin-top: 20px;
+        margin-bottom: 20px;
+        font-size: 22px;
+        text-align: center;
+    }
+}

--- a/apps/web-giddh/src/app/app-login-success/app-login-success.ts
+++ b/apps/web-giddh/src/app/app-login-success/app-login-success.ts
@@ -1,0 +1,13 @@
+import { Component } from '@angular/core';
+
+@Component({
+    selector: 'app-login-success',
+    styleUrls: ['./app-login-success.scss'],
+    templateUrl: './app-login-success.html'
+})
+export class AppLoginSuccessComponent {
+
+    constructor() {
+        //
+    }
+}

--- a/apps/web-giddh/src/app/app.module.ts
+++ b/apps/web-giddh/src/app/app.module.ts
@@ -1,70 +1,71 @@
-import { GiddhHttpInterceptor } from './services/http.interceptor';
+import {GiddhHttpInterceptor} from './services/http.interceptor';
 // import { SuccessComponent } from './settings/linked-accounts/success.component';
-import { BrowserModule } from '@angular/platform-browser';
-import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { HTTP_INTERCEPTORS, HttpClientModule } from '@angular/common/http';
+import {BrowserModule} from '@angular/platform-browser';
+import {FormsModule, ReactiveFormsModule} from '@angular/forms';
+import {HTTP_INTERCEPTORS, HttpClientModule} from '@angular/common/http';
 
-import { NgModule } from '@angular/core';
-import { RouterModule } from '@angular/router';
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { ActionReducer, MetaReducer, StoreModule } from '@ngrx/store';
+import {NgModule} from '@angular/core';
+import {RouterModule} from '@angular/router';
+import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
+import {ActionReducer, MetaReducer, StoreModule} from '@ngrx/store';
 import * as _ from './lodash-optimized';
 /*
  * Platform and Environment providers/pipes/pipes
  */
-import { ROUTES } from './app.routes';
-import { reducers } from './store';
+import {ROUTES} from './app.routes';
+import {reducers} from './store';
 // App is our top level component
-import { AppComponent } from './app.component';
-import { APP_BASE_HREF } from '@angular/common';
-import { APP_RESOLVER_PROVIDERS } from './app.resolver';
-import { PageComponent } from './page.component';
-import { NoContentComponent } from './no-content/no-content.component';
-import { SharedModule } from './shared/shared.module';
-import { ServiceModule } from './services/service.module';
-import { ToastrModule } from 'ngx-toastr';
-import { PERFECT_SCROLLBAR_CONFIG, PerfectScrollbarModule } from 'ngx-perfect-scrollbar';
-import { DummyComponent } from './dummy.component';
-import { WindowRef } from './shared/helpers/window.object';
-import { NewUserComponent } from './newUser.component';
-import { SocialLoginCallbackComponent } from './social-login-callback.component';
-import { BsDatepickerModule, DatepickerModule } from 'ngx-bootstrap/datepicker';
-import { TooltipModule } from 'ngx-bootstrap/tooltip';
-import { PaginationModule } from 'ngx-bootstrap/pagination';
-import { CollapseModule } from 'ngx-bootstrap/collapse';
-import { ModalModule } from 'ngx-bootstrap/modal';
-import { TabsModule } from 'ngx-bootstrap/tabs';
-import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
-import { PopoverModule } from 'ngx-bootstrap/popover';
-import { LaddaModule } from 'angular2-ladda';
-import { ShSelectModule } from './theme/ng-virtual-select/sh-select.module';
-import { LoaderComponent } from './loader/loader.component';
-import { NgbTypeaheadModule } from '@ng-bootstrap/ng-bootstrap';
-import { localStorageSync } from 'ngrx-store-localstorage';
-import { ActionModule } from './actions/action.module';
-import { DecoratorsModule } from './decorators/decorators.module';
-import { PerfectScrollbarConfigInterface } from 'ngx-perfect-scrollbar/dist/lib/perfect-scrollbar.interfaces';
-import { Configuration } from 'apps/web-giddh/src/app/app.constant';
-import { ServiceConfig } from 'apps/web-giddh/src/app/services/service.config';
-import { Daterangepicker } from 'apps/web-giddh/src/app/theme/ng2-daterangepicker/daterangepicker.module';
-import { PublicPageHandlerComponent } from './public-page-handler.component';
-import { OnboardingComponent } from './onboarding/onboarding.component';
-import { NotFoundComponent } from './404/404-component';
-import { IS_ELECTRON_WA } from './app.constant';
-import { UniversalListModule } from './theme/universal-list/universal.list.module';
-import { StoreRouterConnectingModule } from '@ngrx/router-store';
-import { StoreDevtoolsModule } from '@ngrx/store-devtools';
-import { BrowserDetectComponent } from './browser-support/browserDetect.component';
-import { CustomPreloadingStrategy } from './services/lazy-preloading.service';
-import { environment } from '../environments/environment';
-import { SelectPlanComponent } from './selectPlan/selectPlan.component';
-import { BillingDetailComponent } from './billing-details/billingDetail.component';
-import { TokenVerifyComponent } from './login/token-verify.component';
+import {AppComponent} from './app.component';
+import {APP_BASE_HREF} from '@angular/common';
+import {APP_RESOLVER_PROVIDERS} from './app.resolver';
+import {PageComponent} from './page.component';
+import {NoContentComponent} from './no-content/no-content.component';
+import {SharedModule} from './shared/shared.module';
+import {ServiceModule} from './services/service.module';
+import {ToastrModule} from 'ngx-toastr';
+import {PERFECT_SCROLLBAR_CONFIG, PerfectScrollbarModule} from 'ngx-perfect-scrollbar';
+import {DummyComponent} from './dummy.component';
+import {WindowRef} from './shared/helpers/window.object';
+import {NewUserComponent} from './newUser.component';
+import {SocialLoginCallbackComponent} from './social-login-callback.component';
+import {BsDatepickerModule, DatepickerModule} from 'ngx-bootstrap/datepicker';
+import {TooltipModule} from 'ngx-bootstrap/tooltip';
+import {PaginationModule} from 'ngx-bootstrap/pagination';
+import {CollapseModule} from 'ngx-bootstrap/collapse';
+import {ModalModule} from 'ngx-bootstrap/modal';
+import {TabsModule} from 'ngx-bootstrap/tabs';
+import {BsDropdownModule} from 'ngx-bootstrap/dropdown';
+import {PopoverModule} from 'ngx-bootstrap/popover';
+import {LaddaModule} from 'angular2-ladda';
+import {ShSelectModule} from './theme/ng-virtual-select/sh-select.module';
+import {LoaderComponent} from './loader/loader.component';
+import {NgbTypeaheadModule} from '@ng-bootstrap/ng-bootstrap';
+import {localStorageSync} from 'ngrx-store-localstorage';
+import {ActionModule} from './actions/action.module';
+import {DecoratorsModule} from './decorators/decorators.module';
+import {PerfectScrollbarConfigInterface} from 'ngx-perfect-scrollbar/dist/lib/perfect-scrollbar.interfaces';
+import {Configuration} from 'apps/web-giddh/src/app/app.constant';
+import {ServiceConfig} from 'apps/web-giddh/src/app/services/service.config';
+import {Daterangepicker} from 'apps/web-giddh/src/app/theme/ng2-daterangepicker/daterangepicker.module';
+import {PublicPageHandlerComponent} from './public-page-handler.component';
+import {OnboardingComponent} from './onboarding/onboarding.component';
+import {NotFoundComponent} from './404/404-component';
+import {IS_ELECTRON_WA} from './app.constant';
+import {UniversalListModule} from './theme/universal-list/universal.list.module';
+import {StoreRouterConnectingModule} from '@ngrx/router-store';
+import {StoreDevtoolsModule} from '@ngrx/store-devtools';
+import {BrowserDetectComponent} from './browser-support/browserDetect.component';
+import {CustomPreloadingStrategy} from './services/lazy-preloading.service';
+import {environment} from '../environments/environment';
+import {SelectPlanComponent} from './selectPlan/selectPlan.component';
+import {BillingDetailComponent} from './billing-details/billingDetail.component';
+import {TokenVerifyComponent} from './login/token-verify.component';
+import {AppLoginSuccessComponent} from "./app-login-success/app-login-success";
 
 // Application wide providers
 const APP_PROVIDERS = [
     ...APP_RESOLVER_PROVIDERS,
-    { provide: APP_BASE_HREF, useValue: IS_ELECTRON_WA ? './' : AppUrl + APP_FOLDER }
+    {provide: APP_BASE_HREF, useValue: IS_ELECTRON_WA ? './' : AppUrl + APP_FOLDER}
     // { provide: APP_BASE_HREF, useValue: './' }
 ];
 
@@ -84,14 +85,14 @@ let CONDITIONAL_IMPORTS = [];
 
 export function localStorageSyncReducer(reducer: ActionReducer<any>): ActionReducer<any> {
     // return localStorageSync({ keys: ['session', 'permission'], rehydrate: true, storage: IS_ELECTRON_WA ? sessionStorage : localStorage })(reducer);
-    return localStorageSync({ keys: ['session', 'permission'], rehydrate: true, storage: localStorage })(reducer);
+    return localStorageSync({keys: ['session', 'permission'], rehydrate: true, storage: localStorage})(reducer);
     // return localStorageSync({ keys: ['session', 'permission'], rehydrate: true, storage: sessionStorage })(reducer);
 }
 
 let metaReducers: Array<MetaReducer<any, any>> = [localStorageSyncReducer];
 if (!environment.production) {
     // metaReducers.push(storeFreeze);
-    CONDITIONAL_IMPORTS.push(StoreDevtoolsModule.instrument({ maxAge: 50 }));
+    CONDITIONAL_IMPORTS.push(StoreDevtoolsModule.instrument({maxAge: 50}));
 }
 const DEFAULT_PERFECT_SCROLLBAR_CONFIG: PerfectScrollbarConfigInterface = {
     suppressScrollX: true
@@ -111,7 +112,7 @@ const DEFAULT_PERFECT_SCROLLBAR_CONFIG: PerfectScrollbarConfigInterface = {
         TokenVerifyComponent,
         DummyComponent,
         BillingDetailComponent,
-
+        AppLoginSuccessComponent,
         // SuccessComponent,
         NewUserComponent,
         BrowserDetectComponent,
@@ -121,9 +122,9 @@ const DEFAULT_PERFECT_SCROLLBAR_CONFIG: PerfectScrollbarConfigInterface = {
         SelectPlanComponent,
         // SignupComponent
     ],
-	/**
-	 * Import Angular's modules.
-	 */
+    /**
+     * Import Angular's modules.
+     */
     imports: [
         BrowserModule,
         Daterangepicker,
@@ -152,24 +153,28 @@ const DEFAULT_PERFECT_SCROLLBAR_CONFIG: PerfectScrollbarConfigInterface = {
         DecoratorsModule.forRoot(),
         ShSelectModule.forRoot(),
         UniversalListModule.forRoot(),
-        ToastrModule.forRoot({ preventDuplicates: true, maxOpened: 3 }),
-        StoreModule.forRoot(reducers, { metaReducers }),
+        ToastrModule.forRoot({preventDuplicates: true, maxOpened: 3}),
+        StoreModule.forRoot(reducers, {metaReducers}),
         PerfectScrollbarModule,
-        RouterModule.forRoot(ROUTES, { useHash: IS_ELECTRON_WA, preloadingStrategy: CustomPreloadingStrategy, onSameUrlNavigation: 'reload' }),
+        RouterModule.forRoot(ROUTES, {
+            useHash: IS_ELECTRON_WA,
+            preloadingStrategy: CustomPreloadingStrategy,
+            onSameUrlNavigation: 'reload'
+        }),
         StoreRouterConnectingModule,
         ...CONDITIONAL_IMPORTS,
 
-		/**
-		 * This section will import the `DevModuleModule` only in certain build types.
-		 * When the module is not imported it will get tree shaked.
-		 * This is a simple example, a big app should probably implement some logic
-		 */
+        /**
+         * This section will import the `DevModuleModule` only in certain build types.
+         * When the module is not imported it will get tree shaked.
+         * This is a simple example, a big app should probably implement some logic
+         */
         // ...environment.showDevModule ? [DevModuleModule] : [],
     ],
-	/**
-	 * Expose our Services and Providers into Angular's dependency injection.
-	 * enableTracing: true,
-	 */
+    /**
+     * Expose our Services and Providers into Angular's dependency injection.
+     * enableTracing: true,
+     */
     providers: [
         environment.ENV_PROVIDERS,
         APP_PROVIDERS,
@@ -180,7 +185,7 @@ const DEFAULT_PERFECT_SCROLLBAR_CONFIG: PerfectScrollbarConfigInterface = {
         },
         {
             provide: ServiceConfig,
-            useValue: { apiUrl: Configuration.ApiUrl, appUrl: Configuration.AppUrl, _ }
+            useValue: {apiUrl: Configuration.ApiUrl, appUrl: Configuration.AppUrl, _}
         },
         {
             provide: HTTP_INTERCEPTORS,

--- a/apps/web-giddh/src/app/app.routes.ts
+++ b/apps/web-giddh/src/app/app.routes.ts
@@ -1,119 +1,197 @@
-// import { MagicLinkComponent } from './magic-link/magic-link.component';
-import { NeedsAuthorization } from './decorators/needAuthorization';
-// import { SuccessComponent } from './settings/linked-accounts/success.component';
-import { PageComponent } from './page.component';
-import { Routes } from '@angular/router';
-import { NeedsAuthentication } from './decorators/needsAuthentication';
-import { UserAuthenticated } from './decorators/UserAuthenticated';
-import { DummyComponent } from './dummy.component';
-import { NewUserComponent } from './newUser.component';
-import { NewUserAuthGuard } from './decorators/newUserGuard';
-import { SocialLoginCallbackComponent } from './social-login-callback.component';
-import { PublicPageHandlerComponent } from './public-page-handler.component';
-import { WelcomeComponent } from './welcome/welcome.component';
-import { OnboardingComponent } from './onboarding/onboarding.component';
-import { NotFoundComponent } from './404/404-component';
-import { BrowserSupported } from './decorators/BrowserSupported';
-import { BrowserDetectComponent } from './browser-support/browserDetect.component';
-import { SelectPlanComponent } from './selectPlan/selectPlan.component';
-import { BillingDetailComponent } from './billing-details/billingDetail.component';
-import { TokenVerifyComponent } from './login/token-verify.component';
+import {NeedsAuthorization} from './decorators/needAuthorization';
+import {PageComponent} from './page.component';
+import {Routes} from '@angular/router';
+import {NeedsAuthentication} from './decorators/needsAuthentication';
+import {UserAuthenticated} from './decorators/UserAuthenticated';
+import {DummyComponent} from './dummy.component';
+import {NewUserComponent} from './newUser.component';
+import {NewUserAuthGuard} from './decorators/newUserGuard';
+import {SocialLoginCallbackComponent} from './social-login-callback.component';
+import {PublicPageHandlerComponent} from './public-page-handler.component';
+import {WelcomeComponent} from './welcome/welcome.component';
+import {OnboardingComponent} from './onboarding/onboarding.component';
+import {NotFoundComponent} from './404/404-component';
+import {BrowserSupported} from './decorators/BrowserSupported';
+import {BrowserDetectComponent} from './browser-support/browserDetect.component';
+import {SelectPlanComponent} from './selectPlan/selectPlan.component';
+import {BillingDetailComponent} from './billing-details/billingDetail.component';
+import {TokenVerifyComponent} from './login/token-verify.component';
+import {AppLoginSuccessComponent} from "./app-login-success/app-login-success";
 
 export const ROUTES: Routes = [
-    { path: '', redirectTo: 'login', pathMatch: 'full' },
-    { path: '404', component: NotFoundComponent },
+    {path: '', redirectTo: 'login', pathMatch: 'full'},
+    {path: '404', component: NotFoundComponent},
+    {path: 'app-login-success', component: AppLoginSuccessComponent, pathMatch: 'full'},
     {
         path: 'token-verify',
         component: TokenVerifyComponent
     },
-    { path: 'create-invoice', loadChildren: './create/create.module#CreateModule' },
-    { path: 'login', loadChildren: './login/login.module#LoginModule', canActivate: [BrowserSupported, UserAuthenticated] },
-    { path: 'signup', loadChildren: './signup/signup.module#SignupModule' },
-    { path: 'inventory', redirectTo: 'pages/inventory', pathMatch: 'full' },
-    { path: 'inventory-in-out', redirectTo: 'pages/inventory-in-out', pathMatch: 'full' },
+    {path: 'create-invoice', loadChildren: './create/create.module#CreateModule'},
+    {
+        path: 'login',
+        loadChildren: './login/login.module#LoginModule',
+        canActivate: [BrowserSupported, UserAuthenticated]
+    },
+    {path: 'signup', loadChildren: './signup/signup.module#SignupModule'},
+    {path: 'inventory', redirectTo: 'pages/inventory', pathMatch: 'full'},
+    {path: 'inventory-in-out', redirectTo: 'pages/inventory-in-out', pathMatch: 'full'},
     // { path: 'success', component: SuccessComponent },
-    { path: 'home', redirectTo: 'pages/home', pathMatch: 'full' },
+    {path: 'home', redirectTo: 'pages/home', pathMatch: 'full'},
     // { path: 'magic', loadChildren: './magic-link/magicLink.module#MagicLinkModule' },
-    { path: 'search', redirectTo: 'pages/search', pathMatch: 'full' },
-    { path: 'permissions', redirectTo: 'pages/permissions', pathMatch: 'full' },
-    { path: 'settings', redirectTo: 'pages/settings', pathMatch: 'full' },
-    { path: 'manufacturing', redirectTo: 'pages/manufacturing', pathMatch: 'full' },
-    { path: 'about', redirectTo: 'pages/about', pathMatch: 'full' },
-    { path: 'trial-balance-and-profit-loss', redirectTo: 'pages/trial-balance-and-profit-loss', pathMatch: 'full' },
-    { path: 'audit-logs', redirectTo: 'pages/audit-logs', pathMatch: 'full' },
-    { path: 'ledger', redirectTo: 'pages/ledger' },
-    { path: 'dummy', component: DummyComponent },
-    { path: 'browser-support', component: BrowserDetectComponent },
-    { path: 'new-user', component: NewUserComponent, canActivate: [NewUserAuthGuard] },
-    { path: 'welcome', component: WelcomeComponent },
-    { path: 'onboarding', redirectTo: 'pages/onboarding', pathMatch: 'full' },
-    { path: 'social-login-callback', component: SocialLoginCallbackComponent },
-    { path: 'invoice', redirectTo: 'pages/invoice', pathMatch: 'full' },
-    { path: 'sales', redirectTo: 'pages/proforma-invoice/invoice/sales' },
-    { path: 'daybook', redirectTo: 'pages/daybook', pathMatch: 'full' },
-    { path: 'purchase', redirectTo: 'pages/purchase', pathMatch: 'full' },
-    { path: 'user-details', redirectTo: 'pages/user-details', pathMatch: 'full' },
-    { path: 'accounting-voucher', redirectTo: 'pages/accounting-voucher', pathMatch: 'full' },
-    { path: 'contact', redirectTo: 'pages/contact' },
-    { path: 'aging-report', redirectTo: 'pages/aging-report', pathMatch: 'full' },
-    { path: 'import', redirectTo: 'pages/import', pathMatch: 'full' },
-    { path: 'gstfiling', redirectTo: 'pages/gstfiling', pathMatch: 'full' },
-    { path: 'company-import-export', redirectTo: 'pages/company-import-export', pathMatch: 'full' },
+    {path: 'search', redirectTo: 'pages/search', pathMatch: 'full'},
+    {path: 'permissions', redirectTo: 'pages/permissions', pathMatch: 'full'},
+    {path: 'settings', redirectTo: 'pages/settings', pathMatch: 'full'},
+    {path: 'manufacturing', redirectTo: 'pages/manufacturing', pathMatch: 'full'},
+    {path: 'about', redirectTo: 'pages/about', pathMatch: 'full'},
+    {path: 'trial-balance-and-profit-loss', redirectTo: 'pages/trial-balance-and-profit-loss', pathMatch: 'full'},
+    {path: 'audit-logs', redirectTo: 'pages/audit-logs', pathMatch: 'full'},
+    {path: 'ledger', redirectTo: 'pages/ledger'},
+    {path: 'dummy', component: DummyComponent},
+    {path: 'browser-support', component: BrowserDetectComponent},
+    {path: 'new-user', component: NewUserComponent, canActivate: [NewUserAuthGuard]},
+    {path: 'welcome', component: WelcomeComponent},
+    {path: 'onboarding', redirectTo: 'pages/onboarding', pathMatch: 'full'},
+    {path: 'social-login-callback', component: SocialLoginCallbackComponent},
+    {path: 'invoice', redirectTo: 'pages/invoice', pathMatch: 'full'},
+    {path: 'sales', redirectTo: 'pages/proforma-invoice/invoice/sales'},
+    {path: 'daybook', redirectTo: 'pages/daybook', pathMatch: 'full'},
+    {path: 'purchase', redirectTo: 'pages/purchase', pathMatch: 'full'},
+    {path: 'user-details', redirectTo: 'pages/user-details', pathMatch: 'full'},
+    {path: 'accounting-voucher', redirectTo: 'pages/accounting-voucher', pathMatch: 'full'},
+    {path: 'contact', redirectTo: 'pages/contact'},
+    {path: 'aging-report', redirectTo: 'pages/aging-report', pathMatch: 'full'},
+    {path: 'import', redirectTo: 'pages/import', pathMatch: 'full'},
+    {path: 'gstfiling', redirectTo: 'pages/gstfiling', pathMatch: 'full'},
+    {path: 'company-import-export', redirectTo: 'pages/company-import-export', pathMatch: 'full'},
     // { path: 'purchase/create', redirectTo: 'pages/purchase/create' },
     // { path: 'credit-note/create', redirectTo: 'pages/credit-note/create' },
     // { path: 'debit-note/create', redirectTo: 'pages/debit-note/create' },
-    { path: 'new-vs-old-invoices', redirectTo: 'pages/new-vs-old-invoices', pathMatch: 'full' },
-    { path: 'reports', redirectTo: 'pages/reports', pathMatch: 'full' },
-    { path: 'proforma-invoice', redirectTo: 'pages/proforma-invoice', pathMatch: 'full' },
-    { path: 'select-plan', component: SelectPlanComponent },
-    { path: 'billing-detail', component: BillingDetailComponent },
-    { path: 'billing-detail/buy-plan', component: BillingDetailComponent },
+    {path: 'new-vs-old-invoices', redirectTo: 'pages/new-vs-old-invoices', pathMatch: 'full'},
+    {path: 'reports', redirectTo: 'pages/reports', pathMatch: 'full'},
+    {path: 'proforma-invoice', redirectTo: 'pages/proforma-invoice', pathMatch: 'full'},
+    {path: 'select-plan', component: SelectPlanComponent},
+    {path: 'billing-detail', component: BillingDetailComponent},
+    {path: 'billing-detail/buy-plan', component: BillingDetailComponent},
     {
         path: 'pages', component: PageComponent, canActivate: [NeedsAuthentication],
         children: [
-            { path: 'home', loadChildren: './home/home.module#HomeModule', canActivate: [NeedsAuthorization] },
-            { path: 'invoice', loadChildren: './invoice/invoice.module#InvoiceModule', canActivate: [NeedsAuthorization] },
+            {path: 'home', loadChildren: './home/home.module#HomeModule', canActivate: [NeedsAuthorization]},
+            {
+                path: 'invoice',
+                loadChildren: './invoice/invoice.module#InvoiceModule',
+                canActivate: [NeedsAuthorization]
+            },
             // { path: 'sales', loadChildren: './sales/sales.module#SalesModule', canActivate: [NeedsAuthorization] },
-            { path: 'daybook', loadChildren: './daybook/daybook.module#DaybookModule', canActivate: [NeedsAuthorization] },
-            { path: 'purchase', loadChildren: './purchase/purchase.module#PurchaseModule', canActivate: [NeedsAuthorization] },
-            { path: 'about', loadChildren: './about/about.module#AboutModule' },
+            {
+                path: 'daybook',
+                loadChildren: './daybook/daybook.module#DaybookModule',
+                canActivate: [NeedsAuthorization]
+            },
+            {
+                path: 'purchase',
+                loadChildren: './purchase/purchase.module#PurchaseModule',
+                canActivate: [NeedsAuthorization]
+            },
+            {path: 'about', loadChildren: './about/about.module#AboutModule'},
             //{ path: 'aging-report', loadChildren: './aging-report/aging-report.module#AgingReportModule' },
-            { path: 'inventory', loadChildren: './inventory/inventory.module#InventoryModule', canActivate: [NeedsAuthorization] },
-            { path: 'inventory-in-out', loadChildren: './inventory-in-out/inventory-in-out.module#InventoryInOutModule', canActivate: [NeedsAuthorization] },
-            { path: 'search', loadChildren: './search/search.module#SearchModule' },
-            { path: 'trial-balance-and-profit-loss', loadChildren: './tb-pl-bs/tb-pl-bs.module#TBPlBsModule', canActivate: [NeedsAuthentication, NeedsAuthorization] },
-            { path: 'audit-logs', loadChildren: './audit-logs/audit-logs.module#AuditLogsModule', canActivate: [NeedsAuthorization] },
-            { path: 'ledger', loadChildren: './ledger/ledger.module#LedgerModule', canActivate: [NeedsAuthorization] },
-            { path: 'permissions', loadChildren: './permissions/permission.module#PermissionModule', canActivate: [NeedsAuthorization] },
-            { path: 'settings', loadChildren: './settings/settings.module#SettingsModule', canActivate: [NeedsAuthorization] },
-            { path: 'manufacturing', loadChildren: './manufacturing/manufacturing.module#ManufacturingModule', canActivate: [NeedsAuthorization] },
-            { path: 'accounting-voucher', loadChildren: './accounting/accounting.module#AccountingModule' },
-            { path: 'user-details', loadChildren: './userDetails/userDetails.module#UserDetailsModule' },
-            { path: 'contact', loadChildren: './contact/contact.module#ContactModule', canActivate: [NeedsAuthorization] },
-            { path: 'new-vs-old-invoices', loadChildren: './new-vs-old-Invoices/new-vs-old-Invoices.module#NewVsOldInvoicesModule', canActivate: [NeedsAuthorization] },
-            { path: 'import', loadChildren: './import-excel/import-excel.module#ImportExcelModule', canActivate: [NeedsAuthorization] },
-            { path: 'gstfiling', loadChildren: './gst/gst.module#GstModule' },
-            { path: 'company-import-export', loadChildren: './companyImportExport/companyImportExport.module#CompanyImportExportModule' },
+            {
+                path: 'inventory',
+                loadChildren: './inventory/inventory.module#InventoryModule',
+                canActivate: [NeedsAuthorization]
+            },
+            {
+                path: 'inventory-in-out',
+                loadChildren: './inventory-in-out/inventory-in-out.module#InventoryInOutModule',
+                canActivate: [NeedsAuthorization]
+            },
+            {path: 'search', loadChildren: './search/search.module#SearchModule'},
+            {
+                path: 'trial-balance-and-profit-loss',
+                loadChildren: './tb-pl-bs/tb-pl-bs.module#TBPlBsModule',
+                canActivate: [NeedsAuthentication, NeedsAuthorization]
+            },
+            {
+                path: 'audit-logs',
+                loadChildren: './audit-logs/audit-logs.module#AuditLogsModule',
+                canActivate: [NeedsAuthorization]
+            },
+            {path: 'ledger', loadChildren: './ledger/ledger.module#LedgerModule', canActivate: [NeedsAuthorization]},
+            {
+                path: 'permissions',
+                loadChildren: './permissions/permission.module#PermissionModule',
+                canActivate: [NeedsAuthorization]
+            },
+            {
+                path: 'settings',
+                loadChildren: './settings/settings.module#SettingsModule',
+                canActivate: [NeedsAuthorization]
+            },
+            {
+                path: 'manufacturing',
+                loadChildren: './manufacturing/manufacturing.module#ManufacturingModule',
+                canActivate: [NeedsAuthorization]
+            },
+            {path: 'accounting-voucher', loadChildren: './accounting/accounting.module#AccountingModule'},
+            {path: 'user-details', loadChildren: './userDetails/userDetails.module#UserDetailsModule'},
+            {
+                path: 'contact',
+                loadChildren: './contact/contact.module#ContactModule',
+                canActivate: [NeedsAuthorization]
+            },
+            {
+                path: 'new-vs-old-invoices',
+                loadChildren: './new-vs-old-Invoices/new-vs-old-Invoices.module#NewVsOldInvoicesModule',
+                canActivate: [NeedsAuthorization]
+            },
+            {
+                path: 'import',
+                loadChildren: './import-excel/import-excel.module#ImportExcelModule',
+                canActivate: [NeedsAuthorization]
+            },
+            {path: 'gstfiling', loadChildren: './gst/gst.module#GstModule'},
+            {
+                path: 'company-import-export',
+                loadChildren: './companyImportExport/companyImportExport.module#CompanyImportExportModule'
+            },
             // { path: 'purchase/create', loadChildren: './sales/sales.module#SalesModule', canActivate: [NeedsAuthorization] },
             // { path: 'credit-note/create', loadChildren: './sales/sales.module#SalesModule', canActivate: [NeedsAuthorization] },
             // { path: 'debit-note/create', loadChildren: './sales/sales.module#SalesModule', canActivate: [NeedsAuthorization] },
-            { path: 'reports', loadChildren: './reports/reports.module#ReportsModule', canActivate: [NeedsAuthorization] },
-            { path: 'proforma-invoice', loadChildren: './proforma-invoice/proforma-invoice.module#ProformaInvoiceModule', canActivate: [NeedsAuthorization] },
-            { path: 'onboarding', component: OnboardingComponent, canActivate: [NeedsAuthorization] },
-            { path: 'welcome', component: WelcomeComponent, canActivate: [NeedsAuthorization] },
-            { path: 'select-plan', component: SelectPlanComponent, canActivate: [NeedsAuthorization] },
-            { path: 'billing-detail', component: BillingDetailComponent, canActivate: [NeedsAuthorization] },
-            { path: 'tallysync', loadChildren: './tallysync/tallysync.module#TallysyncModule', canActivate: [NeedsAuthorization] },
+            {
+                path: 'reports',
+                loadChildren: './reports/reports.module#ReportsModule',
+                canActivate: [NeedsAuthorization]
+            },
+            {
+                path: 'proforma-invoice',
+                loadChildren: './proforma-invoice/proforma-invoice.module#ProformaInvoiceModule',
+                canActivate: [NeedsAuthorization]
+            },
+            {path: 'onboarding', component: OnboardingComponent, canActivate: [NeedsAuthorization]},
+            {path: 'welcome', component: WelcomeComponent, canActivate: [NeedsAuthorization]},
+            {path: 'select-plan', component: SelectPlanComponent, canActivate: [NeedsAuthorization]},
+            {path: 'billing-detail', component: BillingDetailComponent, canActivate: [NeedsAuthorization]},
+            {
+                path: 'tallysync',
+                loadChildren: './tallysync/tallysync.module#TallysyncModule',
+                canActivate: [NeedsAuthorization]
+            },
 
-            { path: 'expenses-manager', loadChildren: './expenses/expenses.module#ExpensesModule', canActivate: [NeedsAuthorization] },
+            {
+                path: 'expenses-manager',
+                loadChildren: './expenses/expenses.module#ExpensesModule',
+                canActivate: [NeedsAuthorization]
+            },
 
-            { path: 'vat-report', loadChildren: './vat-report/vatReport.module#VarReportModule', canActivate: [NeedsAuthorization] },
+            {
+                path: 'vat-report',
+                loadChildren: './vat-report/vatReport.module#VarReportModule',
+                canActivate: [NeedsAuthorization]
+            },
 
-            { path: '**', redirectTo: 'home', pathMatch: 'full' }
+            {path: '**', redirectTo: 'home', pathMatch: 'full'}
             // {path: '**', pathMatch: 'full', component: NotFoundComponent},
 
         ]
     },
-    // { path: '**', redirectTo: 'login', pathMatch: 'full', canActivate: [CheckIfPublicPath] },
-    { path: '**', pathMatch: 'full', component: PublicPageHandlerComponent },
+    {path: '**', pathMatch: 'full', component: PublicPageHandlerComponent},
 ];


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bugfix, feature, docs update, ...)

this PR is to add app-login-success page. So after electron login User can see the below page. 
![image (3)](https://user-images.githubusercontent.com/8776031/73356197-cafd3500-42bf-11ea-80a4-92ef3db7db55.png)


* **What is the current behavior?** (You can also link to an open issue here)

currently, it is not showing any page. 

* **What is the new behavior (if this is a feature change)?**
after Electron login they see a success login page.




* **Other information**:
