### PR TITLE
fix: Avoid unnecessary currency exchange rate call

### DIFF
--- a/apps/web-giddh/src/app/invoice/preview/invoice.preview.component.html
+++ b/apps/web-giddh/src/app/invoice/preview/invoice.preview.component.html
@@ -627,7 +627,7 @@
     <div bsModal #performActionOnInvoiceModel="bs-modal" class="modal fade" role="dialog" [config]="{keyboard:true}" tabindex="-1">
         <div class="modal-dialog modal-md perform-payment">
             <div class="modal-content">
-                <invoice-payment-model *ngIf="(selectedVoucher !== 'purchase')" [selectedInvoiceForPayment]="selectedInvoice" (closeModelEvent)="closePerformActionPopup($event)">
+                <invoice-payment-model *ngIf="performActionOnInvoiceModel.isShown" [selectedInvoiceForPayment]="selectedInvoice" (closeModelEvent)="closePerformActionPopup($event)">
                 </invoice-payment-model>
             </div>
         </div>

--- a/apps/web-giddh/src/app/invoice/preview/models/invoice-preview-details/invoice-preview-details.component.html
+++ b/apps/web-giddh/src/app/invoice/preview/models/invoice-preview-details/invoice-preview-details.component.html
@@ -472,7 +472,7 @@
 <div bsModal #receivePaymentPopup="bs-modal" class="modal fade" role="dialog" [config]="{keyboard:true}" tabindex="-1">
     <div class="modal-dialog modal-md">
         <div class="modal-content">
-            <invoice-payment-model *ngIf="selectedItem.voucherType !== 'purchase'" [selectedInvoiceForPayment]="selectedItem"
+            <invoice-payment-model *ngIf="receivePaymentPopup.isShown" [selectedInvoiceForPayment]="selectedItem"
                 (closeModelEvent)="processPaymentEvent.emit($event);receivePaymentPopup.toggle()">
             </invoice-payment-model>
         </div>

--- a/apps/web-giddh/src/app/invoice/preview/models/invoicePayment/invoice.payment.model.component.ts
+++ b/apps/web-giddh/src/app/invoice/preview/models/invoicePayment/invoice.payment.model.component.ts
@@ -1,7 +1,7 @@
 import { Observable, of as observableOf, ReplaySubject } from 'rxjs';
 
 import { takeUntil } from 'rxjs/operators';
-import { Component, EventEmitter, Input, OnChanges, OnDestroy, OnInit, Output, QueryList, SimpleChanges, ViewChild, ViewChildren } from '@angular/core';
+import { Component, EventEmitter, Input, OnChanges, OnDestroy, OnInit, Output, QueryList, SimpleChanges, ViewChild, ViewChildren, ChangeDetectorRef } from '@angular/core';
 import { ILedgersInvoiceResult, InvoicePaymentRequest } from '../../../../models/api-models/Invoice';
 import * as moment from 'moment/moment';
 import { GIDDH_DATE_FORMAT } from '../../../../shared/helpers/defaultDateFormat';
@@ -60,6 +60,7 @@ export class InvoicePaymentModelComponent implements OnInit, OnDestroy, OnChange
     public paymentModes$: Observable<IOption[]> = observableOf([]);
 
     constructor(
+        private changeDetectorRef: ChangeDetectorRef,
         private store: Store<AppState>,
         private _settingsTagActions: SettingsTagActions,
         private _ledgerService: LedgerService,
@@ -263,6 +264,7 @@ export class InvoicePaymentModelComponent implements OnInit, OnDestroy, OnChange
                 if (rate) {
                     this.originalExchangeRate = rate;
                     this.exchangeRate = rate;
+                    this.changeDetectorRef.detectChanges();
                 }
             }, (error => {
 

--- a/apps/web-giddh/src/app/proforma-invoice/proforma-invoice.component.ts
+++ b/apps/web-giddh/src/app/proforma-invoice/proforma-invoice.component.ts
@@ -869,18 +869,12 @@ export class ProformaInvoiceComponent implements OnInit, OnDestroy, AfterViewIni
                             this.selectedAccountDetails$.pipe(take(1)).subscribe(acc => {
                                 obj.accountDetails.currencySymbol = acc.currencySymbol || '';
                             });
-
+                            this.fetchCurrencyRate(results);
                         } else if (this.isPurchaseInvoice) {
                             let convertedRes1 = await this.modifyMulticurrencyRes(results[1]);
                             this.isRcmEntry = (results[1]) ? results[1].subVoucher === Subvoucher.ReverseCharge : false;
                             obj = cloneDeep(convertedRes1) as VoucherClass;
-                            if (this.isUpdateMode) {
-                                const vendorCurrency = (results[1].account.currency) ? results[1].account.currency.code : this.companyCurrency;
-                                if (vendorCurrency !== this.companyCurrency) {
-                                    this.isMulticurrencyAccount = true;
-                                    this.getCurrencyRate(this.companyCurrency, vendorCurrency);
-                                }
-                            }
+                            this.fetchCurrencyRate(results);
                         } else {
                             obj = cloneDeep((results[1] as GenericRequestForGenerateSCD).voucher);
                         }
@@ -1960,7 +1954,7 @@ export class ProformaInvoiceComponent implements OnInit, OnDestroy, AfterViewIni
                 } else {
                     this.calculatedRoundOff = Number((calculatedGrandTotal - calculatedGrandTotal).toFixed(2));
                 }
-                
+
                 calculatedGrandTotal = Number((calculatedGrandTotal + this.calculatedRoundOff).toFixed(2));
             } else if (calculatedGrandTotal === 0) {
                 this.calculatedRoundOff = 0;
@@ -3827,6 +3821,16 @@ export class ProformaInvoiceComponent implements OnInit, OnDestroy, AfterViewIni
             }
         });
         return validEntries;
+    }
+
+    public fetchCurrencyRate(results): void {
+        if (this.isUpdateMode) {
+            const vendorCurrency = (results[1].account.currency) ? results[1].account.currency.code : this.companyCurrency;
+            if (vendorCurrency !== this.companyCurrency) {
+                this.isMulticurrencyAccount = true;
+                this.getCurrencyRate(this.companyCurrency, vendorCurrency);
+            }
+        }
     }
 
     /**

--- a/apps/web-giddh/src/app/proforma-invoice/proforma-invoice.component.ts
+++ b/apps/web-giddh/src/app/proforma-invoice/proforma-invoice.component.ts
@@ -3823,6 +3823,12 @@ export class ProformaInvoiceComponent implements OnInit, OnDestroy, AfterViewIni
         return validEntries;
     }
 
+    /**
+     * Fetches the currency rate for multicurrency scenario
+     *
+     * @param {*} results Account details received from API
+     * @memberof ProformaInvoiceComponent
+     */
     public fetchCurrencyRate(results): void {
         if (this.isUpdateMode) {
             const vendorCurrency = (results[1].account.currency) ? results[1].account.currency.code : this.companyCurrency;


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR limits the call to exchange rate API to components where it is actually required and adds the code to fetch the currency exchange rate for Invoice in proforma invoice component


* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Other information**:
