### PR TITLE
Bugfix/G0-4846 | Prod- On the estimates and proforma after click on the delete voucher option not confirmation msg not displayed 

### DIFF
--- a/apps/web-giddh/src/app/invoice/preview/models/confirmation/confirmation.model.component.html
+++ b/apps/web-giddh/src/app/invoice/preview/models/confirmation/confirmation.model.component.html
@@ -6,8 +6,8 @@
     <div class="modal-body pdL2 pdR2 clearfix" id="export-body">
         <form name="newRole" novalidate class="" autocomplete="off">
             <div class="modal_wrap mrB2">
-                <h3>Do you want to delete the selected invoices <b
-                        *ngIf="selectedInvoiceForDelete">{{selectedInvoiceForDelete.invoiceNumber}}</b>?</h3>
+                <h3>Do you want to delete the selected record(s) <b
+                        *ngIf="selectedInvoiceForDelete">{{selectedInvoiceForDelete?.invoiceNumber}}</b>?</h3>
                         <p class="text-gray font-14 mt-05">They will be deleted permanently and will no longer be accessible from any other module. </p>
             </div>
             <div class="d-flex" style="justify-content: flex-start">

--- a/apps/web-giddh/src/app/invoice/preview/models/confirmation/confirmation.model.component.html
+++ b/apps/web-giddh/src/app/invoice/preview/models/confirmation/confirmation.model.component.html
@@ -6,7 +6,7 @@
     <div class="modal-body pdL2 pdR2 clearfix" id="export-body">
         <form name="newRole" novalidate class="" autocomplete="off">
             <div class="modal_wrap mrB2">
-                <h3>Do you want to delete the selected record(s) <b
+                <h3>Do you want to delete the selected voucher(s) <b
                         *ngIf="selectedInvoiceForDelete">{{selectedInvoiceForDelete?.invoiceNumber}}</b>?</h3>
                         <p class="text-gray font-14 mt-05">They will be deleted permanently and will no longer be accessible from any other module. </p>
             </div>

--- a/apps/web-giddh/src/app/invoice/preview/models/invoice-preview-details/invoice-preview-details.component.html
+++ b/apps/web-giddh/src/app/invoice/preview/models/invoice-preview-details/invoice-preview-details.component.html
@@ -460,7 +460,7 @@
     tabindex="-1">
     <div class="modal-dialog modal-md">
         <div class="modal-content">
-            <confirm-modal [body]="'Do you want to delete the voucher / invoice?'"
+            <confirm-modal [body]="'Do you want to delete the voucher?'"
                 (cancelCallBack)="deleteConfirmationModel.toggle()"
                 (successCallBack)="deleteVoucher.emit(true);deleteConfirmationModel.toggle()"></confirm-modal>
         </div>

--- a/apps/web-giddh/src/app/invoice/proforma/proforma-list.component.html
+++ b/apps/web-giddh/src/app/invoice/proforma/proforma-list.component.html
@@ -68,7 +68,7 @@
                     <ul *dropdownMenu class="dropdown-menu" role="menu" aria-labelledby="button-basic">
 
                         <li role="menuitem">
-                            <a class="dropdown-item cp" href="javascript:void(0)" (click)="openConfirmationModal()">Delete</a>
+                            <a class="dropdown-item cp" href="javascript:void(0)" (click)="toggleConfirmationModel(true)">Delete</a>
                         </li>
 
                     </ul>
@@ -468,7 +468,7 @@
     <div bsModal #deleteConfirmationModel="bs-modal" class="modal fade" role="dialog" [config]="{keyboard:true}" tabindex="-1">
         <div class="modal-dialog modal-md">
             <div class="modal-content">
-                <delete-role-confirmation-model (confirmDeleteEvent)="deleteVoucher()" (closeModelEvent)="hideConfirmationModal()">
+                <delete-role-confirmation-model (confirmDeleteEvent)="deleteVoucher()" (closeModelEvent)="toggleConfirmationModel()">
                 </delete-role-confirmation-model>
             </div>
         </div>

--- a/apps/web-giddh/src/app/invoice/proforma/proforma-list.component.html
+++ b/apps/web-giddh/src/app/invoice/proforma/proforma-list.component.html
@@ -68,7 +68,7 @@
                     <ul *dropdownMenu class="dropdown-menu" role="menu" aria-labelledby="button-basic">
 
                         <li role="menuitem">
-                            <a class="dropdown-item cp" href="javascript:void(0)" (click)="deleteVoucher()">Delete</a>
+                            <a class="dropdown-item cp" href="javascript:void(0)" (click)="openConfirmationModal()">Delete</a>
                         </li>
 
                     </ul>
@@ -462,4 +462,14 @@
             </div>
         </div>
 
+    </div>
+
+    <!-- Delete Proforma/Estimate confirmation model -->
+    <div bsModal #deleteConfirmationModel="bs-modal" class="modal fade" role="dialog" [config]="{keyboard:true}" tabindex="-1">
+        <div class="modal-dialog modal-md">
+            <div class="modal-content">
+                <delete-role-confirmation-model (confirmDeleteEvent)="deleteVoucher()" (closeModelEvent)="hideConfirmationModal()">
+                </delete-role-confirmation-model>
+            </div>
+        </div>
     </div>

--- a/apps/web-giddh/src/app/invoice/proforma/proforma-list.component.ts
+++ b/apps/web-giddh/src/app/invoice/proforma/proforma-list.component.ts
@@ -42,6 +42,8 @@ import {GeneralService} from '../../services/general.service';
 
 export class ProformaListComponent implements OnInit, OnDestroy, OnChanges {
     @ViewChild('advanceSearch') public advanceSearch: ModalDirective;
+    /** Confirmation popup for delete operation */
+    @ViewChild('deleteConfirmationModel') public deleteConfirmationModel: ModalDirective;
     @ViewChild(InvoiceAdvanceSearchComponent) public advanceSearchComponent: InvoiceAdvanceSearchComponent;
     @Input() public voucherType: VoucherTypeEnum = VoucherTypeEnum.proforma;
     public voucherData: ProformaResponse;
@@ -629,6 +631,9 @@ export class ProformaListComponent implements OnInit, OnDestroy, OnChanges {
     }
 
     public deleteVoucher() {
+        if (this.deleteConfirmationModel.isShown) {
+            this.deleteConfirmationModel.hide();
+        }
         // for deleting voucher which is previewed
         if (this.selectedVoucher) {
             this.store.dispatch(this.proformaActions.deleteProforma(this.prepareCommonRequest(), this.voucherType));
@@ -674,6 +679,24 @@ export class ProformaListComponent implements OnInit, OnDestroy, OnChanges {
         });
         this.destroyed$.next(true);
         this.destroyed$.complete();
+    }
+
+    /**
+     * Displays the confirmation model
+     *
+     * @memberof ProformaListComponent
+     */
+    public openConfirmationModal(): void {
+        this.deleteConfirmationModel.show();
+    }
+
+    /**
+     * Hides the confirmation model
+     *
+     * @memberof ProformaListComponent
+     */
+    public hideConfirmationModal(): void {
+        this.deleteConfirmationModel.hide();
     }
 
     private prepareCommonRequest(): ProformaGetRequest {

--- a/apps/web-giddh/src/app/invoice/proforma/proforma-list.component.ts
+++ b/apps/web-giddh/src/app/invoice/proforma/proforma-list.component.ts
@@ -631,7 +631,7 @@ export class ProformaListComponent implements OnInit, OnDestroy, OnChanges {
     }
 
     public deleteVoucher() {
-        if (this.deleteConfirmationModel.isShown) {
+        if (this.deleteConfirmationModel && this.deleteConfirmationModel.isShown) {
             this.deleteConfirmationModel.hide();
         }
         // for deleting voucher which is previewed
@@ -686,17 +686,14 @@ export class ProformaListComponent implements OnInit, OnDestroy, OnChanges {
      *
      * @memberof ProformaListComponent
      */
-    public openConfirmationModal(): void {
-        this.deleteConfirmationModel.show();
-    }
-
-    /**
-     * Hides the confirmation model
-     *
-     * @memberof ProformaListComponent
-     */
-    public hideConfirmationModal(): void {
-        this.deleteConfirmationModel.hide();
+    public toggleConfirmationModel(shouldOpenModal: boolean = false): void {
+        if (this.deleteConfirmationModel) {
+            if (shouldOpenModal) {
+                this.deleteConfirmationModel.show();
+            } else {
+                this.deleteConfirmationModel.hide();
+            }
+        }
     }
 
     private prepareCommonRequest(): ProformaGetRequest {

--- a/apps/web-giddh/src/app/invoice/proforma/proforma-list.component.ts
+++ b/apps/web-giddh/src/app/invoice/proforma/proforma-list.component.ts
@@ -684,6 +684,7 @@ export class ProformaListComponent implements OnInit, OnDestroy, OnChanges {
     /**
      * Displays the confirmation model
      *
+     * @param {boolean} shouldOpenModal True, if the modal needs to opened
      * @memberof ProformaListComponent
      */
     public toggleConfirmationModel(shouldOpenModal: boolean = false): void {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

- It adds the confirmation popup for Estimate and Proforma for deletion and also changes the confirmation popup heading text to make it more generic so that it can be reused in other modules


* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Other information**:
