### PR TITLE
advance receipts new flow with edit and create invoice implemented

### DIFF
--- a/apps/web-giddh/src/app/invoice/preview/invoice.preview.component.html
+++ b/apps/web-giddh/src/app/invoice/preview/invoice.preview.component.html
@@ -371,14 +371,14 @@
 
                                 <div>
                                     <div dropdown container="body" class="icon-ellipse selectAction">
-                                        <a id="edit-model-basic" dropdownToggle class="dropdown-toggle icon-dots-three-vertical pull-right" aria-controls="dropdown-basic"></a>
+                                        <a id="edit-model-basic" dropdownToggle class="dropdown-toggle icon-dots-three-vertical pull-right" (click)="clickChangeStatusToggle(item)" aria-controls="dropdown-basic"></a>
 
                                         <div id="dropdown-basic" *dropdownMenu class="dropdown-menu dropdown-menu-right wd00" role="menu" aria-labelledby="edit-model-basic">
                                             <ul class="selectActionDropdown">
                                                 <li (click)="onPerformAction(item, 'paid')">
                                                     <a class="cp" href="javascript:void(0)">Paid</a>
                                                 </li>
-                                                <li *ngIf="selectedVoucher === 'sales'" (click)="onPerformAdjustPaymentAction(item)">
+                                                <li *ngIf="selectedVoucher === 'sales'" [ngClass]="{'no-click': !isAccountHaveAdvanceReceipts}" (click)="onPerformAdjustPaymentAction(item)">
                                                     <a class="cp" href="javascript:void(0)">Adjust Amount</a>
                                                 </li>
                                                 <li (click)="onPerformAction(item, 'unpaid')">

--- a/apps/web-giddh/src/app/invoice/preview/invoice.preview.component.scss
+++ b/apps/web-giddh/src/app/invoice/preview/invoice.preview.component.scss
@@ -1,5 +1,4 @@
 @import "../../../assets/css/color.scss";
-
 .flex-container {
     display: flex;
     flex-direction: row;
@@ -200,6 +199,7 @@ td.card-header.clearfix {
     display: inline-block;
     padding-right: 20px;
 }
+
 .invoiceNameDownload {
     position: relative;
     text-align: right;
@@ -279,6 +279,7 @@ ul.selectActionDropdown {
     padding: 5px 10px;
     display: block;
 }
+
 .selectActionDropdown a:hover {
     color: $chetwode-blue !important;
     background: #eeeff9 !important;
@@ -287,6 +288,7 @@ ul.selectActionDropdown {
 .addInvoice .dropdown-toggle {
     color: #fff;
 }
+
 .invoice-container {
     padding: 0 15px;
 }
@@ -308,9 +310,11 @@ ul.selectActionDropdown {
     cursor: default;
     width: 100%;
 }
+
 .input-group input.form-control:focus {
     border-color: $gainsboro;
 }
+
 .icon-calender {
     position: absolute;
     z-index: 9;
@@ -336,11 +340,13 @@ ul.selectActionDropdown {
     color: $midnight-express;
     background: #fff;
 }
+
 .advance-icon:hover {
     background: #eaeaea;
 }
+
 .dropdown-toggle.spcl_dropdown {
-    color: $navy  !important;
+    color: $navy !important;
     border: 1px solid $chetwode-blue;
     width: 91px;
     padding-left: 10px;
@@ -352,14 +358,17 @@ ul.selectActionDropdown {
     color: $midnight-express;
     background-color: #fff;
 }
+
 .dropdown-toggle.spcl_dropdown:hover {
     background: $chetwode-blue;
     color: #fff !important;
     border-color: $chetwode-blue;
 }
+
 .dropdown-toggle.spcl_dropdown:hover .caret {
     color: #fff !important;
 }
+
 .dropdown-toggle.spcl_dropdown .caret {
     color: #999999;
 }
@@ -392,6 +401,7 @@ button.btn.btn-filter span.icon-cross {
 .invoice-table th .d-flex {
     align-items: center;
 }
+
 .btn-link-2 {
     color: #1c1c1c;
 }
@@ -445,6 +455,12 @@ div.remove-capitalize {
     text-transform: none !important;
 }
 
+li.no-click {
+    pointer-events: none;
+    opacity: 0.6; 
+    cursor: not-allowed;
+}
+
 /* responsive */
 
 @media (max-width: 768px) {
@@ -454,16 +470,13 @@ div.remove-capitalize {
     .mobileTable {
         display: block;
     }
-
     .desktopTable {
         display: none;
     }
-
     .mobileViewPagination {
         display: block;
         text-align: center;
     }
-
     .paginationWrapper {
         margin-top: 20px;
         border: none;
@@ -482,7 +495,6 @@ div.remove-capitalize {
         bottom: 188px;
         border: none;
     }
-
     .date-advanceSearch .dropdown-menu.show.fixedDropdownPlus:after {
         position: absolute;
         width: 20px;
@@ -498,25 +510,20 @@ div.remove-capitalize {
         background-color: #fff;
         z-index: -1;
     }
-
     .displayBlock {
         display: block !important;
     }
-
     .click-dropdwon ul {
         left: auto;
         right: 0;
     }
-
     .invoiceFooter .font-xxlarge {
         font-size: 20px;
     }
-
     .click-dropdwon ul {
         left: auto;
         right: 0;
     }
-
     .plusMoreBtn {
         font-size: 30px;
         width: 50px;
@@ -533,7 +540,6 @@ div.remove-capitalize {
         box-shadow: 0px 0px 18px rgba(0, 0, 0, 0.3) !important;
         display: block;
     }
-
     .date-advanceSearch .dropdown-menu > li > a {
         padding: 8px 10px;
     }
@@ -566,7 +572,6 @@ div.remove-capitalize {
     .invoiceFooter .font-xxlarge {
         font-size: 16px;
     }
-
     .invoiceFooter h1 {
         font-size: 18px !important;
     }
@@ -604,6 +609,7 @@ div.remove-capitalize {
         padding-right: 0;
     }
 }
+
 @media (max-width: 360px) {
     .date-advanceSearch .input-group {
         width: 100%;

--- a/apps/web-giddh/src/app/invoice/preview/invoice.preview.component.ts
+++ b/apps/web-giddh/src/app/invoice/preview/invoice.preview.component.ts
@@ -1548,7 +1548,7 @@ export class InvoicePreviewComponent implements OnInit, OnChanges, OnDestroy {
      * @param {ReciptResponse} item selected row item data
      * @memberof InvoicePreviewComponent
      */
-    public clickChangeStatusToggle(item: any) {
+    public clickChangeStatusToggle(item: any): void {
         this.isAccountHaveAdvanceReceipts = false;
         if (item && item.account && item.account.uniqueName && item.voucherDate) {
             this.getAllAdvanceReceipts(item.account.uniqueName, item.voucherDate);

--- a/apps/web-giddh/src/app/invoice/preview/invoice.preview.component.ts
+++ b/apps/web-giddh/src/app/invoice/preview/invoice.preview.component.ts
@@ -1549,7 +1549,8 @@ export class InvoicePreviewComponent implements OnInit, OnChanges, OnDestroy {
      * @memberof InvoicePreviewComponent
      */
     public clickChangeStatusToggle(item: any) {
-        if (item.account.uniqueName && item.voucherDate) {
+        this.isAccountHaveAdvanceReceipts = false;
+        if (item && item.account && item.account.uniqueName && item.voucherDate) {
             this.getAllAdvanceReceipts(item.account.uniqueName, item.voucherDate);
         }
     }
@@ -1561,10 +1562,10 @@ export class InvoicePreviewComponent implements OnInit, OnChanges, OnDestroy {
      * @param {*} voucherDate Voucher Date (DD-MM-YYYY)
      * @memberof InvoicePreviewComponent
      */
-    public getAllAdvanceReceipts(customerUniquename, voucherDate): void {
-        if (customerUniquename && voucherDate) {
+    public getAllAdvanceReceipts(customerUniqueName, voucherDate): void {
+        if (customerUniqueName && voucherDate) {
             let requestObject = {
-                accountUniqueName: customerUniquename,
+                accountUniqueName: customerUniqueName,
                 invoiceDate: voucherDate
             };
             this.salesService.getAllAdvanceReceiptVoucher(requestObject).subscribe(res => {
@@ -1575,7 +1576,7 @@ export class InvoicePreviewComponent implements OnInit, OnChanges, OnDestroy {
                         this.isAccountHaveAdvanceReceipts = false;
                     }
                 }
-            })
+            });
         }
     }
 }

--- a/apps/web-giddh/src/app/invoice/preview/invoice.preview.component.ts
+++ b/apps/web-giddh/src/app/invoice/preview/invoice.preview.component.ts
@@ -241,6 +241,8 @@ export class InvoicePreviewComponent implements OnInit, OnChanges, OnDestroy {
     public depositAmount: number = 0;
     /** True, if select perform adjust payment action for an invoice  */
     public selectedPerformAdjustPaymentAction: boolean = false;
+    /** To check is selected account/customer have advance receipts */
+    public isAccountHaveAdvanceReceipts: boolean = false;
 
     constructor(
         private store: Store<AppState>,
@@ -1535,8 +1537,45 @@ export class InvoicePreviewComponent implements OnInit, OnChanges, OnDestroy {
      * @memberof InvoicePreviewComponent
      */
     public openAdvanceReceiptModal(event): void {
-        if (event) {
+        if (event && this.isAccountHaveAdvanceReceipts) {
             this.onPerformAdjustPaymentAction(this.selectedInvoice);
+        }
+    }
+
+    /**
+     * To toggle change status container
+     *
+     * @param {ReciptResponse} item selected row item data
+     * @memberof InvoicePreviewComponent
+     */
+    public clickChangeStatusToggle(item: any) {
+        if (item.account.uniqueName && item.voucherDate) {
+            this.getAllAdvanceReceipts(item.account.uniqueName, item.voucherDate);
+        }
+    }
+
+    /**
+     * Call API to get all advance receipts of an invoice
+     *
+     * @param {*} customerUniquename Selected customer unique name
+     * @param {*} voucherDate Voucher Date (DD-MM-YYYY)
+     * @memberof InvoicePreviewComponent
+     */
+    public getAllAdvanceReceipts(customerUniquename, voucherDate): void {
+        if (customerUniquename && voucherDate) {
+            let requestObject = {
+                accountUniqueName: customerUniquename,
+                invoiceDate: voucherDate
+            };
+            this.salesService.getAllAdvanceReceiptVoucher(requestObject).subscribe(res => {
+                if (res && res.status === 'success') {
+                    if (res.body && res.body.length) {
+                        this.isAccountHaveAdvanceReceipts = true;
+                    } else {
+                        this.isAccountHaveAdvanceReceipts = false;
+                    }
+                }
+            })
         }
     }
 }

--- a/apps/web-giddh/src/app/invoice/preview/invoice.preview.component.ts
+++ b/apps/web-giddh/src/app/invoice/preview/invoice.preview.component.ts
@@ -1562,7 +1562,7 @@ export class InvoicePreviewComponent implements OnInit, OnChanges, OnDestroy {
      * @param {*} voucherDate Voucher Date (DD-MM-YYYY)
      * @memberof InvoicePreviewComponent
      */
-    public getAllAdvanceReceipts(customerUniqueName, voucherDate): void {
+    public getAllAdvanceReceipts(customerUniqueName: string, voucherDate: string): void {
         if (customerUniqueName && voucherDate) {
             let requestObject = {
                 accountUniqueName: customerUniqueName,

--- a/apps/web-giddh/src/app/proforma-invoice/proforma-invoice.component.html
+++ b/apps/web-giddh/src/app/proforma-invoice/proforma-invoice.component.html
@@ -283,7 +283,7 @@
                                     <!-- added multicurrency feature make it functional to change into appropriate currency -->
                                     <span class="sp-rupees" *ngIf='isMulticurrencyAccount'>
                                         <span *ngIf="isMulticurrencyAccount">{{baseCurrencySymbol}}</span>
-                                    <span>{{invFormData.voucherDetails.balanceDue * exchangeRate - adjustPaymentBalanceDueData | giddhCurrency}}</span>
+                                    <span>{{invFormData.voucherDetails.balanceDue * exchangeRate  | giddhCurrency}}</span>
                                     </span>
                                     <span class="sp-rupees" *ngIf='!isMulticurrencyAccount'>
                                         <ng-container *ngIf="adjustPaymentData?.totalAdjustedAmount">
@@ -1155,7 +1155,7 @@
                     </div>
 
                     <!--region balance due for non-purchase-->
-                    <div class="tableRow" *ngIf="((isSalesInvoice || isCashInvoice) && !isUpdateMode)">
+                    <div class="tableRow" *ngIf="((isSalesInvoice || isCashInvoice))">
 
                         <div class="tableCell depositeSection">
 
@@ -1164,7 +1164,7 @@
                                 <div (click)="clickedInside($event)" id="deposit-dropdown" class="form-group pd1">
                                     <p>Deposit</p>
                                     <ul>
-                                        <ng-container *ngIf="isSalesInvoice">
+                                        <ng-container *ngIf="isSalesInvoice && (isAccountHaveAdvanceReceipts || isInvoiceAdjustedWithAdvanceReceipts)">
                                             <li role="menuitem" class="mrT1 ">
                                                 <div class="clearfix paymentMode">
 
@@ -1216,40 +1216,41 @@
                                             </li>
                                         </ng-container>
 
-                                        <li role="menuitem" class="mrT1 ">
-                                            <div class="clearfix paymentMode">
+                                        <ng-container *ngIf="!isUpdateMode">
+                                            <li role="menuitem" class="mrT1 ">
+                                                <div class="clearfix paymentMode">
 
-                                                <sh-select class="pull-right " name="depositAccountUniqueName" [options]="bankAccounts$ | async" [(ngModel)]="depositAccountUniqueName" (selected)="onSelectPaymentMode($event)" [placeholder]="'Select Account'" [notFoundLink]="false" [forceClearReactive]="forceClear$ | async"
-                                                    [multiple]="false" [ItemHeight]="33" [useInBuiltFilterForIOptionTypeItems]="true" class="text-left">
-                                                    <ng-template #optionTemplate1 let-option="option">
-                                                        <a href="javascript:void(0)" class="list-item" style="border-bottom: 1px solid #ccc;">
-                                                            <div class="item">{{ option.label }}
-                                                            </div>
-                                                            <div class="item_unq">{{ option.value }}
-                                                            </div>
-                                                        </a>
-                                                    </ng-template>
-                                                </sh-select>
-                                                <label class="pull-right">Payment Mode</label>
-                                            </div>
-                                        </li>
+                                                    <sh-select class="pull-right " name="depositAccountUniqueName" [options]="bankAccounts$ | async" [(ngModel)]="depositAccountUniqueName" (selected)="onSelectPaymentMode($event)" [placeholder]="'Select Account'" [notFoundLink]="false" [forceClearReactive]="forceClear$ | async"
+                                                        [multiple]="false" [ItemHeight]="33" [useInBuiltFilterForIOptionTypeItems]="true" class="text-left">
+                                                        <ng-template #optionTemplate1 let-option="option">
+                                                            <a href="javascript:void(0)" class="list-item" style="border-bottom: 1px solid #ccc;">
+                                                                <div class="item">{{ option.label }}
+                                                                </div>
+                                                                <div class="item_unq">{{ option.value }}
+                                                                </div>
+                                                            </a>
+                                                        </ng-template>
+                                                    </sh-select>
+                                                    <label class="pull-right">Payment Mode</label>
+                                                </div>
+                                            </li>
 
-                                        <li class="clearfix mrT1" *ngIf="isSalesInvoice">
-                                            <input type="text" (blur)="calculateBalanceDue()" placeholder="Amount" name="dueAmount" class="form-control amountField text-right pull-right max100" [(ngModel)]="depositAmount" [prefix]="depositCurrSymbol" [suffix]="selectedSuffixForCurrency" [mask]="inputMaskFormat"
-                                            />
-                                            <label class="pull-right">Amount</label>
-                                        </li>
+                                            <li class="clearfix mrT1" *ngIf="isSalesInvoice">
+                                                <input type="text" (blur)="calculateBalanceDue()" placeholder="Amount" name="dueAmount" class="form-control amountField text-right pull-right max100" [(ngModel)]="depositAmount" [prefix]="depositCurrSymbol" [suffix]="selectedSuffixForCurrency" [mask]="inputMaskFormat"
+                                                />
+                                                <label class="pull-right">Amount</label>
+                                            </li>
 
-                                        <li class="clearfix mrT1" *ngIf="isCashInvoice">
-                                            <span class="amountField pull-right max100 amountFiledCash">
+                                            <li class="clearfix mrT1" *ngIf="isCashInvoice">
+                                                <span class="amountField pull-right max100 amountFiledCash">
                                                                     <span
                                                                         *ngIf="isMulticurrencyAccount && !isPurchaseInvoice">{{invFormData.accountDetails.currencySymbol}}</span> {{invFormData.voucherDetails.balanceDue
-                                            | giddhCurrency}}</span>
-                                            <label class="pull-right">Amount</label>
-                                        </li>
+                                                | giddhCurrency}}</span>
+                                                <label class="pull-right">Amount</label>
+                                            </li>
 
-                                        <li class="clearfix mrT1 biggerDollar" *ngIf="isSalesInvoice ">
-                                            <strong class="pull-right balanceDueText"> <span
+                                            <li class="clearfix mrT1 biggerDollar" *ngIf="isSalesInvoice ">
+                                                <strong class="pull-right balanceDueText"> <span
                                                                         *ngIf="isMulticurrencyAccount && !isPurchaseInvoice">{{invFormData.accountDetails.currencySymbol}}</span>
                                                                     <ng-container *ngIf="adjustPaymentData?.totalAdjustedAmount">
                                                                         {{adjustPaymentBalanceDueData | giddhCurrency }}
@@ -1258,9 +1259,9 @@
                                                                         {{invFormData.voucherDetails.balanceDue | giddhCurrency }}
                                                                     </ng-container>
                                                                 </strong>
-                                            <strong class="pull-right">Balance Due</strong>
-                                        </li>
-
+                                                <strong class="pull-right">Balance Due</strong>
+                                            </li>
+                                        </ng-container>
                                     </ul>
                                 </div>
 

--- a/apps/web-giddh/src/app/proforma-invoice/proforma-invoice.component.ts
+++ b/apps/web-giddh/src/app/proforma-invoice/proforma-invoice.component.ts
@@ -4394,8 +4394,10 @@ export class ProformaInvoiceComponent implements OnInit, OnDestroy, AfterViewIni
                     } else {
                         this.isAccountHaveAdvanceReceipts = false;
                     }
+                } else {
+                    this.isAccountHaveAdvanceReceipts = false;
                 }
-            })
+            });
         } else {
             this.isAccountHaveAdvanceReceipts = false;
         }

--- a/apps/web-giddh/src/app/proforma-invoice/proforma-invoice.component.ts
+++ b/apps/web-giddh/src/app/proforma-invoice/proforma-invoice.component.ts
@@ -39,7 +39,7 @@ import {
     PurchaseRecordRequest,
     TemplateDetailsClass
 } from '../models/api-models/Sales';
-import { auditTime, delay, filter, take, takeUntil } from 'rxjs/operators';
+import { auditTime, delay, filter, take, takeUntil, debounceTime, distinctUntilChanged } from 'rxjs/operators';
 import { IOption } from '../theme/ng-select/option.interface';
 import { combineLatest, Observable, of as observableOf, ReplaySubject } from 'rxjs';
 import { ElementViewContainerRef } from '../shared/helpers/directives/elementViewChild/element.viewchild.directive';
@@ -389,6 +389,11 @@ export class ProformaInvoiceComponent implements OnInit, OnDestroy, AfterViewIni
     }
     public applyRoundOff: boolean = true;
     public customerAccount: any = { email: '' };
+    /** To check is selected account/customer have advance receipts */
+    public isAccountHaveAdvanceReceipts: boolean = false;
+    /** To check is selected invoice already adjusted with at least one advance receipts  */
+    public isInvoiceAdjustedWithAdvanceReceipts: boolean = false;
+
 
     /**
      * Returns true, if Purchase Record creation record is broken
@@ -919,8 +924,12 @@ export class ProformaInvoiceComponent implements OnInit, OnDestroy, AfterViewIni
                     }
                     if (this.isSalesInvoice) {
                         if (results[1] && results[1].advanceReceiptAdjustment && results[1].advanceReceiptAdjustment && results[1].advanceReceiptAdjustment.adjustments && results[1].advanceReceiptAdjustment.adjustments.length) {
+                            this.isInvoiceAdjustedWithAdvanceReceipts = true;
                             this.calculateAdjustedVoucherTotal(results[1].advanceReceiptAdjustment.adjustments);
                             this.advanceReceiptAdjustmentData = results[1].advanceReceiptAdjustment;
+                        } else {
+                            this.isInvoiceAdjustedWithAdvanceReceipts = false;
+
                         }
 
                     }
@@ -1981,13 +1990,21 @@ export class ProformaInvoiceComponent implements OnInit, OnDestroy, AfterViewIni
         if (isNaN(count)) {
             count = 0;
         }
-        if (!this.isUpdateMode) {
-            this.adjustPaymentBalanceDueData = this.invFormData.voucherDetails.grandTotal - this.adjustPaymentData.totalAdjustedAmount - depositAmount + this.invFormData.voucherDetails.tcsTotal + this.invFormData.voucherDetails.tdsTotal;
+        if (!depositAmount) {
+            this.depositAmount = this.invFormData.voucherDetails.deposit;
         }
-
+        if ((this.isAccountHaveAdvanceReceipts || this.isInvoiceAdjustedWithAdvanceReceipts) && this.adjustPaymentData.totalAdjustedAmount) {
+            this.adjustPaymentBalanceDueData = this.getCalculatedBalanceDueAfterAdvanceReceiptsAdjustment();
+        } else {
+            this.adjustPaymentBalanceDueData = 0;
+        }
         this.invFormData.voucherDetails.balanceDue =
             ((count + this.invFormData.voucherDetails.tcsTotal + this.calculatedRoundOff) - this.invFormData.voucherDetails.tdsTotal) - depositAmount - Number(this.depositAmountAfterUpdate) - this.totalAdvanceReceiptsAdjustedAmount;
-        // this.invFormData.voucherDetails.balanceDue = this.invFormData.voucherDetails.balanceDue + this.calculatedRoundOff - this.totalAdvanceReceiptsAdjustedAmount;
+        if (this.isUpdateMode && this.isInvoiceAdjustedWithAdvanceReceipts && !this.adjustPaymentData.totalAdjustedAmount) {
+            this.invFormData.voucherDetails.balanceDue =
+                ((count + this.invFormData.voucherDetails.tcsTotal + this.calculatedRoundOff) - this.invFormData.voucherDetails.tdsTotal) - Number(this.depositAmountAfterUpdate) - this.totalAdvanceReceiptsAdjustedAmount;
+        }
+
     }
 
     public calculateSubTotal() {
@@ -2241,6 +2258,9 @@ export class ProformaInvoiceComponent implements OnInit, OnDestroy, AfterViewIni
         if (item.value) {
             this.invFormData.voucherDetails.customerName = item.label;
             this.getAccountDetails(item.value);
+            if (this.invFormData.voucherDetails.customerUniquename && this.invFormData.voucherDetails.voucherDate) {
+                this.getAllAdvanceReceipts(this.invFormData.voucherDetails.customerUniquename, moment(this.invFormData.voucherDetails.voucherDate).format('DD-MM-YYYY'))
+            }
             this.isCustomerSelected = true;
             this.invFormData.accountDetails.name = '';
             if (item.additional) {
@@ -3617,6 +3637,9 @@ export class ProformaInvoiceComponent implements OnInit, OnDestroy, AfterViewIni
         if (this.isMultiCurrencyModule() && this.isMulticurrencyAccount && selectedDate && !moment(selectedDate).isSame(moment(modelDate))) {
             this.getCurrencyRate(this.companyCurrency, this.customerCurrencyCode, moment(selectedDate).format('DD-MM-YYYY'));
         }
+        if (selectedDate === modelDate && this.invFormData && this.invFormData.voucherDetails && this.invFormData.voucherDetails.voucherDate && this.invFormData.accountDetails && this.invFormData.accountDetails.uniqueName) {
+            this.getAllAdvanceReceipts(this.invFormData.voucherDetails.customerUniquename, moment(selectedDate).format('DD-MM-YYYY'));
+        }
     }
 
     /**
@@ -4284,7 +4307,9 @@ export class ProformaInvoiceComponent implements OnInit, OnDestroy, AfterViewIni
             this.isAdjustAmount = false;
             this.adjustPaymentBalanceDueData = 0;
             this.adjustPaymentData.totalAdjustedAmount = 0;
+            this.totalAdvanceReceiptsAdjustedAmount = 0;
             this.advanceReceiptAdjustmentData = null;
+            this.calculateBalanceDue();
         }
     }
 
@@ -4298,17 +4323,16 @@ export class ProformaInvoiceComponent implements OnInit, OnDestroy, AfterViewIni
 
         this.advanceReceiptAdjustmentData = advanceReceiptsAdjustEvent.adjustVoucherData;
         // this.invFormData.voucherDetails.balanceDue = advanceReceiptsAdjustEvent.adjustPaymentData.balanceDue;
-        this.adjustPaymentBalanceDueData = advanceReceiptsAdjustEvent.adjustPaymentData.grandTotal - advanceReceiptsAdjustEvent.adjustPaymentData.totalAdjustedAmount;
-
-        if (this.depositAmount) {
-            let deposit = cloneDeep(this.depositAmount);
-            this.adjustPaymentBalanceDueData = this.adjustPaymentBalanceDueData - deposit;
-        }
-        this.adjustPaymentBalanceDueData = this.adjustPaymentBalanceDueData + this.invFormData.voucherDetails.tcsTotal + this.invFormData.voucherDetails.tdsTotal;
         this.adjustPaymentData = advanceReceiptsAdjustEvent.adjustPaymentData;
+        if (this.adjustPaymentData.totalAdjustedAmount) {
+            this.isAdjustAmount = true;
+        } else {
+            this.isAdjustAmount = false;
+        }
         if (this.isUpdateMode) {
             this.calculateAdjustedVoucherTotal(advanceReceiptsAdjustEvent.adjustVoucherData.adjustments)
         }
+        this.adjustPaymentBalanceDueData = this.getCalculatedBalanceDueAfterAdvanceReceiptsAdjustment();
         this.closeAdvanceReceiptModal();
     }
 
@@ -4329,8 +4353,47 @@ export class ProformaInvoiceComponent implements OnInit, OnDestroy, AfterViewIni
                 });
             }
             this.totalAdvanceReceiptsAdjustedAmount = totalAmount;
+            this.adjustPaymentData.totalAdjustedAmount = this.totalAdvanceReceiptsAdjustedAmount;
+            if (this.adjustPaymentData.totalAdjustedAmount > 0) {
+                this.isAdjustAmount = true;
+            }
         } else {
             this.advanceReceiptAdjustmentData = null;
+        }
+    }
+
+    /**
+     * To calculate balance due amount after adjustment of advance receipts
+     *
+     * @returns {number} Balance due amount
+     * @memberof ProformaInvoiceComponent
+     */
+    public getCalculatedBalanceDueAfterAdvanceReceiptsAdjustment(): number {
+        return this.invFormData.voucherDetails.grandTotal - this.adjustPaymentData.totalAdjustedAmount - this.depositAmount + this.invFormData.voucherDetails.tcsTotal - this.invFormData.voucherDetails.tdsTotal
+    }
+
+    /**
+     * Call API to get all advance receipts of an invoice
+     *
+     * @param {*} customerUniquename Selected customer unique name
+     * @param {*} voucherDate  Voucher Date (DD-MM-YYYY) of selected invoice
+     * @memberof ProformaInvoiceComponent
+     */
+    public getAllAdvanceReceipts(customerUniquename, voucherDate): void {
+        if (customerUniquename && voucherDate) {
+            let requestObject = {
+                accountUniqueName: customerUniquename,
+                invoiceDate: voucherDate
+            };
+            this.salesService.getAllAdvanceReceiptVoucher(requestObject).subscribe(res => {
+                if (res && res.status === 'success') {
+                    if (res.body && res.body.length) {
+                        this.isAccountHaveAdvanceReceipts = true;
+                    } else {
+                        this.isAccountHaveAdvanceReceipts = false;
+                    }
+                }
+            })
         }
     }
 }

--- a/apps/web-giddh/src/app/proforma-invoice/proforma-invoice.component.ts
+++ b/apps/web-giddh/src/app/proforma-invoice/proforma-invoice.component.ts
@@ -4381,7 +4381,7 @@ export class ProformaInvoiceComponent implements OnInit, OnDestroy, AfterViewIni
      * @param {*} voucherDate  Voucher Date (DD-MM-YYYY) of selected invoice
      * @memberof ProformaInvoiceComponent
      */
-    public getAllAdvanceReceipts(customerUniqueName, voucherDate): void {
+    public getAllAdvanceReceipts(customerUniqueName: string, voucherDate: string): void {
         if (customerUniqueName && voucherDate) {
             let requestObject = {
                 accountUniqueName: customerUniqueName,

--- a/apps/web-giddh/src/app/proforma-invoice/proforma-invoice.component.ts
+++ b/apps/web-giddh/src/app/proforma-invoice/proforma-invoice.component.ts
@@ -4381,10 +4381,10 @@ export class ProformaInvoiceComponent implements OnInit, OnDestroy, AfterViewIni
      * @param {*} voucherDate  Voucher Date (DD-MM-YYYY) of selected invoice
      * @memberof ProformaInvoiceComponent
      */
-    public getAllAdvanceReceipts(customerUniquename, voucherDate): void {
-        if (customerUniquename && voucherDate) {
+    public getAllAdvanceReceipts(customerUniqueName, voucherDate): void {
+        if (customerUniqueName && voucherDate) {
             let requestObject = {
-                accountUniqueName: customerUniquename,
+                accountUniqueName: customerUniqueName,
                 invoiceDate: voucherDate
             };
             this.salesService.getAllAdvanceReceiptVoucher(requestObject).subscribe(res => {

--- a/apps/web-giddh/src/app/proforma-invoice/proforma-invoice.component.ts
+++ b/apps/web-giddh/src/app/proforma-invoice/proforma-invoice.component.ts
@@ -923,7 +923,7 @@ export class ProformaInvoiceComponent implements OnInit, OnDestroy, AfterViewIni
                         }
                     }
                     if (this.isSalesInvoice) {
-                        if (results[1] && results[1].advanceReceiptAdjustment && results[1].advanceReceiptAdjustment && results[1].advanceReceiptAdjustment.adjustments && results[1].advanceReceiptAdjustment.adjustments.length) {
+                        if (results[1] && results[1].advanceReceiptAdjustment && results[1].advanceReceiptAdjustment.adjustments && results[1].advanceReceiptAdjustment.adjustments.length) {
                             this.isInvoiceAdjustedWithAdvanceReceipts = true;
                             this.calculateAdjustedVoucherTotal(results[1].advanceReceiptAdjustment.adjustments);
                             this.advanceReceiptAdjustmentData = results[1].advanceReceiptAdjustment;
@@ -2259,7 +2259,7 @@ export class ProformaInvoiceComponent implements OnInit, OnDestroy, AfterViewIni
             this.invFormData.voucherDetails.customerName = item.label;
             this.getAccountDetails(item.value);
             if (this.invFormData.voucherDetails.customerUniquename && this.invFormData.voucherDetails.voucherDate) {
-                this.getAllAdvanceReceipts(this.invFormData.voucherDetails.customerUniquename, moment(this.invFormData.voucherDetails.voucherDate).format('DD-MM-YYYY'))
+                this.getAllAdvanceReceipts(this.invFormData.voucherDetails.customerUniquename, moment(this.invFormData.voucherDetails.voucherDate).format(GIDDH_DATE_FORMAT))
             }
             this.isCustomerSelected = true;
             this.invFormData.accountDetails.name = '';
@@ -3635,10 +3635,10 @@ export class ProformaInvoiceComponent implements OnInit, OnDestroy, AfterViewIni
      */
     public onVoucherDateChanged(selectedDate, modelDate) {
         if (this.isMultiCurrencyModule() && this.isMulticurrencyAccount && selectedDate && !moment(selectedDate).isSame(moment(modelDate))) {
-            this.getCurrencyRate(this.companyCurrency, this.customerCurrencyCode, moment(selectedDate).format('DD-MM-YYYY'));
+            this.getCurrencyRate(this.companyCurrency, this.customerCurrencyCode, moment(selectedDate).format(GIDDH_DATE_FORMAT));
         }
         if (selectedDate === modelDate && this.invFormData && this.invFormData.voucherDetails && this.invFormData.voucherDetails.voucherDate && this.invFormData.accountDetails && this.invFormData.accountDetails.uniqueName) {
-            this.getAllAdvanceReceipts(this.invFormData.voucherDetails.customerUniquename, moment(selectedDate).format('DD-MM-YYYY'));
+            this.getAllAdvanceReceipts(this.invFormData.voucherDetails.customerUniquename, moment(selectedDate).format(GIDDH_DATE_FORMAT));
         }
     }
 
@@ -3647,10 +3647,10 @@ export class ProformaInvoiceComponent implements OnInit, OnDestroy, AfterViewIni
      *
      * @param {*} to Converted to currency symbol
      * @param {*} from Converted from currency symbol
-     * @param {string} [date=moment().format('DD-MM-YYYY')] Date on which currency rate is required, default is today's date
+     * @param {string} [date=moment().format(GIDDH_DATE_FORMAT)] Date on which currency rate is required, default is today's date
      * @memberof ProformaInvoiceComponent
      */
-    public getCurrencyRate(to, from, date = moment().format('DD-MM-YYYY')): void {
+    public getCurrencyRate(to, from, date = moment().format(GIDDH_DATE_FORMAT)): void {
         if (from && to) {
             this._ledgerService.GetCurrencyRateNewApi(from, to, date).subscribe(response => {
                 let rate = response.body;
@@ -4356,6 +4356,8 @@ export class ProformaInvoiceComponent implements OnInit, OnDestroy, AfterViewIni
             this.adjustPaymentData.totalAdjustedAmount = this.totalAdvanceReceiptsAdjustedAmount;
             if (this.adjustPaymentData.totalAdjustedAmount > 0) {
                 this.isAdjustAmount = true;
+            } else {
+                this.isAdjustAmount = false;
             }
         } else {
             this.advanceReceiptAdjustmentData = null;
@@ -4394,6 +4396,8 @@ export class ProformaInvoiceComponent implements OnInit, OnDestroy, AfterViewIni
                     }
                 }
             })
+        } else {
+            this.isAccountHaveAdvanceReceipts = false;
         }
     }
 }

--- a/apps/web-giddh/src/app/shared/advance-receipt-adjustment/advance-receipt-adjustment.component.html
+++ b/apps/web-giddh/src/app/shared/advance-receipt-adjustment/advance-receipt-adjustment.component.html
@@ -18,10 +18,10 @@
                         <input type="text" class="form-control" name="customerName" [(ngModel)]="adjustPayment.customerName" readonly disabled>
                     </div>
                 </div>
-                <div class="col-md-3 text-right font-14 pt-2 xs-left" *ngIf="!isUpdateMode">
+                <div class="col-md-3 text-right font-14 pt-2 xs-left">
                     <p>Invoice Total: <i class="font-10"></i>{{invoiceFormDetails.accountDetails.currencySymbol}}{{adjustPayment?.grandTotal | giddhCurrency}}
                     </p>
-                    <p>Due <span class="text-light">(Post Adj):</span> <i class="font-10"></i> {{invoiceFormDetails.accountDetails.currencySymbol}} {{ adjustPayment.grandTotal - adjustPayment.totalAdjustedAmount - depositAmount + adjustPayment.tcsTotal +
+                    <p>Due <span class="text-light">(Post Adj):</span> <i class="font-10"></i> {{invoiceFormDetails.accountDetails.currencySymbol}} {{ adjustPayment.grandTotal - adjustPayment.totalAdjustedAmount - depositAmount + adjustPayment.tcsTotal -
                         adjustPayment.tdsTotal | giddhCurrency}}
                     </p>
                 </div>
@@ -32,9 +32,9 @@
                         <div class="col-sm-3">
                             <div class="form-group">
                                 <label for="name">Adjustment Voucher<span class="text-danger">*</span></label>
-                                <div [class.error-box]="entry.uniqueName === ''">
-                                    <sh-select class="text-left dropdown-arrow" name="uniqueName_{{entryIdx}}" [defaultValue]="entry.voucherNumber" (click)="clickSelectVoucher(entryIdx);" required [placeholder]="'Select Voucher'" [(ngModel)]="entry.uniqueName" (selected)="selectVoucher($event, entry, entryIdx);"
-                                        [options]="adjustVoucherOptions" [multiple]="false">
+                                <div [class.error-box]="entry.uniqueName === '' && adjustAdvancePaymentForm?.form.controls['voucherName'+entryIdx]?.touched">
+                                    <sh-select class="text-left dropdown-arrow" name="voucherName{{entryIdx}}" [defaultValue]="entry.voucherNumber" (click)="clickSelectVoucher(entryIdx, adjustAdvancePaymentForm);" required [placeholder]="'Select Voucher'" [(ngModel)]="entry.uniqueName"
+                                        (selected)="selectVoucher($event, entry, entryIdx);" [options]="adjustVoucherOptions" [multiple]="false">
                                         <ng-template #optionTemplate let-option="option">
                                             <a href="javascript:void(0)" class="list-item">
                                                 <div class="item">{{option.label}}</div>
@@ -57,8 +57,8 @@
                                         (Inclusive
                                         Tax){{invoiceFormDetails.accountDetails.currencySymbol}}</span></label>
                                 <!-- decimalDigitsDirective -->
-                                <input [class.error-box]="entry.dueAmount.amountForAccount === 0" required decimalDigitsDirective type="text" class="form-control" placeholder="Enter Amount" name="dueAmount.amountForAccount_{{entryIdx}}" [(ngModel)]="entry.dueAmount.amountForAccount"
-                                    (ngModelChange)="calculateTax(entry, entryIdx )" [prefix]="currencySymbol" [mask]="inputMaskFormat">
+                                <input [class.error-box]="entry.dueAmount.amountForAccount === 0 && adjustAdvancePaymentForm?.form.controls['amount'+entryIdx]?.touched" required decimalDigitsDirective type="text" class="form-control" placeholder="Enter Amount" name="amount{{entryIdx}}"
+                                    [(ngModel)]="entry.dueAmount.amountForAccount" (ngModelChange)="calculateTax(entry, entryIdx)" [prefix]="currencySymbol" [mask]="inputMaskFormat">
                             </div>
                         </div>
                         <div class="col-sm-3">
@@ -131,14 +131,14 @@
                             </div>
                         </div>
                     </ng-container>
-                    <span class="text-light" *ngIf="isUpdateMode">
+                    <span class="text-light" *ngIf="exceedDueAmount<0">
                         Excess amount:
-                        {{invoiceFormDetails.accountDetails.currencySymbol}}{{adjustPayment.totalAdjustedAmount- adjustPayment.grandTotal - depositAmount + adjustPayment.tcsTotal + adjustPayment.tdsTotal  | giddhCurrency}}
+                        {{invoiceFormDetails.accountDetails.currencySymbol}}{{-exceedDueAmount  | giddhCurrency}}
                     </span>
                     <div class="mt-4">
                         <button *ngIf="!isUpdateMode" type="button" class="btn btn-success mrR1" [disabled]="isInvalidForm" (click)="saveAdjustAdvanceReceipt()">Save</button>
                         <button *ngIf="isUpdateMode" type="button" class="btn btn-success mrR1" [disabled]="isInvalidForm" (click)="saveAdjustAdvanceReceipt()">Update</button>
-                        <button type="button" class="btn btn-cancel" (click)="onCancel()">Cancel</button>
+                        <button type="button" class="btn btn-cancel" (click)="onClear()">Cancel</button>
                     </div>
                 </div>
 

--- a/apps/web-giddh/src/app/shared/advance-receipt-adjustment/advance-receipt-adjustment.component.ts
+++ b/apps/web-giddh/src/app/shared/advance-receipt-adjustment/advance-receipt-adjustment.component.ts
@@ -147,7 +147,7 @@ export class AdvanceReceiptAdjustmentComponent implements OnInit {
      *
      * @memberof AdvanceReceiptAdjustmentComponent
      */
-    public onClear() {
+    public onClear(): void {
         this.adjustVoucherForm = {
             tdsTaxUniqueName: '',
             tdsAmount: {

--- a/apps/web-giddh/src/app/shared/advance-receipt-adjustment/advance-receipt-adjustment.component.ts
+++ b/apps/web-giddh/src/app/shared/advance-receipt-adjustment/advance-receipt-adjustment.component.ts
@@ -8,9 +8,7 @@ import { AppState } from '../../store';
 import { Store, select } from '@ngrx/store';
 import { takeUntil } from 'rxjs/operators';
 import { ReplaySubject } from 'rxjs';
-import { NgForOf } from '@angular/common';
 import { NgForm } from '@angular/forms';
-import { copyStyles } from '@angular/animations/browser/src/util';
 import { ToasterService } from '../../services/toaster.service';
 import { cloneDeep } from '../../lodash-optimized';
 
@@ -40,6 +38,9 @@ export class AdvanceReceiptAdjustmentComponent implements OnInit {
     public isInvalidForm: boolean = false;
     /** Message for toaster when due amount get negative  */
     public exceedDueErrorMessage: string = 'The adjusted amount of the linked invoice\'s is more than this receipt due amount';
+    /** Exceed Amount from invoice amount after adjustment */
+    public exceedDueAmount: number = 0;
+
 
 
 
@@ -85,26 +86,7 @@ export class AdvanceReceiptAdjustmentComponent implements OnInit {
      */
     public ngOnInit() {
         this.adjustVoucherForm = new AdvanceReceiptAdjustment();
-        this.adjustVoucherForm = {
-            tdsTaxUniqueName: '',
-            tdsAmount: {
-                amountForAccount: 0
-            },
-            description: '',
-            adjustments: [
-                {
-                    voucherNumber: '',
-                    dueAmount: {
-                        amountForAccount: 0,
-                        amountForCompany: 0
-                    },
-                    voucherDate: '',
-                    taxRate: 0,
-                    uniqueName: '',
-                    taxUniqueName: '',
-                }
-            ]
-        };
+        this.onClear();
         if (this.advanceReceiptAdjustmentUpdatedData) {
             this.adjustVoucherForm = this.advanceReceiptAdjustmentUpdatedData.adjustments.length ? this.advanceReceiptAdjustmentUpdatedData : this.adjustVoucherForm;
             if (this.advanceReceiptAdjustmentUpdatedData && this.advanceReceiptAdjustmentUpdatedData.adjustments && this.advanceReceiptAdjustmentUpdatedData.adjustments.length && this.advanceReceiptAdjustmentUpdatedData.tdsTaxUniqueName) {
@@ -158,6 +140,29 @@ export class AdvanceReceiptAdjustmentComponent implements OnInit {
         //     return;
         // }
         this.closeModelEvent.emit(true);
+    }
+
+    public onClear() {
+        this.adjustVoucherForm = {
+            tdsTaxUniqueName: '',
+            tdsAmount: {
+                amountForAccount: 0
+            },
+            description: '',
+            adjustments: [
+                {
+                    voucherNumber: '',
+                    dueAmount: {
+                        amountForAccount: 0,
+                        amountForCompany: 0
+                    },
+                    voucherDate: '',
+                    taxRate: 0,
+                    uniqueName: '',
+                    taxUniqueName: '',
+                }
+            ]
+        };
     }
 
     /**
@@ -367,7 +372,7 @@ export class AdvanceReceiptAdjustmentComponent implements OnInit {
             this.toaster.errorToast('The adjusted amount of the linked invoice\'s is more than this receipt');
             isValid = false;
         }
-        if (this.adjustVoucherForm && this.adjustVoucherForm.adjustments && this.adjustVoucherForm.adjustments.length) {
+        if (this.adjustVoucherForm && this.adjustVoucherForm.adjustments && this.adjustVoucherForm.adjustments.length>1) {
             this.adjustVoucherForm.adjustments.forEach(item => {
                 if (!item.voucherNumber) {
                     isValid = false;
@@ -376,7 +381,7 @@ export class AdvanceReceiptAdjustmentComponent implements OnInit {
                 }
             });
         }
-        if (isValid) {
+        if (isValid ) {
             this.submitClicked.emit({
                 adjustVoucherData: this.adjustVoucherForm,
                 adjustPaymentData: this.adjustPayment
@@ -404,7 +409,8 @@ export class AdvanceReceiptAdjustmentComponent implements OnInit {
      *
      * @memberof AdvanceReceiptAdjustmentComponent
      */
-    public clickSelectVoucher(index: number): void {
+    public clickSelectVoucher(index: number, form: NgForm): void {
+        form.controls[`voucherName${index}`].markAsTouched();
         this.adjustVoucherOptions = this.getAdvanceReceiptUnselectedVoucher();
         if (this.adjustVoucherForm.adjustments.length && this.adjustVoucherForm.adjustments[index] && this.adjustVoucherForm.adjustments[index].voucherNumber) {
             let selectedItem = this.newAdjustVoucherOptions.find(item => item.value === this.adjustVoucherForm.adjustments[index].uniqueName);
@@ -484,7 +490,8 @@ export class AdvanceReceiptAdjustmentComponent implements OnInit {
             });
             // this.adjustPayment.balanceDue = Number(this.adjustPayment.grandTotal.) - Number(totalAmount);
             this.adjustPayment.totalAdjustedAmount = Number(totalAmount);
-            if (this.getBalanceDue() < 0) {
+            this.exceedDueAmount = this.getBalanceDue();
+            if (this.exceedDueAmount < 0) {
                 this.isInvalidForm = true;
             } else {
                 this.isInvalidForm = false;
@@ -498,6 +505,6 @@ export class AdvanceReceiptAdjustmentComponent implements OnInit {
      * @memberof AdvanceReceiptAdjustmentComponent
      */
     public getBalanceDue(): number {
-            return this.adjustPayment.grandTotal - this.adjustPayment.totalAdjustedAmount - this.depositAmount + this.adjustPayment.tdsTotal + this.adjustPayment.tcsTotal;
-        }
+        return this.adjustPayment.grandTotal - this.adjustPayment.totalAdjustedAmount - this.depositAmount - this.adjustPayment.tdsTotal + this.adjustPayment.tcsTotal;
+    }
 }

--- a/apps/web-giddh/src/app/shared/advance-receipt-adjustment/advance-receipt-adjustment.component.ts
+++ b/apps/web-giddh/src/app/shared/advance-receipt-adjustment/advance-receipt-adjustment.component.ts
@@ -142,6 +142,11 @@ export class AdvanceReceiptAdjustmentComponent implements OnInit {
         this.closeModelEvent.emit(true);
     }
 
+    /**
+     * To clear advance receipt adjustment form
+     *
+     * @memberof AdvanceReceiptAdjustmentComponent
+     */
     public onClear() {
         this.adjustVoucherForm = {
             tdsTaxUniqueName: '',
@@ -372,7 +377,7 @@ export class AdvanceReceiptAdjustmentComponent implements OnInit {
             this.toaster.errorToast('The adjusted amount of the linked invoice\'s is more than this receipt');
             isValid = false;
         }
-        if (this.adjustVoucherForm && this.adjustVoucherForm.adjustments && this.adjustVoucherForm.adjustments.length>1) {
+        if (this.adjustVoucherForm && this.adjustVoucherForm.adjustments && this.adjustVoucherForm.adjustments.length > 1) {
             this.adjustVoucherForm.adjustments.forEach(item => {
                 if (!item.voucherNumber) {
                     isValid = false;
@@ -381,7 +386,7 @@ export class AdvanceReceiptAdjustmentComponent implements OnInit {
                 }
             });
         }
-        if (isValid ) {
+        if (isValid) {
             this.submitClicked.emit({
                 adjustVoucherData: this.adjustVoucherForm,
                 adjustPaymentData: this.adjustPayment


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
 in case of edit invoice we will show the deposit section and only the adjust amount button will display in that.
 If no advance receipt of any particular debtor is present then we will disable that button. As 
from the management page, we will provide both the action that is if the user wants to adjust the amount from here he can do that and also if he wants to update the adjusted amount he can also do that.
 When an invoice is adjusted multiple times with the same advance we will club that invoice and display a single time.


* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Other information**:
