### PR TITLE
G0-5462 | fix: VAT report is not working, nothing happens on selecting any filter

### DIFF
--- a/apps/web-giddh/src/app/vat-report/vatReport.component.html
+++ b/apps/web-giddh/src/app/vat-report/vatReport.component.html
@@ -168,7 +168,10 @@
                                         </table>
                                     </div>
                                 </div>
-                            </div>
+							</div>
+							<div *ngIf="!vatReport?.length" class="no-data no-report">
+								<h1>To see the VAT report for this company, please provide a TRN in its profile section.</h1>
+							</div>
                         </tab>
                     </tabset>
                 </div>

--- a/apps/web-giddh/src/app/vat-report/vatReport.component.scss
+++ b/apps/web-giddh/src/app/vat-report/vatReport.component.scss
@@ -55,6 +55,11 @@
     width: 280px;
 }
 
+.no-report {
+    margin: 100px auto;
+    align-items: center;
+}
+
 @media only screen and (max-width: 767px) {
     .navbar_header.mb-2 {
         margin-top: 60px;


### PR DESCRIPTION

![localhost_3000_pages_vat-report](https://user-images.githubusercontent.com/57517770/78666279-beffa600-78f4-11ea-9b89-f45915272955.png)
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Show a default message when TRN is not provided in Settings Profile


* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Other information**:
