### PR TITLE
Feature/G0-4882 | Prod - Delete option is not available for line items in edit mode for Invoice/Proforma/Estimate/Credit Note/Debit Note/Purchase Record

### DIFF
--- a/apps/web-giddh/src/app/proforma-invoice/proforma-invoice.component.html
+++ b/apps/web-giddh/src/app/proforma-invoice/proforma-invoice.component.html
@@ -926,7 +926,7 @@
 
     </div>
 
-    <div class="trash-icon-delete" *ngIf="!isUpdateMode || (isUpdateMode && entry.isNewEntryInUpdateMode)" (click)="removeTransaction(entryIdx)">
+    <div class="trash-icon-delete" *ngIf="!isUpdateMode || (isUpdateMode && (entry.isNewEntryInUpdateMode || (!isPurchaseInvoice && !isEstimateInvoice && !isProformaInvoice)))" (click)="removeTransaction(entryIdx)">
         <span class="cp">
                                                 <i class="icon-trash" aria-hidden="true"></i>
                                             </span>
@@ -1382,7 +1382,7 @@
                         <img src="assets/images/edit-pencilicon.svg">
                     </div>
 
-                    <div class="del-card" (click)="removeTransaction(entryIdx)" *ngIf="!isUpdateMode || (isUpdateMode && entry.isNewEntryInUpdateMode)">
+                    <div class="del-card" (click)="removeTransaction(entryIdx)" *ngIf="!isUpdateMode || (isUpdateMode && (entry.isNewEntryInUpdateMode || (!isPurchaseInvoice && !isEstimateInvoice && !isProformaInvoice)))">
                         <i class="icon-trash" aria-hidden="true"></i>
                     </div>
 
@@ -1689,7 +1689,7 @@
                     <i class="fa fa-floppy-o" aria-hidden="true"></i>
                 </div>
 
-                <div class="del-card pointer" (click)="removeTransaction(entryIdx)" *ngIf="!isUpdateMode || (isUpdateMode && entry.isNewEntryInUpdateMode)">
+                <div class="del-card pointer" (click)="removeTransaction(entryIdx)" *ngIf="!isUpdateMode || (isUpdateMode && (entry.isNewEntryInUpdateMode || (!isPurchaseInvoice && !isEstimateInvoice && !isProformaInvoice)))">
                     <i class="icon-trash" aria-hidden="true"></i>
                 </div>
 

--- a/apps/web-giddh/src/app/proforma-invoice/proforma-invoice.component.ts
+++ b/apps/web-giddh/src/app/proforma-invoice/proforma-invoice.component.ts
@@ -2209,14 +2209,13 @@ export class ProformaInvoiceComponent implements OnInit, OnDestroy, AfterViewIni
     }
 
     public removeTransaction(entryIdx: number) {
-        if (this.invFormData.entries.length > 1) {
-            if (this.activeIndx === entryIdx) {
-                this.activeIndx = null;
-            }
-            this.invFormData.entries = this.invFormData.entries.filter((entry, index) => entryIdx !== index);
-            this.calculateAffectedThingsFromOtherTaxChanges();
-        } else {
-            this._toasty.warningToast('Unable to delete a single transaction');
+        if (this.activeIndx === entryIdx) {
+            this.activeIndx = null;
+        }
+        this.invFormData.entries = this.invFormData.entries.filter((entry, index) => entryIdx !== index);
+        this.calculateAffectedThingsFromOtherTaxChanges();
+        if (this.invFormData.entries.length === 0) {
+            this.addBlankRow(null);
         }
         this.handleWarehouseVisibility();
     }


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
It adds a new item if the user deletes the last item in any invoice


* **What is the current behavior?** (You can also link to an open issue here)
Currently, a warning message is displayed '`Unable to delete a single transaction`' which makes it difficult for the user to reset the last entry. He only has the option to first add a new empty entry and only then he can delete his old entry.


* **What is the new behavior (if this is a feature change)?**



* **Other information**:
