### PR TITLE
HOTFIX: taxes linked account added current assets and current liabilities grp i…

### DIFF
--- a/apps/web-giddh/src/app/shared/aside-menu-create-tax/aside-menu-create-tax.component.ts
+++ b/apps/web-giddh/src/app/shared/aside-menu-create-tax/aside-menu-create-tax.component.ts
@@ -82,21 +82,14 @@ export class AsideMenuCreateTaxComponent implements OnInit, OnChanges {
 
         this.store.pipe(select(p => p.general.flattenAccounts), takeUntil(this.destroyed$)).subscribe(res => {
             let arr: IOption[] = [];
-            // TODO: API development under process
-            // if (res) {
-            //     let accountObject = res.filter(accountObj =>
-            //         accountObj.parentGroups && accountObj.parentGroups.length > 1 &&
-            //         ["currentassets", "currentliabilities"].includes(accountObj.parentGroups[0].uniqueName) &&
-            //         !["cash", "bankaccounts", "sundrydebtors", "sundrycreditors"].includes(accountObj.parentGroups[1].uniqueName));
-            //     accountObject.forEach(accountObj => {
-            //         arr.push({ label: `${accountObj.name} - (${accountObj.uniqueName})`, value: accountObj.uniqueName });
-            //     });
-            // }
             if (res) {
-                res.filter(f => f.parentGroups.some(s => s.uniqueName === 'dutiestaxes'))
-                    .forEach(r => {
-                        arr.push({ label: `${r.name} - (${r.uniqueName})`, value: r.uniqueName });
-                    });
+                let accountObject = res.filter(accountObj =>
+                    accountObj.parentGroups && accountObj.parentGroups.length > 1 &&
+                    ["currentassets", "currentliabilities"].includes(accountObj.parentGroups[0].uniqueName) &&
+                    !["cash", "bankaccounts", "sundrydebtors", "sundrycreditors", "reversecharge", "taxonadvance"].includes(accountObj.parentGroups[1].uniqueName));
+                accountObject.forEach(accountObj => {
+                    arr.push({ label: `${accountObj.name} - (${accountObj.uniqueName})`, value: accountObj.uniqueName });
+                });
             } else {
                 arr = [];
             }


### PR DESCRIPTION
…n case of other

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Need to update the list of accounts which are displayed in 'Linked Account' dropdown for 'Other' Tax type 

* **What is the current behavior?** (You can also link to an open issue here)

only takesandduties grp implemented 

* **What is the new behavior (if this is a feature change)?**
include currentassets", "currentliabilities and 
exclude groups "cash", "bankaccounts", "sundrydebtors", "sundrycreditors", "reversecharge", "taxonadvance"

* **Other information**:
