### PR TITLE
Hotfix/g0 4409

### DIFF
--- a/apps/web-giddh/src/app/shared/header/header.component.html
+++ b/apps/web-giddh/src/app/shared/header/header.component.html
@@ -429,7 +429,7 @@
 
         <div class="nav_wrapper">
 
-            <perfect-scrollbar class="scrClass" wheel-propagation="true" wheel-speed="1" min-scrollbar-length="0" auto-height [scrollIndicators]="false" (psYReachEnd)="menuScrollEnd($event)">
+            <perfect-scrollbar class="scrClass" wheel-propagation="true" wheel-speed="1" min-scrollbar-length="0" auto-height [scrollIndicators]="false">
 
                 <!-- Accounts menu -->
                 <ul class="left_fixed_header mrT1" [ngClass]="{'open':sideMenu.isopen}" *ngIf="(selectedCompany | async)">
@@ -471,10 +471,9 @@
                             <span class="label">{{menu.name}}</span>
                         </a>
                     </li>
-                    <li id="other" *ngIf="!isMobileSite" (mouseenter)="allModulesPopover.show()" (mouseleave)="allModulesPopover.hide()">
-                        <a #allModulesPopover="bs-popover" [popover]="allModules" placement="right" container="body"
-                            containerClass="all-modules-popover" (mouseenter)="allModulesPopover.show()"
-                            (mouseleave)="allModulesPopover.hide()">All
+                    <li id="other" *ngIf="!isMobileSite" (mouseenter)="allModulesPopover.show()" (mouseleave)="handleAllModulesLeaveEvent($event)">
+                        <a #allModulesPopover="bs-popover" [popover]="allModules" placement="right" containerClass="all-modules-popover"
+                            (mouseenter)="allModulesPopover.show()" container="body">All
                             Modules <i *ngIf="!isMobileSite" tooltip="All Modules" placement="bottom" container="body"
                                 class="fa fa-angle-right cp"></i></a>
                     </li>

--- a/apps/web-giddh/src/app/shared/header/header.component.html
+++ b/apps/web-giddh/src/app/shared/header/header.component.html
@@ -471,12 +471,92 @@
                             <span class="label">{{menu.name}}</span>
                         </a>
                     </li>
-                    <li id="other" *ngIf="!isMobileSite" (click)="toggleAllmoduleMenu()" (mouseenter)="showOtherMenu = true" (mouseleave)="showOtherMenu = false">
-                        <a (mouseenter)="openSubMenu(true)" (mouseleave)="openSubMenu(false)">All Modules <i
-                                *ngIf="!isMobileSite" tooltip="All Modules" placement="bottom" container="body"
+                    <li id="other" *ngIf="!isMobileSite" (mouseenter)="allModulesPopover.show()" (mouseleave)="allModulesPopover.hide()">
+                        <a #allModulesPopover="bs-popover" [popover]="allModules" placement="right" container="body"
+                            containerClass="all-modules-popover" (mouseenter)="allModulesPopover.show()"
+                            (mouseleave)="allModulesPopover.hide()">All
+                            Modules <i *ngIf="!isMobileSite" tooltip="All Modules" placement="bottom" container="body"
                                 class="fa fa-angle-right cp"></i></a>
                     </li>
+                    <!-- All Modules list -->
+                    <ng-template #allModules>
+                        <ul class="left-sub-menu left_fixed_header open" id="other_sub_menu" (mouseenter)="allModulesPopover.show()"
+                            (mouseleave)="allModulesPopover.hide()" style="height: fit-content">
+                            <li>
+                                <div class="clearfix">
+                                    <ul>
+                                        <li><a href="javascript:void(0)"><strong>General</strong></a></li>
+                                        <li><a (click)="analyzeOtherMenus('contact/customer', {tab: 'customer', tabIndex: 0})">Customer</a>
+                                        </li>
+                                        <li><a (click)="analyzeOtherMenus('contact/vendor', {tab: 'vendor', tabIndex: 0})">Vendor</a>
+                                        </li>
+                                        <li><a (click)="analyzeOtherMenus('accounting-voucher')">Journal Voucher</a>
+                                        </li>
+                                        <li><a (click)="analyzeOtherMenus('daybook')">Daybook</a></li>
+                                        <li><a
+                                                (click)="analyzeOtherMenus('trial-balance-and-profit-loss', { tab: 'trial-balance', tabIndex: 0 })">
+                                                Trial Balance</a></li>
+                                        <li><a
+                                                (click)="analyzeOtherMenus('trial-balance-and-profit-loss', { tab: 'trial-balance', tabIndex: 1 })">P&L,
+                                                B/S</a></li>
+                                    </ul>
 
+                                    <ul>
+                                        <li><a href="javascript:void(0)"><strong>Invoice</strong></a></li>
+                                        <li><a (click)="analyzeOtherMenus('proforma-invoice/invoice/sales')">Sales</a></li>
+                                        <li><a (click)="analyzeOtherMenus('proforma-invoice/invoice/purchase')">Purchase</a></li>
+                                        <li><a (click)="analyzeOtherMenus('proforma-invoice/invoice/cash')">Cash</a></li>
+                                        <li><a
+                                                (click)="analyzeOtherMenus('invoice/preview/credit note', {tab: 'credit note', tabIndex: 1})">Dr/Cr
+                                                Note</a></li>
+                                        <li><a
+                                                (click)="analyzeOtherMenus('invoice/preview/sales', {tab: 'templates', tabIndex: 3})">Template</a>
+                                        </li>
+                                        <li><a (click)="analyzeOtherMenus('invoice/preview/sales', {tab: 'invoice', tabIndex: 0})">Invoice
+                                                Management</a></li>
+                                    </ul>
+
+                                    <ul>
+                                        <li><a href="javascript:void(0)"><strong>Inventory</strong></a></li>
+                                        <li><a (click)="analyzeOtherMenus('inventory')">Inventory</a></li>
+                                        <li><a (click)="analyzeOtherMenus('manufacturing/report')">Manufacturing</a></li>
+                                        <!-- <li><a (click)="analyzeOtherMenus('inventory/jobwork')">Job Work</a></li> -->
+                                        <li><a (click)="analyzeOtherMenus('inventory/report')">Branch Transfer</a></li>
+                                        <li><a (click)="analyzeOtherMenus('settings/warehouse')">Warehouse</a></li>
+                                    </ul>
+
+                                    <ul>
+                                        <li><a href="javascript:void(0)"><strong>Settings</strong></a></li>
+                                        <li><a (click)="analyzeOtherMenus('permissions')">Permission</a></li>
+                                        <li><a (click)="analyzeOtherMenus('import/select-type')">Import Data</a></li>
+                                        <li>
+                                            <a (click)="analyzeOtherMenus('settings/integration', { tab: 'integration', tabIndex: 1 })">Integration
+                                            </a>
+                                        </li>
+                                        <li>
+                                            <a (click)="analyzeOtherMenus('settings/taxes', { tab: 'taxes', tabIndex: 0 })">Settings
+                                            </a>
+                                        </li>
+                                    </ul>
+
+                                    <ul>
+                                        <li><a href="#"><strong>Others</strong></a></li>
+                                        <li><a (click)="analyzeOtherMenus('audit-logs')">Audit Log</a></li>
+                                        <li><a (click)="analyzeOtherMenus('search')">Search</a></li>
+                                        <li><a (click)="analyzeOtherMenus('gstfiling')"
+                                                *ngIf="activeCompany && activeCompany.countryV2 && activeCompany.countryV2.alpha2CountryCode == 'IN'">GSTR</a>
+                                        </li>
+                                        <li><a (click)="analyzeOtherMenus('vat-report')"
+                                                *ngIf="activeCompany && activeCompany.countryV2 && activeCompany.countryV2.alpha2CountryCode != 'IN'">Vat
+                                                Report</a></li>
+                                        <li><a (click)="analyzeOtherMenus('home')">Dashboard</a></li>
+                                    </ul>
+
+                                </div>
+                            </li>
+
+                        </ul>
+                    </ng-template>
                 </ul>
                 <!-- <app-fixed-footer></app-fixed-footer> -->
 
@@ -484,76 +564,6 @@
 
         </div>
 
-        <!-- All Modules list -->
-        <ul class="left-sub-menu left_fixed_header" id="other_sub_menu" [ngClass]="{'open': showOtherMenu}" (mouseenter)="showOtherMenu = true" (mouseleave)="showOtherMenu = false" style="height: fit-content">
-            <li>
-                <div class="clearfix">
-                    <ul>
-                        <li><a href="javascript:void(0)"><strong>General</strong></a></li>
-                        <li><a (click)="analyzeOtherMenus('contact/customer', {tab: 'customer', tabIndex: 0})">Customer</a>
-                        </li>
-                        <li><a (click)="analyzeOtherMenus('contact/vendor', {tab: 'vendor', tabIndex: 0})">Vendor</a>
-                        </li>
-                        <li><a (click)="analyzeOtherMenus('accounting-voucher')">Journal Voucher</a>
-                        </li>
-                        <li><a (click)="analyzeOtherMenus('daybook')">Daybook</a></li>
-                        <li><a (click)="analyzeOtherMenus('trial-balance-and-profit-loss', { tab: 'trial-balance', tabIndex: 0 })">
-                                Trial Balance</a></li>
-                        <li><a (click)="analyzeOtherMenus('trial-balance-and-profit-loss', { tab: 'trial-balance', tabIndex: 1 })">P&L,
-                                B/S</a></li>
-                    </ul>
-
-                    <ul>
-                        <li><a href="javascript:void(0)"><strong>Invoice</strong></a></li>
-                        <li><a (click)="analyzeOtherMenus('proforma-invoice/invoice/sales')">Sales</a></li>
-                        <li><a (click)="analyzeOtherMenus('proforma-invoice/invoice/purchase')">Purchase</a></li>
-                        <li><a (click)="analyzeOtherMenus('proforma-invoice/invoice/cash')">Cash</a></li>
-                        <li><a (click)="analyzeOtherMenus('invoice/preview/credit note', {tab: 'credit note', tabIndex: 1})">Dr/Cr
-                                Note</a></li>
-                        <li><a (click)="analyzeOtherMenus('invoice/preview/sales', {tab: 'templates', tabIndex: 3})">Template</a>
-                        </li>
-                        <li><a (click)="analyzeOtherMenus('invoice/preview/sales', {tab: 'invoice', tabIndex: 0})">Invoice
-                                Management</a></li>
-                    </ul>
-
-                    <ul>
-                        <li><a href="javascript:void(0)"><strong>Inventory</strong></a></li>
-                        <li><a (click)="analyzeOtherMenus('inventory')">Inventory</a></li>
-                        <li><a (click)="analyzeOtherMenus('manufacturing/report')">Manufacturing</a></li>
-                        <!-- <li><a (click)="analyzeOtherMenus('inventory/jobwork')">Job Work</a></li> -->
-                        <li><a (click)="analyzeOtherMenus('inventory/report')">Branch Transfer</a></li>
-                        <li><a (click)="analyzeOtherMenus('settings/warehouse')">Warehouse</a></li>
-                    </ul>
-
-                    <ul>
-                        <li><a href="javascript:void(0)"><strong>Settings</strong></a></li>
-                        <li><a (click)="analyzeOtherMenus('permissions')">Permission</a></li>
-                        <li><a (click)="analyzeOtherMenus('import/select-type')">Import Data</a></li>
-                        <li>
-                            <a (click)="analyzeOtherMenus('settings/integration', { tab: 'integration', tabIndex: 1 })">Integration
-                            </a>
-                        </li>
-                        <li>
-                            <a (click)="analyzeOtherMenus('settings/taxes', { tab: 'taxes', tabIndex: 0 })">Settings
-                            </a>
-                        </li>
-                    </ul>
-
-                    <ul>
-                        <li><a href="#"><strong>Others</strong></a></li>
-                        <li><a (click)="analyzeOtherMenus('audit-logs')">Audit Log</a></li>
-                        <li><a (click)="analyzeOtherMenus('search')">Search</a></li>
-                        <li><a (click)="analyzeOtherMenus('gstfiling')" *ngIf="activeCompany && activeCompany.countryV2 && activeCompany.countryV2.alpha2CountryCode == 'IN'">GSTR</a>
-                        </li>
-                        <li><a (click)="analyzeOtherMenus('vat-report')" *ngIf="activeCompany && activeCompany.countryV2 && activeCompany.countryV2.alpha2CountryCode != 'IN'">Vat
-                                Report</a></li>
-                        <li><a (click)="analyzeOtherMenus('home')">Dashboard</a></li>
-                    </ul>
-
-                </div>
-            </li>
-
-        </ul>
 
 
     </div>

--- a/apps/web-giddh/src/app/shared/header/header.component.scss
+++ b/apps/web-giddh/src/app/shared/header/header.component.scss
@@ -313,7 +313,7 @@ a[vr-item]:focus {
 .left-sub-menu {
     background: #fff;
     position: absolute;
-    left: 215px;
+    left: -20px;
     bottom: 0;
     width: 570px;
     z-index: -1;

--- a/apps/web-giddh/src/app/shared/header/header.component.scss
+++ b/apps/web-giddh/src/app/shared/header/header.component.scss
@@ -313,7 +313,7 @@ a[vr-item]:focus {
 .left-sub-menu {
     background: #fff;
     position: absolute;
-    left: -20px;
+    left: -12px;
     bottom: 0;
     width: 570px;
     z-index: -1;

--- a/apps/web-giddh/src/app/shared/header/header.component.ts
+++ b/apps/web-giddh/src/app/shared/header/header.component.ts
@@ -1222,7 +1222,13 @@ export class HeaderComponent implements OnInit, AfterViewInit, OnDestroy, AfterV
         this.hoveredIndx = i;
     }
 
-    public handleAllModulesLeaveEvent(event: any) {
+    /**
+     * Mouse leave handler for all modules label to hide the popover
+     *
+     * @param {*} event Mouse leave event
+     * @memberof HeaderComponent
+     */
+    public handleAllModulesLeaveEvent(event: any): void {
         const menu = document.getElementById('other_sub_menu');
         if (menu && !menu.contains(event.toElement)) {
             // Hide 'All Modules' popover if the mouse points to any element other than sub menu as target
@@ -1235,10 +1241,6 @@ export class HeaderComponent implements OnInit, AfterViewInit, OnDestroy, AfterV
             navigator.add(sublist.children[1]);
             navigator.nextVertical();
         }
-    }
-
-    public openSubMenu(type: boolean) {
-        // this.showOtherMenu = type;
     }
 
     public switchCompanyMenuShown() {

--- a/apps/web-giddh/src/app/shared/header/header.component.ts
+++ b/apps/web-giddh/src/app/shared/header/header.component.ts
@@ -1230,7 +1230,8 @@ export class HeaderComponent implements OnInit, AfterViewInit, OnDestroy, AfterV
      */
     public handleAllModulesLeaveEvent(event: any): void {
         const menu = document.getElementById('other_sub_menu');
-        if (menu && !menu.contains(event.toElement)) {
+        const targetElement = event.toElement || event.relatedTarget;
+        if (menu && !menu.contains(targetElement)) {
             // Hide 'All Modules' popover if the mouse points to any element other than sub menu as target
             this.allModulesPopover.hide();
         }

--- a/apps/web-giddh/src/app/shared/header/header.component.ts
+++ b/apps/web-giddh/src/app/shared/header/header.component.ts
@@ -1222,12 +1222,12 @@ export class HeaderComponent implements OnInit, AfterViewInit, OnDestroy, AfterV
         this.hoveredIndx = i;
     }
 
-    public menuScrollEnd(ev) {
-        // let offset = $('#other').position();
-        // if (offset) {
-        //     let exactPosition = offset.top - 100;
-        //     $('#other_sub_menu').css('top', exactPosition);
-        // }
+    public handleAllModulesLeaveEvent(event: any) {
+        const menu = document.getElementById('other_sub_menu');
+        if (menu && !menu.contains(event.toElement)) {
+            // Hide 'All Modules' popover if the mouse points to any element other than sub menu as target
+            this.allModulesPopover.hide();
+        }
     }
 
     public onCompanyShown(sublist, navigator) {
@@ -1239,12 +1239,6 @@ export class HeaderComponent implements OnInit, AfterViewInit, OnDestroy, AfterV
 
     public openSubMenu(type: boolean) {
         // this.showOtherMenu = type;
-    }
-
-    public toggleAllmoduleMenu(event) {
-        // this.showOtherMenu = !this.showOtherMenu;
-        // event.stopPropagation();
-        this.allModulesPopover.show();
     }
 
     public switchCompanyMenuShown() {

--- a/apps/web-giddh/src/app/shared/header/header.component.ts
+++ b/apps/web-giddh/src/app/shared/header/header.component.ts
@@ -5,7 +5,7 @@ import { GIDDH_DATE_FORMAT } from './../helpers/defaultDateFormat';
 import { CompanyAddNewUiComponent, ManageGroupsAccountsComponent } from './components';
 import { AfterViewChecked, AfterViewInit, ChangeDetectorRef, Component, ComponentFactoryResolver, ElementRef, EventEmitter, HostListener, NgZone, OnDestroy, OnInit, Output, TemplateRef, ViewChild } from '@angular/core';
 import { select, Store } from '@ngrx/store';
-import { BsDropdownDirective, BsModalRef, BsModalService, ModalDirective, ModalOptions, TabsetComponent } from 'ngx-bootstrap';
+import { BsDropdownDirective, BsModalRef, BsModalService, ModalDirective, ModalOptions, TabsetComponent, PopoverDirective } from 'ngx-bootstrap';
 import { AppState } from '../../store';
 import { LoginActions } from '../../actions/login.action';
 import { CompanyActions } from '../../actions/company.actions';
@@ -74,6 +74,8 @@ export class HeaderComponent implements OnInit, AfterViewInit, OnDestroy, AfterV
     @ViewChild('expiredPlanModel') public expiredPlanModel: TemplateRef<any>;
     @ViewChild('crossedTxLimitModel') public crossedTxLimitModel: TemplateRef<any>;
     @ViewChild('companyDetailsDropDownWeb') public companyDetailsDropDownWeb: BsDropdownDirective;
+    /** All modules popover instance */
+    @ViewChild('allModulesPopover') public allModulesPopover: PopoverDirective;
 
     public hideAsDesignChanges: false;
     public title: Observable<string>;
@@ -1221,11 +1223,11 @@ export class HeaderComponent implements OnInit, AfterViewInit, OnDestroy, AfterV
     }
 
     public menuScrollEnd(ev) {
-        let offset = $('#other').position();
-        if (offset) {
-            let exactPosition = offset.top - 100;
-            $('#other_sub_menu').css('top', exactPosition);
-        }
+        // let offset = $('#other').position();
+        // if (offset) {
+        //     let exactPosition = offset.top - 100;
+        //     $('#other_sub_menu').css('top', exactPosition);
+        // }
     }
 
     public onCompanyShown(sublist, navigator) {
@@ -1236,11 +1238,13 @@ export class HeaderComponent implements OnInit, AfterViewInit, OnDestroy, AfterV
     }
 
     public openSubMenu(type: boolean) {
-        this.showOtherMenu = type;
+        // this.showOtherMenu = type;
     }
 
-    public toggleAllmoduleMenu() {
-        this.showOtherMenu = !this.showOtherMenu;
+    public toggleAllmoduleMenu(event) {
+        // this.showOtherMenu = !this.showOtherMenu;
+        // event.stopPropagation();
+        this.allModulesPopover.show();
     }
 
     public switchCompanyMenuShown() {

--- a/apps/web-giddh/src/assets/css/style-2.scss
+++ b/apps/web-giddh/src/assets/css/style-2.scss
@@ -8655,7 +8655,7 @@ p.remvBrnchName {
     margin-top: 0;
     border-radius: 0;
 }
-.popover.purchase-invoice-rcm, .update-ledger-rcm {
+.popover.purchase-invoice-rcm, .update-ledger-rcm, .all-modules-popover {
     .popover-arrow.arrow {
         display: none;
     }


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
It removes the manual calculation of **top** for all modules popover as it is incorrectly calculated based on browser screen density and the company user is currently using (for companies with more sections in side menu).


* **What is the current behavior?** (You can also link to an open issue here)
Currently, UI programmatically calculates the **top** value in **px** which is incorrectly calculated based on browser screen density and the company user is currently using (for companies with more sections in side menu). 


* **What is the new behavior (if this is a feature change)?**
Now we make use of `ngx-bootstrap-popover` component to show the popover instead of manual calculation of position of div


* **Other information**:
