### PR TITLE
G0-5366 | Prod - "This Financial Year to Date" filter is not working on date picker for "Total Overdues" section in Dashboard module

### DIFF
--- a/apps/web-giddh/src/app/home/components/datepickeroptions/datepickeroptions.component.ts
+++ b/apps/web-giddh/src/app/home/components/datepickeroptions/datepickeroptions.component.ts
@@ -39,7 +39,7 @@ export class DatepickeroptionsComponent implements OnInit, OnDestroy {
                 moment()
             ],
             'This Financial Year to Date': [
-                moment().startOf('year').subtract(9, 'year'),
+                moment().startOf('year').subtract(9, 'month'),
                 moment()
             ],
             'This Year to Date': [


### PR DESCRIPTION
G0-5366 | Prod - "This Financial Year to Date" filter is not working on date picker for "Total Overdues" section in Dashboard module