### PR TITLE
Prod - Text of ledger heading on CR and DR side for Reverse Charge ledger is incorrect

### DIFF
--- a/apps/web-giddh/src/app/ledger/underStandingTextData.ts
+++ b/apps/web-giddh/src/app/ledger/underStandingTextData.ts
@@ -68,8 +68,8 @@ export const underStandingTextData = [
     {
         accountType: 'ReverseCharge',
         text: {
-            cr: `<accountName> is decreasing ↑`,
-            dr: '<accountName> is increasing ↓'
+            cr: `<accountName> is decreasing ↓`,
+            dr: '<accountName> is increasing ↑'
         },
         balanceText: {
             cr: '(-) Reverse Charge ( ohh no!)',

--- a/apps/web-giddh/src/app/ledger/underStandingTextData.ts
+++ b/apps/web-giddh/src/app/ledger/underStandingTextData.ts
@@ -68,8 +68,8 @@ export const underStandingTextData = [
     {
         accountType: 'ReverseCharge',
         text: {
-            cr: `<accountName> is increasing ↑`,
-            dr: '<accountName> is decreasing ↓'
+            cr: `<accountName> is decreasing ↑`,
+            dr: '<accountName> is increasing ↓'
         },
         balanceText: {
             cr: '(-) Reverse Charge ( ohh no!)',


### PR DESCRIPTION
I have confirmed with @Akanksha that Increasing should be on left side and Decreasing on right side.