### PR TITLE
Fixed - G0-4892 | Prod- Heading is wrongly displayed when click on the other module

### DIFF
--- a/apps/web-giddh/src/app/invoice/invoice.component.ts
+++ b/apps/web-giddh/src/app/invoice/invoice.component.ts
@@ -10,6 +10,8 @@ import { TabsetComponent } from 'ngx-bootstrap';
 import { VoucherTypeEnum } from '../models/api-models/Sales';
 import { BreakpointObserver } from '@angular/cdk/layout';
 import { GeneralService } from '../services/general.service';
+import { CurrentPage } from '../models/api-models/Common';
+import { GeneralActions } from '../actions/general/general.actions';
 @Component({
     templateUrl: './invoice.component.html'
 })
@@ -23,7 +25,7 @@ export class InvoiceComponent implements OnInit, OnDestroy {
     constructor(private store: Store<AppState>,
         private companyActions: CompanyActions,
         private router: Router,
-        private _cd: ChangeDetectorRef, private _activatedRoute: ActivatedRoute, private _breakPointObservar: BreakpointObserver, private _generalService: GeneralService) {
+        private _cd: ChangeDetectorRef, private _activatedRoute: ActivatedRoute, private _breakPointObservar: BreakpointObserver, private _generalActions: GeneralActions) {
         this._breakPointObservar.observe([
             '(max-width: 1023px)'
         ]).subscribe(result => {
@@ -93,6 +95,14 @@ public tabChanged(tab: string, e, type?: string) {
         if (e && !e.target) {
             this.saveLastState(tab);
         }
+
+        if(tab === "pending") {
+            this.setCurrentPageTitle("Pending");
+        } else if(tab === "templates") {
+            this.setCurrentPageTitle("Templates");
+        } else if(tab === "settings") {
+            this.setCurrentPageTitle("Settings");
+        }
     }
 
     public ngOnDestroy() {
@@ -108,5 +118,12 @@ public tabChanged(tab: string, e, type?: string) {
         stateDetailsRequest.lastState = `pages/invoice/preview/${state}`;
 
         this.store.dispatch(this.companyActions.SetStateDetails(stateDetailsRequest));
+    }
+
+    public setCurrentPageTitle(title) {
+        let currentPageObj = new CurrentPage();
+        currentPageObj.name = "Invoice > " + title;
+        currentPageObj.url = this.router.url;
+        this.store.dispatch(this._generalActions.setPageTitle(currentPageObj));
     }
 }

--- a/apps/web-giddh/src/app/invoice/invoice.component.ts
+++ b/apps/web-giddh/src/app/invoice/invoice.component.ts
@@ -125,7 +125,7 @@ public tabChanged(tab: string, e, type?: string) {
      * @param {string} title
      * @memberof InvoiceComponent
      */
-    public setCurrentPageTitle(title) {
+    public setCurrentPageTitle(title: string) : void {
         let currentPageObj = new CurrentPage();
         currentPageObj.name = "Invoice > " + title;
         currentPageObj.url = this.router.url;

--- a/apps/web-giddh/src/app/invoice/invoice.component.ts
+++ b/apps/web-giddh/src/app/invoice/invoice.component.ts
@@ -9,7 +9,6 @@ import { combineLatest, ReplaySubject } from 'rxjs';
 import { TabsetComponent } from 'ngx-bootstrap';
 import { VoucherTypeEnum } from '../models/api-models/Sales';
 import { BreakpointObserver } from '@angular/cdk/layout';
-import { GeneralService } from '../services/general.service';
 import { CurrentPage } from '../models/api-models/Common';
 import { GeneralActions } from '../actions/general/general.actions';
 @Component({
@@ -120,6 +119,12 @@ public tabChanged(tab: string, e, type?: string) {
         this.store.dispatch(this.companyActions.SetStateDetails(stateDetailsRequest));
     }
 
+    /**
+     * This function will set the page heading
+     *
+     * @param {string} title
+     * @memberof InvoiceComponent
+     */
     public setCurrentPageTitle(title) {
         let currentPageObj = new CurrentPage();
         currentPageObj.name = "Invoice > " + title;


### PR DESCRIPTION
Steps to recreate

1. Click on to the invoice management page2. then click on Invoices3. Then click on the Recurring Hensding is displayed as Invoice> Recurring4. Then click on the pending no heading changes displayed the same as for the setting and templatesThe same issue is for the credit and debit note heading issue

Expected-  When user click on the pending then heading should be Invoice> PendingInvoice> SettingsInvoice> Template