### PR TITLE
fix: State not mandatory for sundary Debtor

### DIFF
--- a/apps/web-giddh/src/app/contact/aside-menu-account/aside.menu.account.component.ts
+++ b/apps/web-giddh/src/app/contact/aside-menu-account/aside.menu.account.component.ts
@@ -118,11 +118,7 @@ export class AsideMenuAccountInContactComponent implements OnInit, OnDestroy {
             if (flattenGroups) {
                 let items: IOption[] = flattenGroups.filter(grps => {
                     return grps.groupUniqueName === this.activeGroupUniqueName || grps.parentGroups.some(s => s.uniqueName === this.activeGroupUniqueName);
-                }).map(m => {
-                    return {
-                        value: m.groupUniqueName, label: m.groupName, additional: m.parentGroups
-                    };
-                });
+                }).map((m: any) => ({ value: m.groupUniqueName, label: m.groupName, additional: m.parentGroups }));
                 this.flatGroupsOptions = items;
             }
         });

--- a/apps/web-giddh/src/app/shared/header/components/account-add-new-details/account-add-new-details.component.ts
+++ b/apps/web-giddh/src/app/shared/header/components/account-add-new-details/account-add-new-details.component.ts
@@ -792,7 +792,8 @@ export class AccountAddNewDetailsComponent implements OnInit, OnChanges, AfterVi
      * @memberof AccountAddNewDetailsComponent
      */
     public checkActiveGroupCountry(): boolean {
-        if (this.activeCompany && this.activeCompany.countryV2 && this.activeCompany.countryV2.alpha2CountryCode === this.addAccountForm.get('country').get('countryCode').value && (this.activeGroupUniqueName === "sundrydebtors" || this.activeGroupUniqueName === "sundrycreditors")) {
+        if (this.activeCompany && this.activeCompany.countryV2 && this.activeCompany.countryV2.alpha2CountryCode === this.addAccountForm.get('country').get('countryCode').value &&
+            this.isCreditorOrDebtor(this.activeGroupUniqueName)) {
             return true;
         } else {
             return false;
@@ -880,5 +881,23 @@ export class AccountAddNewDetailsComponent implements OnInit, OnChanges, AfterVi
                  element.classList.remove('error-box');
             }
         }
+    }
+
+    /**
+     * Returns true if passed account belongs to creditor or debtor category
+     * required to make state mandatory
+     *
+     * @private
+     * @param {string} accountUniqueName Account unique name
+     * @returns {boolean} True if passed account belongs to creditor or debtor category
+     * @memberof AccountAddNewDetailsComponent
+     */
+    private isCreditorOrDebtor(accountUniqueName: string): boolean {
+        if (this.flatGroupsOptions) {
+            const groupDetails: any = this.flatGroupsOptions.filter((group) => group.value === accountUniqueName).pop();
+            return (groupDetails) ?
+                groupDetails.additional.some((parentGroup) => parentGroup.uniqueName === 'sundrydebtors' || parentGroup.uniqueName === 'sundrycreditors') : false;
+        }
+        return false;
     }
 }

--- a/apps/web-giddh/src/app/shared/header/components/account-add-new-details/account-add-new-details.component.ts
+++ b/apps/web-giddh/src/app/shared/header/components/account-add-new-details/account-add-new-details.component.ts
@@ -259,11 +259,7 @@ export class AccountAddNewDetailsComponent implements OnInit, OnChanges, AfterVi
             if (flattenGroups) {
                 let items: IOption[] = flattenGroups.filter(grps => {
                     return grps.groupUniqueName === this.activeGroupUniqueName || grps.parentGroups.some(s => s.uniqueName === this.activeGroupUniqueName);
-                }).map(m => {
-                    return {
-                        value: m.groupUniqueName, label: m.groupName, additional: m.parentGroups
-                    }
-                });
+                }).map((m: any) => ({ value: m.groupUniqueName, label: m.groupName, additional: m.parentGroups }));
                 this.flatGroupsOptions = items;
                 if (this.flatGroupsOptions.length > 0 && this.activeGroupUniqueName) {
                     let selectedGroupDetails;
@@ -281,6 +277,7 @@ export class AccountAddNewDetailsComponent implements OnInit, OnChanges, AfterVi
                             }
                         }
                     }
+                    this.toggleStateRequired();
                 }
             }
         });
@@ -893,10 +890,15 @@ export class AccountAddNewDetailsComponent implements OnInit, OnChanges, AfterVi
      * @memberof AccountAddNewDetailsComponent
      */
     private isCreditorOrDebtor(accountUniqueName: string): boolean {
-        if (this.flatGroupsOptions) {
+        if (this.flatGroupsOptions && _.isArray(this.flatGroupsOptions) && this.flatGroupsOptions.length && accountUniqueName) {
             const groupDetails: any = this.flatGroupsOptions.filter((group) => group.value === accountUniqueName).pop();
-            return (groupDetails) ?
-                groupDetails.additional.some((parentGroup) => parentGroup.uniqueName === 'sundrydebtors' || parentGroup.uniqueName === 'sundrycreditors') : false;
+            if (groupDetails) {
+                return groupDetails.additional.some((parentGroup) => {
+                    const groups = [parentGroup.uniqueName, groupDetails.value]
+                    return groups.includes('sundrydebtors') || groups.includes('sundrycreditors');
+                });
+            }
+            return false;
         }
         return false;
     }


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR fixes the state not mandatory while creating account within sundry creditor or sundry debtor.


* **What is the current behavior?** (You can also link to an open issue here)
Currently the code only compares for current active group unique name with hard coded value '`sundrydebtor`' or '`sundrycreditor`'.


* **What is the new behavior (if this is a feature change)?**
Now the code searches for all the parent groups and if any of the groups lies in '`sundrydebtor`' or '`sundrycreditor`' then state is made mandatory


* **Other information**:
