### PR TITLE
fix: Make tax amount zero for future taxes in CREATE and UPDATE ledger

### DIFF
--- a/apps/web-giddh/src/app/ledger/components/updateLedger-tax-control/updateLedger-tax-control.component.ts
+++ b/apps/web-giddh/src/app/ledger/components/updateLedger-tax-control/updateLedger-tax-control.component.ts
@@ -20,6 +20,7 @@ import { INameUniqueName } from '../../../models/api-models/Inventory';
 import { ITaxDetail } from '../../../models/interfaces/tax.interface';
 import { giddhRoundOff } from '../../../shared/helpers/helperFunctions';
 import { TaxControlData } from '../../../theme/tax-control/tax-control.component';
+import { GIDDH_DATE_FORMAT } from '../../../shared/helpers/defaultDateFormat';
 
 export const TAX_CONTROL_VALUE_ACCESSOR: any = {
     provide: NG_VALUE_ACCESSOR,
@@ -131,7 +132,7 @@ export class UpdateLedgerTaxControlComponent implements OnInit, OnDestroy, OnCha
             if (index > -1) {
                 if (this.date && tax.taxDetail && tax.taxDetail.length) {
                     this.taxRenderData[index].amount =
-                        (moment(tax.taxDetail[0].date, 'DD-MM-YYYY').isSame(moment(this.date, 'DD-MM-YYYY')) || moment(tax.taxDetail[0].date, 'DD-MM-YYYY') < moment(this.date, 'DD-MM-YYYY')) ?
+                        (moment(tax.taxDetail[0].date, GIDDH_DATE_FORMAT).isSame(moment(this.date, GIDDH_DATE_FORMAT)) || moment(tax.taxDetail[0].date, GIDDH_DATE_FORMAT) < moment(this.date, GIDDH_DATE_FORMAT)) ?
                             tax.taxDetail[0].taxValue : 0;
                 }
             } else {
@@ -141,13 +142,13 @@ export class UpdateLedgerTaxControlComponent implements OnInit, OnDestroy, OnCha
                 taxObj.uniqueName = tax.uniqueName;
                 if (this.date) {
                     let taxObject = _.orderBy(tax.taxDetail, (p: ITaxDetail) => {
-                        return moment(p.date, 'DD-MM-YYYY');
+                        return moment(p.date, GIDDH_DATE_FORMAT);
                     }, 'desc');
-                    let exactDate = taxObject.filter(p => moment(p.date, 'DD-MM-YYYY').isSame(moment(this.date, 'DD-MM-YYYY')));
+                    let exactDate = taxObject.filter(p => moment(p.date, GIDDH_DATE_FORMAT).isSame(moment(this.date, GIDDH_DATE_FORMAT)));
                     if (exactDate.length > 0) {
                         taxObj.amount = exactDate[0].taxValue;
                     } else {
-                        let filteredTaxObject = taxObject.filter(p => moment(p.date, 'DD-MM-YYYY') < moment(this.date, 'DD-MM-YYYY'));
+                        let filteredTaxObject = taxObject.filter(p => moment(p.date, GIDDH_DATE_FORMAT) < moment(this.date, GIDDH_DATE_FORMAT));
                         if (filteredTaxObject.length > 0) {
                             taxObj.amount = filteredTaxObject[0].taxValue;
                         } else {

--- a/apps/web-giddh/src/app/ledger/components/updateLedger-tax-control/updateLedger-tax-control.component.ts
+++ b/apps/web-giddh/src/app/ledger/components/updateLedger-tax-control/updateLedger-tax-control.component.ts
@@ -114,9 +114,9 @@ export class UpdateLedgerTaxControlComponent implements OnInit, OnDestroy, OnCha
      */
     public prepareTaxObject() {
         // if updating don't recalculate
-        if (this.taxRenderData.length) {
-            return;
-        }
+        // if (this.taxRenderData.length) {
+        //     return;
+        // }
 
         if (this.customTaxTypesForTaxFilter && this.customTaxTypesForTaxFilter.length) {
             this.taxes = this.taxes.filter(f => this.customTaxTypesForTaxFilter.includes(f.taxType));
@@ -125,34 +125,43 @@ export class UpdateLedgerTaxControlComponent implements OnInit, OnDestroy, OnCha
         if (this.exceptTaxTypes && this.exceptTaxTypes.length) {
             this.taxes = this.taxes.filter(f => !this.exceptTaxTypes.includes(f.taxType));
         }
-
-        this.taxes.map(tx => {
-            let taxObj = new TaxControlData();
-            taxObj.name = tx.name;
-            taxObj.type = tx.taxType;
-            taxObj.uniqueName = tx.uniqueName;
-            if (this.date) {
-                let taxObject = _.orderBy(tx.taxDetail, (p: ITaxDetail) => {
-                    return moment(p.date, 'DD-MM-YYYY');
-                }, 'desc');
-                let exactDate = taxObject.filter(p => moment(p.date, 'DD-MM-YYYY').isSame(moment(this.date, 'DD-MM-YYYY')));
-                if (exactDate.length > 0) {
-                    taxObj.amount = exactDate[0].taxValue;
-                } else {
-                    let filteredTaxObject = taxObject.filter(p => moment(p.date, 'DD-MM-YYYY') < moment(this.date, 'DD-MM-YYYY'));
-                    if (filteredTaxObject.length > 0) {
-                        taxObj.amount = filteredTaxObject[0].taxValue;
-                    } else {
-                        taxObj.amount = 0;
-                    }
+        this.taxes.map(tax => {
+            const index = this.taxRenderData.findIndex(f => f.uniqueName === tax.uniqueName);
+            // if tax is already prepared then only check if it's checked or not on basis of applicable taxes
+            if (index > -1) {
+                if (this.date && tax.taxDetail && tax.taxDetail.length) {
+                    this.taxRenderData[index].amount =
+                        (moment(tax.taxDetail[0].date, 'DD-MM-YYYY').isSame(moment(this.date, 'DD-MM-YYYY')) || moment(tax.taxDetail[0].date, 'DD-MM-YYYY') < moment(this.date, 'DD-MM-YYYY')) ?
+                            tax.taxDetail[0].taxValue : 0;
                 }
             } else {
-                taxObj.amount = tx.taxDetail[0].taxValue;
+                let taxObj = new TaxControlData();
+                taxObj.name = tax.name;
+                taxObj.type = tax.taxType;
+                taxObj.uniqueName = tax.uniqueName;
+                if (this.date) {
+                    let taxObject = _.orderBy(tax.taxDetail, (p: ITaxDetail) => {
+                        return moment(p.date, 'DD-MM-YYYY');
+                    }, 'desc');
+                    let exactDate = taxObject.filter(p => moment(p.date, 'DD-MM-YYYY').isSame(moment(this.date, 'DD-MM-YYYY')));
+                    if (exactDate.length > 0) {
+                        taxObj.amount = exactDate[0].taxValue;
+                    } else {
+                        let filteredTaxObject = taxObject.filter(p => moment(p.date, 'DD-MM-YYYY') < moment(this.date, 'DD-MM-YYYY'));
+                        if (filteredTaxObject.length > 0) {
+                            taxObj.amount = filteredTaxObject[0].taxValue;
+                        } else {
+                            taxObj.amount = 0;
+                        }
+                    }
+                } else {
+                    taxObj.amount = tax.taxDetail[0].taxValue;
+                }
+                taxObj.isChecked = (this.applicableTaxes && (this.applicableTaxes.indexOf(tax.uniqueName) > -1));
+                // if (taxObj.amount && taxObj.amount > 0) {
+                this.taxRenderData.push(taxObj);
+                // }
             }
-            taxObj.isChecked = (this.applicableTaxes && (this.applicableTaxes.indexOf(tx.uniqueName) > -1));
-            // if (taxObj.amount && taxObj.amount > 0) {
-            this.taxRenderData.push(taxObj);
-            // }
         });
     }
 

--- a/apps/web-giddh/src/app/theme/tax-control/tax-control.component.ts
+++ b/apps/web-giddh/src/app/theme/tax-control/tax-control.component.ts
@@ -109,9 +109,7 @@ export class TaxControlComponent implements OnInit, OnDestroy, OnChanges {
         if ('date' in changes && changes.date.currentValue !== changes.date.previousValue) {
             if (moment(changes['date'].currentValue, 'DD-MM-YYYY').isValid()) {
                 this.taxSum = 0;
-                if (changes.date.firstChange) {
-                    this.prepareTaxObject();
-                }
+                this.prepareTaxObject();
                 this.change();
             }
         }
@@ -154,7 +152,14 @@ export class TaxControlComponent implements OnInit, OnDestroy, OnChanges {
 
             // if tax is already prepared then only check if it's checked or not on basis of applicable taxes
             if (index > -1) {
-                   this.taxRenderData[index].isChecked = this.applicableTaxes && this.applicableTaxes.length ? this.applicableTaxes.some(item => item === tax.uniqueName) : false;
+                this.taxRenderData[index].isChecked =
+                    this.applicableTaxes && this.applicableTaxes.length ? this.applicableTaxes.some(item => item === tax.uniqueName) :
+                        this.taxRenderData[index].isChecked ? this.taxRenderData[index].isChecked : false;
+                if (this.date && tax.taxDetail && tax.taxDetail.length) {
+                    this.taxRenderData[index].amount =
+                        (moment(tax.taxDetail[0].date, 'DD-MM-YYYY').isSame(moment(this.date, 'DD-MM-YYYY')) || moment(tax.taxDetail[0].date, 'DD-MM-YYYY') < moment(this.date, 'DD-MM-YYYY')) ?
+                        tax.taxDetail[0].taxValue : 0;
+                }
             } else {
 
                 let taxObj = new TaxControlData();

--- a/apps/web-giddh/src/app/theme/tax-control/tax-control.component.ts
+++ b/apps/web-giddh/src/app/theme/tax-control/tax-control.component.ts
@@ -23,6 +23,7 @@ import { TaxResponse } from '../../models/api-models/Company';
 import { ITaxDetail } from '../../models/interfaces/tax.interface';
 import { giddhRoundOff } from '../../shared/helpers/helperFunctions';
 import { AppState } from '../../store';
+import { GIDDH_DATE_FORMAT } from '../../shared/helpers/defaultDateFormat';
 
 export const TAX_CONTROL_VALUE_ACCESSOR: any = {
     provide: NG_VALUE_ACCESSOR,
@@ -157,7 +158,7 @@ export class TaxControlComponent implements OnInit, OnDestroy, OnChanges {
                         this.taxRenderData[index].isChecked ? this.taxRenderData[index].isChecked : false;
                 if (this.date && tax.taxDetail && tax.taxDetail.length) {
                     this.taxRenderData[index].amount =
-                        (moment(tax.taxDetail[0].date, 'DD-MM-YYYY').isSame(moment(this.date, 'DD-MM-YYYY')) || moment(tax.taxDetail[0].date, 'DD-MM-YYYY') < moment(this.date, 'DD-MM-YYYY')) ?
+                        (moment(tax.taxDetail[0].date, GIDDH_DATE_FORMAT).isSame(moment(this.date, GIDDH_DATE_FORMAT)) || moment(tax.taxDetail[0].date, GIDDH_DATE_FORMAT) < moment(this.date, GIDDH_DATE_FORMAT)) ?
                         tax.taxDetail[0].taxValue : 0;
                 }
             } else {
@@ -169,13 +170,13 @@ export class TaxControlComponent implements OnInit, OnDestroy, OnChanges {
 
                 if (this.date) {
                     let taxObject = _.orderBy(tax.taxDetail, (p: ITaxDetail) => {
-                        return moment(p.date, 'DD-MM-YYYY');
+                        return moment(p.date, GIDDH_DATE_FORMAT);
                     }, 'desc');
-                    let exactDate = taxObject.filter(p => moment(p.date, 'DD-MM-YYYY').isSame(moment(this.date, 'DD-MM-YYYY')));
+                    let exactDate = taxObject.filter(p => moment(p.date, GIDDH_DATE_FORMAT).isSame(moment(this.date, GIDDH_DATE_FORMAT)));
                     if (exactDate.length > 0) {
                         taxObj.amount = exactDate[0].taxValue;
                     } else {
-                        let filteredTaxObject = taxObject.filter(p => moment(p.date, 'DD-MM-YYYY') < moment(this.date, 'DD-MM-YYYY'));
+                        let filteredTaxObject = taxObject.filter(p => moment(p.date, GIDDH_DATE_FORMAT) < moment(this.date, GIDDH_DATE_FORMAT));
                         if (filteredTaxObject.length > 0) {
                             taxObj.amount = filteredTaxObject[0].taxValue;
                         } else {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Make tax amount zero for future taxes in CREATE and UPDATE ledger


* **What is the current behavior?** (You can also link to an open issue here)
Currently the tax amount is calculated only during instantiation and not when user changes the entry date


* **What is the new behavior (if this is a feature change)?**
Tax will be calculated on ledger CREATE and UPDATE flow and future taxes will have amount set to 0 if entry date is changed to a past date and is less than tax date


* **Other information**:
