### PR TITLE
Feature/G0-4885 | Default Tax applied on Sales account in Manage Accounts is not applied by default in Sales Ledger

### DIFF
--- a/apps/web-giddh/src/app/ledger/components/newLedgerEntryPanel/newLedgerEntryPanel.component.ts
+++ b/apps/web-giddh/src/app/ledger/components/newLedgerEntryPanel/newLedgerEntryPanel.component.ts
@@ -285,22 +285,14 @@ export class NewLedgerEntryPanelComponent implements OnInit, OnDestroy, OnChange
 
     public ngOnChanges(changes: SimpleChanges): void {
         if (this.currentTxn && this.currentTxn.selectedAccount) {
+            let activeAccountTaxes = [];
+            if (this.activeAccount && this.activeAccount.applicableTaxes) {
+                activeAccountTaxes = this.activeAccount.applicableTaxes.map((tax) => tax.uniqueName);
+            }
             if (this.currentTxn.selectedAccount.stock && this.currentTxn.selectedAccount.stock.stockTaxes && this.currentTxn.selectedAccount.stock.stockTaxes.length) {
-                this.taxListForStock = this.currentTxn.selectedAccount.stock.stockTaxes;
+                this.taxListForStock = this.mergeInvolvedAccountsTaxes(this.currentTxn.selectedAccount.stock.stockTaxes, activeAccountTaxes);
             } else if (this.currentTxn.selectedAccount.parentGroups && this.currentTxn.selectedAccount.parentGroups.length) {
-                let parentAcc = this.currentTxn.selectedAccount.parentGroups[0].uniqueName;
-                let incomeAccArray = ['revenuefromoperations', 'otherincome'];
-                let expensesAccArray = ['operatingcost', 'indirectexpenses'];
-                let assetsAccArray = ['assets'];
-                let incomeAndExpensesAccArray = [...incomeAccArray, ...expensesAccArray, ...assetsAccArray];
-
-                if (incomeAndExpensesAccArray.indexOf(parentAcc) > -1) {
-                    let appTaxes = [];
-                    if (this.activeAccount && this.activeAccount.applicableTaxes) {
-                        this.activeAccount.applicableTaxes.forEach(app => appTaxes.push(app.uniqueName));
-                        this.taxListForStock = appTaxes;
-                    }
-                }
+                this.taxListForStock = this.mergeInvolvedAccountsTaxes(this.currentTxn.selectedAccount.applicableTaxes, activeAccountTaxes);
             } else {
                 this.taxListForStock = [];
             }
@@ -333,11 +325,6 @@ export class NewLedgerEntryPanelComponent implements OnInit, OnDestroy, OnChange
             if (this.blankLedger.otherTaxModal.appliedOtherTax && this.blankLedger.otherTaxModal.appliedOtherTax.uniqueName) {
                 this.blankLedger.isOtherTaxesApplicable = true;
             }
-        }
-
-        if ('selectedCurrency' in changes) {
-            // this.baseCurrencyToDisplay = this.selectedCurrency === 0 ? cloneDeep(this.baseCurrencyDetails) : cloneDeep(this.foreignCurrencyDetails);
-            // this.foreignCurrencyToDisplay = this.selectedCurrency === 0 ? cloneDeep(this.foreignCurrencyDetails) : cloneDeep(this.baseCurrencyDetails);
         }
     }
 
@@ -1009,5 +996,27 @@ export class NewLedgerEntryPanelComponent implements OnInit, OnDestroy, OnChange
     private validateTaxes(): boolean {
         const taxes = [...this.currentTxn.taxesVm.filter(p => p.isChecked).map(p => p.uniqueName)];
         return taxes.length > 0;
+    }
+
+    /**
+     * Merges the involved accounts (current ledger account and particular account) taxes
+     *
+     * @private
+     * @param {Array<string>} firstAccountTaxes Taxes array of first account
+     * @param {Array<string>} secondAccountTaxes Taxes array of second account
+     * @returns {Array<string>} Merged taxes array of unique taxes from both accounts
+     * @memberof NewLedgerEntryPanelComponent
+     */
+    private mergeInvolvedAccountsTaxes(firstAccountTaxes: Array<string>, secondAccountTaxes: Array<string>): Array<string> {
+        const mergedAccountTaxes = (firstAccountTaxes) ? [...firstAccountTaxes] : [];
+        if (secondAccountTaxes) {
+            secondAccountTaxes.forEach((tax: string) => {
+                if (!mergedAccountTaxes.includes(tax)) {
+                    mergedAccountTaxes.push(tax);
+                }
+            });
+
+        }
+        return mergedAccountTaxes;
     }
 }

--- a/apps/web-giddh/src/app/ledger/ledger.component.ts
+++ b/apps/web-giddh/src/app/ledger/ledger.component.ts
@@ -119,7 +119,7 @@ export class LedgerComponent implements OnInit, OnDestroy {
     public advanceSearchRequest: AdvanceSearchRequest;
     public isLedgerCreateSuccess$: Observable<boolean>;
     public needToReCalculate: BehaviorSubject<boolean> = new BehaviorSubject(false);
-    @ViewChild('newLedPanel') public newLedPanelCtrl: NewLedgerEntryPanelComponent;
+    @ViewChild('newLedPanel') public newLedgerComponent: NewLedgerEntryPanelComponent;
     @ViewChild('updateLedgerModal') public updateLedgerModal: ModalDirective;
     @ViewChild('exportLedgerModal') public exportLedgerModal: ModalDirective;
     @ViewChild('shareLedgerModal') public shareLedgerModal: ModalDirective;
@@ -406,9 +406,8 @@ export class LedgerComponent implements OnInit, OnDestroy {
         txn.showTaxationDiscountBox = this.getCategoryNameFromAccountUniqueName(txn);
         this.handleRcmVisibility(txn);
         this.handleTaxableAmountVisibility(txn);
-        this.newLedPanelCtrl.calculateTotal();
-        // this.newLedPanelCtrl.checkForMulitCurrency();
-        this.newLedPanelCtrl.detectChanges();
+        this.newLedgerComponent.calculateTotal();
+        this.newLedgerComponent.detectChanges();
         this.selectedTxnAccUniqueName = txn.selectedAccount.uniqueName;
     }
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
It merges the taxes of ledger account and particular account with autofill only the taxes that are pre-applied to those accounts


* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Other information**:
