### PR TITLE
Fixed G0-3980 | Prod- In the GST module date picker issue

### DIFF
--- a/apps/web-giddh/src/app/gst/gst.component.html
+++ b/apps/web-giddh/src/app/gst/gst.component.html
@@ -15,7 +15,7 @@
                     <li>
                         <div class="btn-group dropdown" dropdown [autoClose]="false"
                             (isOpenChange)="onOpenChange($event)" #periodDropdown="bs-dropdown"
-                            (clickOutside)="periodDropdown.hide()" [attachOutsideOnClick]="true"
+                            (clickOutside)="checkIfDatepickerVisible()" [attachOutsideOnClick]="true"
                             [isDisabled]="((gstr1OverviewDataInProgress$ | async) || (gstr2OverviewDataInProgress$ | async)) || !activeCompanyGstNumber">
                             <button id="button-nested" dropdownToggle type="button"
                                 class="dropdown clearfix list-title filter-by return-sel font-large dropdown-toggle pull-left"
@@ -56,7 +56,7 @@
                                 </li>
 
                                 <li role="menuitem">
-                                    <a class="dropdown-item" href="javascript:void(0)" (click)="monthWise.hide()">
+                                    <a class="dropdown-item" href="javascript:void(0)" (click)="updateDatepickerVisibility('visible'); monthWise.hide()">
                                         <label for="daterangeInput" class="d-block cp">Custom Range
                                             <div class="pull-right">
                                                 <span class="caret rotate-90"></span>
@@ -67,7 +67,7 @@
                                         <input id="daterangeInput" type="text" name="daterangeInput"
                                             [options]="{'autoApply': true}" #dateRangePickerCmp daterangepicker
                                             class="form-control daterangePicker"
-                                            (applyDaterangepicker)="periodChanged($event);" />
+                                            (applyDaterangepicker)="periodChanged($event);" (hideDaterangepicker)="updateDatepickerVisibility('hidden')" />
                                     </a>
                                 </li>
 

--- a/apps/web-giddh/src/app/gst/gst.component.ts
+++ b/apps/web-giddh/src/app/gst/gst.component.ts
@@ -40,8 +40,11 @@ import { createSelector } from 'reselect';
         ])
     ]
 })
+
 export class GstComponent implements OnInit {
     @ViewChild('monthWise') public monthWise: BsDropdownDirective;
+    @ViewChild('periodDropdown') public periodDropdown;
+
     public showCalendar: boolean = false;
     public period: any = null;
     public companies: CompanyResponse[] = [];
@@ -72,6 +75,7 @@ export class GstComponent implements OnInit {
     public selectedMonth: any = null;
     public userEmail: string = '';
     public returnGstr3B: {} = { via: null };
+    public datepickerVisibility: any = 'hidden';
 
     private destroyed$: ReplaySubject<boolean> = new ReplaySubject(1);
 
@@ -261,4 +265,15 @@ export class GstComponent implements OnInit {
         this.openMonthWiseCalendar(data);
     }
 
+    public updateDatepickerVisibility(visibility) {
+        this.datepickerVisibility = visibility;
+    }
+
+    public checkIfDatepickerVisible() {
+        setTimeout(() => {
+            if(this.datepickerVisibility === "hidden") {
+                this.periodDropdown.hide();
+            }
+        }, 500);    
+    }
 }


### PR DESCRIPTION
Steps

1. Go to GST module

2. Click on the Date picker > Custom range

3. Click on the left/right arrows to set the range

4. Then the calendar shifts to the upward direction which is not expected

Actual- The calendar shifts to the upward direction which is not expected

Expected- The calendar should not be shifted upward side when the user tries to set the date range