### PR TITLE
fix: Add nullity check in get currency rate method in proforma

### DIFF
--- a/apps/web-giddh/src/app/proforma-invoice/proforma-invoice.component.ts
+++ b/apps/web-giddh/src/app/proforma-invoice/proforma-invoice.component.ts
@@ -3448,24 +3448,26 @@ export class ProformaInvoiceComponent implements OnInit, OnDestroy, AfterViewIni
     }
 
     public getCurrencyRate(to, from, date = moment().format('DD-MM-YYYY')) {
-        this._ledgerService.GetCurrencyRateNewApi(from, to, date).subscribe(response => {
-            let rate = response.body;
-            if (rate) {
-                this.originalExchangeRate = rate;
-                this.exchangeRate = rate;
-                this._cdr.detectChanges();
-                if (this.isPurchaseInvoice && this.isUpdateMode) {
-                    // TODO: Remove this code once purchase invoice supports multicurrency
-                    this.calculateSubTotal();
-                    this.calculateTotalDiscount();
-                    this.calculateTotalTaxSum();
-                    this.calculateGrandTotal();
-                    this.calculateBalanceDue();
+        if (from && to) {
+            this._ledgerService.GetCurrencyRateNewApi(from, to, date).subscribe(response => {
+                let rate = response.body;
+                if (rate) {
+                    this.originalExchangeRate = rate;
+                    this.exchangeRate = rate;
+                    this._cdr.detectChanges();
+                    if (this.isPurchaseInvoice && this.isUpdateMode) {
+                        // TODO: Remove this code once purchase invoice supports multicurrency
+                        this.calculateSubTotal();
+                        this.calculateTotalDiscount();
+                        this.calculateTotalTaxSum();
+                        this.calculateGrandTotal();
+                        this.calculateBalanceDue();
+                    }
                 }
-            }
-        }, (error => {
+            }, (error => {
 
-        }));
+            }));
+        }
     }
 
     public updateBankAccountObject(accCurr) {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
It avoids the API call to currency rate api if either of the from or to date is a falsy value


* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Other information**:
