### PR TITLE
fix: Calculation not taking place if the involved account is liability

### DIFF
--- a/apps/web-giddh/src/app/ledger/components/updateLedgerEntryPanel/updateLedger.vm.ts
+++ b/apps/web-giddh/src/app/ledger/components/updateLedgerEntryPanel/updateLedger.vm.ts
@@ -204,7 +204,7 @@ export class UpdateLedgerVm {
     }
 
     public isValidCategory(category: string): boolean {
-        return category === 'income' || category === 'expenses' || category === 'fixedassets' || (this.isAdvanceReceipt && category === 'assets');
+        return category === 'income' || category === 'expenses' || category === 'fixedassets' || this.isAdvanceReceipt;
     }
 
     public isThereStockEntry(uniqueName: string): boolean {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Calculation takes place only for `assets` category, this check was removed


* **What is the current behavior?** (You can also link to an open issue here)
Currently through ledger any entry is allowed to become an Advance Receipt entry and therefore limiting the calculation only for `assets` category will give issues for other category accounts


* **What is the new behavior (if this is a feature change)?**



* **Other information**: