### PR TITLE
fix: Calculate compound total

### DIFF
--- a/apps/web-giddh/src/app/ledger/components/updateLedgerEntryPanel/updateLedgerEntryPanel.component.ts
+++ b/apps/web-giddh/src/app/ledger/components/updateLedgerEntryPanel/updateLedgerEntryPanel.component.ts
@@ -543,6 +543,7 @@ export class UpdateLedgerEntryPanelComponent implements OnInit, AfterViewInit, O
                         // Calculate entry total for credit and debit transactions when UI panel at the bottom to update
                         // transaction is not visible
                         this.vm.getEntryTotal();
+                        this.vm.generateCompoundTotal();
                     }
                     this.vm.generatePanelAmount();
                 }


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
It adds the missing calculation of compound total for expense category transactions


* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Other information**:
