### PR TITLE
Fixed G0-4906 | Prod- On the subscription module Professional Plan is displayed as default instead of plan name

### DIFF
--- a/apps/web-giddh/src/app/userDetails/components/subscriptions/subscriptions.component.html
+++ b/apps/web-giddh/src/app/userDetails/components/subscriptions/subscriptions.component.html
@@ -87,7 +87,7 @@
                 <p><small>Please renew your plan or pay now to continue subscription.</small></p>
             </div>
 
-            <h2 class="subscription-title" *ngIf="subscriptions">Professional Plan <span
+            <h2 class="subscription-title" *ngIf="subscriptions">{{seletedUserPlans?.planDetails?.name}} <span
                     *ngIf="seletedUserPlans?.startedAt">({{seletedUserPlans?.startedAt}})</span></h2>
             <div class="row">
                 <div class="col-sm-7 transaction-list">


### PR DESCRIPTION
Steps

1. Go to the subscription module
2. Then Professional plan is displayed as default which is not expected

Expected- Selected plan name should be displayed instead of Professional plan