### PR TITLE
Fixed | 4126 | Prod - Virtual account error is displayed for users who had enabled virtual account before this feature was removed

### DIFF
--- a/apps/web-giddh/src/app/actions/accounts.actions.ts
+++ b/apps/web-giddh/src/app/actions/accounts.actions.ts
@@ -171,9 +171,9 @@ export class AccountsAction {
                 } else {
                     this._generalServices.eventHandler.next({ name: eventsConst.accountAdded, payload: action.payload });
                     this._toasty.successToast('Account Created Successfully');
-                    if (action.payload.body.errorMessageForCashFreeVirtualAccount) {
-                        this._toasty.warningToast('Virtual account could not be created for Account "' + action.payload.body.name + '", ' + action.payload.body.errorMessageForCashFreeVirtualAccount);
-                    }
+                    // if (action.payload.body.errorMessageForCashFreeVirtualAccount) {
+                    //     this._toasty.warningToast('Virtual account could not be created for Account "' + action.payload.body.name + '", ' + action.payload.body.errorMessageForCashFreeVirtualAccount);
+                    // }
                     // if (action.payload.body.errorMessageForBankDetails) {
                     //   this._toasty.warningToast(action.payload.body.errorMessageForBankDetails);
                     // }

--- a/apps/web-giddh/src/app/actions/ledger/ledger.actions.ts
+++ b/apps/web-giddh/src/app/actions/ledger/ledger.actions.ts
@@ -235,9 +235,9 @@ export class LedgerActions {
                     };
                 } else {
                     this._toasty.successToast('Account Created Successfully');
-                    if (action.payload.body.errorMessageForCashFreeVirtualAccount) {
-                        this._toasty.warningToast('Virtual account could not be created for Account "' + action.payload.body.name + '", ' + action.payload.body.errorMessageForCashFreeVirtualAccount);
-                    }
+                    // if (action.payload.body.errorMessageForCashFreeVirtualAccount) {
+                    //     this._toasty.warningToast('Virtual account could not be created for Account "' + action.payload.body.name + '", ' + action.payload.body.errorMessageForCashFreeVirtualAccount);
+                    // }
                     // if (action.payload.body.errorMessageForBankDetails) {
                     //   this._toasty.warningToast(action.payload.body.errorMessageForBankDetails);
                     // }

--- a/apps/web-giddh/src/app/actions/sales/sales.action.ts
+++ b/apps/web-giddh/src/app/actions/sales/sales.action.ts
@@ -110,9 +110,9 @@ export class SalesActions {
                     };
                 } else {
                     this._toasty.successToast('Account Created Successfully');
-                    if (action.payload.body.errorMessageForCashFreeVirtualAccount) {
-                        this._toasty.warningToast('Virtual account could not be created for Account "' + action.payload.body.name + '", ' + action.payload.body.errorMessageForCashFreeVirtualAccount);
-                    }
+                    // if (action.payload.body.errorMessageForCashFreeVirtualAccount) {
+                    //     this._toasty.warningToast('Virtual account could not be created for Account "' + action.payload.body.name + '", ' + action.payload.body.errorMessageForCashFreeVirtualAccount);
+                    // }
                     // if (action.payload.body.errorMessageForBankDetails) {
                     //   this._toasty.warningToast(action.payload.body.errorMessageForBankDetails);
                     // }

--- a/apps/web-giddh/src/app/invoice/settings/invoice.settings.component.html
+++ b/apps/web-giddh/src/app/invoice/settings/invoice.settings.component.html
@@ -52,7 +52,7 @@
 
                             </div>
 
-                            <div class="clearfix pdT1" *ngIf="false">
+                            <!-- <div class="clearfix pdT1">
                                 <div class="row">
 
                                     <div class="col-xs-12 col-sm-3">
@@ -67,7 +67,7 @@
                                     </div>
                                 </div>
 
-                            </div>
+                            </div> -->
 
                             <!-- region razor-pay-->
                             <div class="clearfix pdT1" *ngIf="false">


### PR DESCRIPTION
This issue is reported by Sheba. Virtual account error is displayed for those existing Production users who had enabled virtual account feature before this Cash free feature i.e. Cash free API was removed from Prod. So this error should not be displayed now. 