### PR TITLE
fix: Rename URL to HTTPS

### DIFF
--- a/apps/electron-giddh/src/main-auth.config.ts
+++ b/apps/electron-giddh/src/main-auth.config.ts
@@ -52,5 +52,5 @@ export const LinkedinLoginElectronConfig = {
     authorizationUrl: "https://www.linkedin.com/uas/oauth2/authorization",
     tokenUrl: "https://www.linkedin.com/oauth/v2/accessToken",
     useBasicAuthorizationHeader: false,
-    redirectUri: "http://test.giddh.com/login" || "http://localhost"
+    redirectUri: "https://test.giddh.com/login" || "http://localhost"
 };


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
It renames the URL of TEST for electron to HTTPS


* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Other information**:
