### PR TITLE
G0-2348 | fixed UI logic to show SAC number

### DIFF
--- a/apps/web-giddh/src/app/proforma-invoice/proforma-invoice.component.html
+++ b/apps/web-giddh/src/app/proforma-invoice/proforma-invoice.component.html
@@ -782,7 +782,8 @@
 
                                                             <div class="hsnCodeDropdown" *ngIf="hsnDropdownShow">
                                                                 <label>HSN/SAC</label>
-                                                                <input type="text" maxLength="10" placeholder="HSN/SAC Number" name="transaction.hsnNumber_{{entryIdx}}" [(ngModel)]="(inventorySettings?.manageInventory || !transaction.sacNumber) ? transaction.hsnNumber : transaction.sacNumber" />
+                                                                <input type="text" maxLength="10" placeholder="HSN/SAC Number" name="transaction.hsnNumber_{{entryIdx}}" *ngIf="(inventorySettings?.manageInventory || !transaction.sacNumber)" [(ngModel)]="transaction.hsnNumber" />
+                                                                <input type="text" maxLength="10" placeholder="HSN/SAC Number" name="transaction.hsnNumber_{{entryIdx}}" *ngIf="!(inventorySettings?.manageInventory || !transaction.sacNumber)" [(ngModel)]="transaction.sacNumber" />
                                                                 <a>
                                                                 </a>
                                                                 <div class="btngroup m-t-10">
@@ -1485,7 +1486,8 @@
 
                                                         <div class="hsnCodeDropdown" *ngIf="hsnDropdownShow">
                                                             <label>HSN/SAC</label>
-                                                            <input type="text" maxLength="10" placeholder="HSN/SAC Number" name="transaction.hsnNumber_{{entryIdx}}" [(ngModel)]="(inventorySettings?.manageInventory || !transaction.sacNumber) ? transaction.hsnNumber : transaction.sacNumber" />
+                                                            <input type="text" maxLength="10" placeholder="HSN/SAC Number" name="transaction.hsnNumber_{{entryIdx}}" *ngIf="(inventorySettings?.manageInventory || !transaction.sacNumber)" [(ngModel)]="transaction.hsnNumber" />
+                                                            <input type="text" maxLength="10" placeholder="HSN/SAC Number" name="transaction.hsnNumber_{{entryIdx}}" *ngIf="!(inventorySettings?.manageInventory || !transaction.sacNumber)" [(ngModel)]="transaction.sacNumber" />
                                                             <a>
                                                             </a>
                                                             <div class="btngroup m-t-10">


### PR DESCRIPTION
According to Sir, If stock has a hsn number and sac number is not there and manage inventory in company-setting is false then also we have to show hsn number in invoice and vice-versa.

If both HSN and SAC number are present in stock then we need to check manageInventory setting -

if true → show HSN

if false → show SAC