### PR TITLE
fix: Issue #G0-4824

### DIFF
--- a/apps/web-giddh/src/app/inventory/components/add-stock-components/inventory.addstock.component.ts
+++ b/apps/web-giddh/src/app/inventory/components/add-stock-components/inventory.addstock.component.ts
@@ -768,7 +768,7 @@ export class InventoryAddStockComponent implements OnInit, AfterViewInit, OnDest
                     unitRates: formObj.purchaseUnitRates
                 };
             } else {
-                this._toasty.errorToast('Unit and Rate are mandatory if either of them is provided');
+                this._toasty.errorToast('Both Unit and Rate fields are mandatory if you provide data for either of them.');
                 return;
             }
         }
@@ -784,7 +784,7 @@ export class InventoryAddStockComponent implements OnInit, AfterViewInit, OnDest
                     unitRates: formObj.saleUnitRates
                 };
             } else {
-                this._toasty.errorToast('Unit and Rate are mandatory if either of them is provided');
+                this._toasty.errorToast('Both Unit and Rate fields are mandatory if you provide data for either of them.');
                 return;
             }
         }
@@ -878,7 +878,7 @@ export class InventoryAddStockComponent implements OnInit, AfterViewInit, OnDest
                     unitRates: formObj.purchaseUnitRates
                 };
             } else {
-                this._toasty.errorToast('Unit and Rate are mandatory if either of them is provided');
+                this._toasty.errorToast('Both Unit and Rate fields are mandatory if you provide data for either of them.');
                 return;
             }
         }
@@ -893,7 +893,7 @@ export class InventoryAddStockComponent implements OnInit, AfterViewInit, OnDest
                     unitRates: formObj.saleUnitRates
                 };
             } else {
-                this._toasty.errorToast('Unit and Rate are mandatory if either of them is provided');
+                this._toasty.errorToast('Both Unit and Rate fields are mandatory if you provide data for either of them.');
                 return;
             }
         }

--- a/apps/web-giddh/src/app/inventory/components/add-stock-components/inventory.addstock.component.ts
+++ b/apps/web-giddh/src/app/inventory/components/add-stock-components/inventory.addstock.component.ts
@@ -25,6 +25,7 @@ import { CompanyActions } from '../../../actions/company.actions';
 import { InvoiceActions } from '../../../actions/invoice/invoice.actions';
 import { InvViewService } from '../../inv.view.service';
 
+/** Error message to display if the stock is invalid */
 const INVALID_STOCK_ERROR_MESSAGE = 'Both Unit and Rate fields are mandatory if you provide data for either of them.';
 
 @Component({

--- a/apps/web-giddh/src/app/inventory/components/add-stock-components/inventory.addstock.component.ts
+++ b/apps/web-giddh/src/app/inventory/components/add-stock-components/inventory.addstock.component.ts
@@ -759,26 +759,34 @@ export class InventoryAddStockComponent implements OnInit, AfterViewInit, OnDest
 
 
         if (formObj.enablePurchase) {
-            formObj.purchaseUnitRates = formObj.purchaseUnitRates.filter((pr) => {
-                // Aditya: In inventory while creating purchase and sales unit and rate are mandatory error issue
-                // return pr.stockUnitCode && pr.rate;
-                return pr.stockUnitCode || pr.rate;
-            });
-            stockObj.purchaseAccountDetails = {
-                accountUniqueName: formObj.purchaseAccountUniqueName,
-                unitRates: formObj.purchaseUnitRates
-            };
+            if (this.validateStock(formObj.purchaseUnitRates)) {
+                formObj.purchaseUnitRates = formObj.purchaseUnitRates.filter((pr) => {
+                    return pr.stockUnitCode || pr.rate;
+                });
+                stockObj.purchaseAccountDetails = {
+                    accountUniqueName: formObj.purchaseAccountUniqueName,
+                    unitRates: formObj.purchaseUnitRates
+                };
+            } else {
+                this._toasty.errorToast('Unit and Rate are mandatory if either of them is provided');
+                return;
+            }
         }
         if (formObj.enableSales) {
-            formObj.saleUnitRates = formObj.saleUnitRates.filter((pr) => {
-                // Aditya: In inventory while creating purchase and sales unit and rate are mandatory error issue
-                // return pr.stockUnitCode && pr.rate;
-                return pr.stockUnitCode || pr.rate;
-            });
-            stockObj.salesAccountDetails = {
-                accountUniqueName: formObj.salesAccountUniqueName,
-                unitRates: formObj.saleUnitRates
-            };
+            if (this.validateStock(formObj.saleUnitRates)) {
+                formObj.saleUnitRates = formObj.saleUnitRates.filter((pr) => {
+                    // Aditya: In inventory while creating purchase and sales unit and rate are mandatory error issue
+                    // return pr.stockUnitCode && pr.rate;
+                    return pr.stockUnitCode || pr.rate;
+                });
+                stockObj.salesAccountDetails = {
+                    accountUniqueName: formObj.salesAccountUniqueName,
+                    unitRates: formObj.saleUnitRates
+                };
+            } else {
+                this._toasty.errorToast('Unit and Rate are mandatory if either of them is provided');
+                return;
+            }
         }
 
         stockObj.isFsStock = formObj.isFsStock;
@@ -861,23 +869,33 @@ export class InventoryAddStockComponent implements OnInit, AfterViewInit, OnDest
         stockObj.customField2Value = formObj.customField2Value;
 
         if (formObj.enablePurchase) {
-            formObj.purchaseUnitRates = formObj.purchaseUnitRates.filter((pr) => {
-                return pr.stockUnitCode && pr.rate;
-            });
-            stockObj.purchaseAccountDetails = {
-                accountUniqueName: formObj.purchaseAccountUniqueName,
-                unitRates: formObj.purchaseUnitRates
-            };
+            if (this.validateStock(formObj.purchaseUnitRates)) {
+                formObj.purchaseUnitRates = formObj.purchaseUnitRates.filter((pr) => {
+                    return pr.stockUnitCode || pr.rate;
+                });
+                stockObj.purchaseAccountDetails = {
+                    accountUniqueName: formObj.purchaseAccountUniqueName,
+                    unitRates: formObj.purchaseUnitRates
+                };
+            } else {
+                this._toasty.errorToast('Unit and Rate are mandatory if either of them is provided');
+                return;
+            }
         }
 
         if (formObj.enableSales) {
-            formObj.saleUnitRates = formObj.saleUnitRates.filter((pr) => {
-                return pr.stockUnitCode && pr.rate;
-            });
-            stockObj.salesAccountDetails = {
-                accountUniqueName: formObj.salesAccountUniqueName,
-                unitRates: formObj.saleUnitRates
-            };
+            if (this.validateStock(formObj.saleUnitRates)) {
+                formObj.saleUnitRates = formObj.saleUnitRates.filter((pr) => {
+                    return pr.stockUnitCode || pr.rate;
+                });
+                stockObj.salesAccountDetails = {
+                    accountUniqueName: formObj.salesAccountUniqueName,
+                    unitRates: formObj.saleUnitRates
+                };
+            } else {
+                this._toasty.errorToast('Unit and Rate are mandatory if either of them is provided');
+                return;
+            }
         }
 
         stockObj.isFsStock = formObj.isFsStock;
@@ -1162,5 +1180,24 @@ export class InventoryAddStockComponent implements OnInit, AfterViewInit, OnDest
     public closeAsidePane() {
         this.resetStockForm();
         this.closeAsideEvent.emit();
+    }
+
+    /**
+     * Validates the stock to have both unit and rate if either of them has been provided
+     * The stock to be created is valid if the user has either provided both unit and rate or
+     * has provided none. If the user provides anyone of them then it is invalid entry and method
+     * will return false
+     *
+     * @private
+     * @param {Array<any>} unitRates Array of stockUnitCode and rate keys
+     * @returns {boolean} True, if the stock is valid
+     * @memberof InventoryAddStockComponent
+     */
+    private validateStock(unitRates: Array<any>): boolean {
+        const formEntries = unitRates.filter((unitRate) => {
+			// tslint:disable-next-line: no-bitwise
+			return (unitRate.stockUnitCode && !unitRate.rate) || (!unitRate.stockUnitCode && unitRate.rate);
+		});
+		return formEntries.length === 0;
     }
 }

--- a/apps/web-giddh/src/app/inventory/components/add-stock-components/inventory.addstock.component.ts
+++ b/apps/web-giddh/src/app/inventory/components/add-stock-components/inventory.addstock.component.ts
@@ -25,6 +25,8 @@ import { CompanyActions } from '../../../actions/company.actions';
 import { InvoiceActions } from '../../../actions/invoice/invoice.actions';
 import { InvViewService } from '../../inv.view.service';
 
+const INVALID_STOCK_ERROR_MESSAGE = 'Both Unit and Rate fields are mandatory if you provide data for either of them.';
+
 @Component({
     selector: 'inventory-add-stock',  // <home></home>
     templateUrl: './inventory.addstock.component.html',
@@ -768,7 +770,7 @@ export class InventoryAddStockComponent implements OnInit, AfterViewInit, OnDest
                     unitRates: formObj.purchaseUnitRates
                 };
             } else {
-                this._toasty.errorToast('Both Unit and Rate fields are mandatory if you provide data for either of them.');
+                this._toasty.errorToast(INVALID_STOCK_ERROR_MESSAGE);
                 return;
             }
         }
@@ -784,7 +786,7 @@ export class InventoryAddStockComponent implements OnInit, AfterViewInit, OnDest
                     unitRates: formObj.saleUnitRates
                 };
             } else {
-                this._toasty.errorToast('Both Unit and Rate fields are mandatory if you provide data for either of them.');
+                this._toasty.errorToast(INVALID_STOCK_ERROR_MESSAGE);
                 return;
             }
         }
@@ -878,7 +880,7 @@ export class InventoryAddStockComponent implements OnInit, AfterViewInit, OnDest
                     unitRates: formObj.purchaseUnitRates
                 };
             } else {
-                this._toasty.errorToast('Both Unit and Rate fields are mandatory if you provide data for either of them.');
+                this._toasty.errorToast(INVALID_STOCK_ERROR_MESSAGE);
                 return;
             }
         }
@@ -893,7 +895,7 @@ export class InventoryAddStockComponent implements OnInit, AfterViewInit, OnDest
                     unitRates: formObj.saleUnitRates
                 };
             } else {
-                this._toasty.errorToast('Both Unit and Rate fields are mandatory if you provide data for either of them.');
+                this._toasty.errorToast(INVALID_STOCK_ERROR_MESSAGE);
                 return;
             }
         }


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
It displays an error toast if the user during stock creation only provides either of unit or rates


* **What is the current behavior?** (You can also link to an open issue here)
Currently no error message is displayed and on form submit first Group creation API is called and then Stock creation API is called. Former call succeeds and the latter call fails.


* **What is the new behavior (if this is a feature change)?**
Unless the user enters both unit and rate or leave both blank he will neither be able to create Group nor Stock.


* **Other information**:
