### PR TITLE
G0 - 4892 | Prod- Heading is wrongly displayed when click on the other module

### DIFF
--- a/apps/web-giddh/src/app/invoice/invoice.component.ts
+++ b/apps/web-giddh/src/app/invoice/invoice.component.ts
@@ -127,7 +127,7 @@ public tabChanged(tab: string, e, type?: string) {
      */
     public setCurrentPageTitle(title: string) : void {
         let currentPageObj = new CurrentPage();
-        currentPageObj.name = "Invoice > " + title;
+        currentPageObj.name = (this.selectedVoucherType !== 'debit note' && this.selectedVoucherType !== 'credit note') ? "Invoice > " + title : title;
         currentPageObj.url = this.router.url;
         this.store.dispatch(this._generalActions.setPageTitle(currentPageObj));
     }


### PR DESCRIPTION
Steps to recreate

1. Click on to the invoice management page
2. then click on Invoices
3. Then click on the Recurring Hensding is displayed as Invoice> Recurring
4. Then click on the pending no heading changes displayed the same as for the setting and templatesThe same issue is for the credit and debit note heading issue

Expected-  When user click on the pending then heading should be Invoice> PendingInvoice> SettingsInvoice> Template