### PR TITLE
fix: Infinite loading on user details screen

### DIFF
--- a/apps/web-giddh/src/app/store/Settings/Settings.reducer.ts
+++ b/apps/web-giddh/src/app/store/Settings/Settings.reducer.ts
@@ -221,9 +221,10 @@ export function SettingsReducer(state = initialState, action: CustomActions): Se
             if (response.status === 'success') {
                 newState.profile = response.body;
                 newState.profileRequest = true;
+                newState.updateProfileInProgress = false;
                 return Object.assign({}, state, newState);
             }
-            return { ...state, updateProfileInProgress: true };
+            return { ...state, updateProfileInProgress: false };
         }
         case SETTINGS_PROFILE_ACTIONS.UPDATE_PROFILE_RESPONSE: {
             let response: BaseResponse<CompanyResponse, string> = action.payload;

--- a/apps/web-giddh/src/app/userDetails/userDetails.component.ts
+++ b/apps/web-giddh/src/app/userDetails/userDetails.component.ts
@@ -363,7 +363,9 @@ export class UserDetailsComponent implements OnInit, OnDestroy, AfterViewInit {
     }
 
     public selectTab(id: number) {
-        this.staticTabs.tabs[id].active = true;
+        if (this.staticTabs) {
+            this.staticTabs.tabs[id].active = true;
+        }
     }
 
     public ngOnDestroy() {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- It resets the flag `updateProfileInProgress` that is never reset after making a service call which leads to infinite loading indicator to occur
- It adds the nullity check to `staticTabs`


* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Other information**:
