### PR TITLE
G0-4886 | On the sales invoice page after selecting one gst tax other gst taxes are not displayed disabled

### DIFF
--- a/apps/web-giddh/src/app/proforma-invoice/proforma-invoice.component.html
+++ b/apps/web-giddh/src/app/proforma-invoice/proforma-invoice.component.html
@@ -862,7 +862,7 @@
                                     <td class="pos-rel dropdown-container item-tax" style="height:1px;">
                                         <div class="td_Wrapper">
                                             <div class="text-right" style="flex:1;">
-                                                <tax-control [taxes]="companyTaxesList" [date]="entry.entryDate" [taxRenderData]="entry.taxes" [totalForTax]="transaction.taxableValue" [applicableTaxes]="transaction.applicableTaxes" [exceptTaxTypes]="exceptTaxTypes" [allowedSelectionOfAType]="[{ type: ['GST', 'commongst', 'InputGST'], count:1 }]"
+                                                <tax-control [taxes]="companyTaxesList" [date]="entry.entryDate" [taxRenderData]="entry.taxes" [totalForTax]="transaction.taxableValue" [applicableTaxes]="transaction.applicableTaxes" [exceptTaxTypes]="exceptTaxTypes" [allowedSelectionOfAType]="allowedSelectionOfAType"
                                                     [showHeading]="false" [rootClass]="'salseInvoicetable'" (taxAmountSumEvent)="calculateWhenTrxAltered(entry, transaction)" (hideOtherPopups)="closeDiscountPopup()" [maskInput]="inputMaskFormat" [prefixInput]="invFormData.accountDetails.currencySymbol"
                                                     [suffixInput]="selectedSuffixForCurrency">
                                                 </tax-control>
@@ -1590,7 +1590,7 @@
                                     <label class="card-label text-right">Tax</label>
 
                                     <div class="text-right" style="flex:1;">
-                                        <tax-control [taxes]="companyTaxesList" [date]="entry.entryDate" [taxRenderData]="entry.taxes" [totalForTax]="transaction.taxableValue" [applicableTaxes]="transaction.applicableTaxes" [exceptTaxTypes]="exceptTaxTypes" [allowedSelectionOfAType]="[{ type: ['GST', 'commongst', 'InputGST'], count:1 }]"
+                                        <tax-control [taxes]="companyTaxesList" [date]="entry.entryDate" [taxRenderData]="entry.taxes" [totalForTax]="transaction.taxableValue" [applicableTaxes]="transaction.applicableTaxes" [exceptTaxTypes]="exceptTaxTypes" [allowedSelectionOfAType]="allowedSelectionOfAType"
                                             [showHeading]="false" [rootClass]="'salseInvoicetable'" (taxAmountSumEvent)="calculateWhenTrxAltered(entry, transaction)" (hideOtherPopups)="closeDiscountPopup()" [maskInput]="inputMaskFormat" [prefixInput]="invFormData.accountDetails.currencySymbol"
                                             [suffixInput]="selectedSuffixForCurrency">
                                         </tax-control>

--- a/apps/web-giddh/src/app/proforma-invoice/proforma-invoice.component.ts
+++ b/apps/web-giddh/src/app/proforma-invoice/proforma-invoice.component.ts
@@ -316,6 +316,10 @@ export class ProformaInvoiceComponent implements OnInit, OnDestroy, AfterViewIni
     public reverseExchangeRate: number;
     public originalReverseExchangeRate: number;
     public countryCode: string = '';
+    /** Allowed taxes list contains the unique name of all
+     * tax types within a company and count upto which they are allowed
+     */
+    public allowedSelectionOfAType: any = { type: [], count: 1 };
 
     // private members
     private destroyed$: ReplaySubject<boolean> = new ReplaySubject(1);
@@ -610,8 +614,14 @@ export class ProformaInvoiceComponent implements OnInit, OnDestroy, AfterViewIni
                             }
                             return item;
                         });
+                        this.companyTaxesList.forEach((tax) => {
+                            if (!this.allowedSelectionOfAType.type.includes(tax.taxType)) {
+                                this.allowedSelectionOfAType.type.push(tax.taxType);
+                            }
+                        });
                     } else {
                         this.companyTaxesList = [];
+                        this.allowedSelectionOfAType.type = [];
                     }
                 });
             }

--- a/apps/web-giddh/src/app/theme/tax-control/tax-control.component.ts
+++ b/apps/web-giddh/src/app/theme/tax-control/tax-control.component.ts
@@ -200,18 +200,18 @@ export class TaxControlComponent implements OnInit, OnDestroy, OnChanges {
                 let selectedTaxes = this.taxRenderData.filter(appliedTaxes => (appliedTaxes.isChecked && taxType === appliedTaxes.type));
 
                 if (selectedTaxes.length >= this.allowedSelectionOfAType.count) {
-                    this.taxRenderData.map((m => {
-                        if (taxType === m.type && !m.isChecked) {
-                            m.isDisabled = true;
+                    this.taxRenderData.map((taxesApplied => {
+                        if (taxType === taxesApplied.type && !taxesApplied.isChecked) {
+                            taxesApplied.isDisabled = true;
                         }
-                        return m;
+                        return taxesApplied;
                     }));
                 } else {
-                    this.taxRenderData.map((m => {
-                        if (taxType === m.type && m.isDisabled) {
-                            m.isDisabled = false;
+                    this.taxRenderData.map((taxesApplied => {
+                        if (taxType === taxesApplied.type && taxesApplied.isDisabled) {
+                            taxesApplied.isDisabled = false;
                         }
-                        return m;
+                        return taxesApplied;
                     }));
                 }
             });

--- a/apps/web-giddh/src/app/theme/tax-control/tax-control.component.ts
+++ b/apps/web-giddh/src/app/theme/tax-control/tax-control.component.ts
@@ -57,7 +57,7 @@ export class TaxControlComponent implements OnInit, OnDestroy, OnChanges {
     @Input() public customTaxTypesForTaxFilter: string[] = [];
     @Input() public exceptTaxTypes: string[] = [];
     @Input() public allowedSelection: number = 0;
-    @Input() public allowedSelectionOfAType: Array<{ type: string[], count: number }>;
+    @Input() public allowedSelectionOfAType: { type: string[], count: number };
     @Input() public maskInput: string;
     @Input() public prefixInput: string;
     @Input() public suffixInput: string;
@@ -195,20 +195,20 @@ export class TaxControlComponent implements OnInit, OnDestroy, OnChanges {
             }
         }
 
-        if (this.allowedSelectionOfAType && this.allowedSelectionOfAType.length) {
-            this.allowedSelectionOfAType.forEach(ast => {
-                let selectedTaxes = this.taxRenderData.filter(f => f.isChecked).filter(t => ast.type.includes(t.type));
+        if (this.allowedSelectionOfAType && this.allowedSelectionOfAType.type.length) {
+            this.allowedSelectionOfAType.type.forEach(taxType => {
+                let selectedTaxes = this.taxRenderData.filter(appliedTaxes => (appliedTaxes.isChecked && taxType === appliedTaxes.type));
 
-                if (selectedTaxes.length >= ast.count) {
+                if (selectedTaxes.length >= this.allowedSelectionOfAType.count) {
                     this.taxRenderData.map((m => {
-                        if (ast.type.includes(m.type) && !m.isChecked) {
+                        if (taxType === m.type && !m.isChecked) {
                             m.isDisabled = true;
                         }
                         return m;
                     }));
                 } else {
                     this.taxRenderData.map((m => {
-                        if (ast.type.includes(m.type) && m.isDisabled) {
+                        if (taxType === m.type && m.isDisabled) {
                             m.isDisabled = false;
                         }
                         return m;


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
It removes the hard coded tax types used due to which tax of particular type is not disabled if the same type of tax is already selected


* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Other information**:
