### PR TITLE
fix: Build failing error as package can't be found

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://yarn.npmjs.org


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR changes the registry CDN as NPM is having issue in installing packages that begins with a number '7zip', so changed the CDN to avoid error. An open issue (at the time of PR) can be found at [here](https://github.com/yarnpkg/yarn/issues/7902)


* **What is the current behavior?** (You can also link to an open issue here)
Currently the NPM registry points to the default CDN


* **What is the new behavior (if this is a feature change)?**
It changes the CDN to avoid installation issue


* **Other information**:
