### PR TITLE
PROD: G0-5478 | fix: Save button gets disabled on moving the cursor in GSTIN field on Create Account page for Sundry Debtor/Sundry Creditor

### DIFF
--- a/apps/web-giddh/src/app/shared/header/components/account-add-new-details/account-add-new-details.component.ts
+++ b/apps/web-giddh/src/app/shared/header/components/account-add-new-details/account-add-new-details.component.ts
@@ -439,18 +439,15 @@ export class AccountAddNewDetailsComponent implements OnInit, OnChanges, AfterVi
                 this.statesSource$.pipe(take(1)).subscribe(state => {
                     let stateCode = this.stateGstCode[gstVal.substr(0, 2)];
 
-                    let s = state.find(st => st.value === stateCode);
-                    // statesEle.setDisabledState(false);
-                    if (s) {
-                        gstForm.get('stateCode').patchValue(s.value);
-                        gstForm.get('state').get('code').patchValue(s.value);
-                        // statesEle.setDisabledState(true);
+                    let currentState = state.find(st => st.value === stateCode);
+                    if (currentState) {
+                        gstForm.get('stateCode').patchValue(currentState.value);
+                        gstForm.get('state').get('code').patchValue(currentState.value);
                     } else {
                         if (this.isIndia) {
                             gstForm.get('stateCode').patchValue(null);
                             gstForm.get('state').get('code').patchValue(null);
                         }
-                        // statesEle.setDisabledState(false);
                         this._toaster.clearAllToaster();
                         if (this.formFields['taxName']) {
                             this._toaster.errorToast(`Invalid ${this.formFields['taxName'].label}`);

--- a/apps/web-giddh/src/app/shared/header/components/account-add-new-details/account-add-new-details.component.ts
+++ b/apps/web-giddh/src/app/shared/header/components/account-add-new-details/account-add-new-details.component.ts
@@ -430,37 +430,39 @@ export class AccountAddNewDetailsComponent implements OnInit, OnChanges, AfterVi
     public getStateCode(gstForm: FormGroup, statesEle: ShSelectComponent) {
         let gstVal: string = gstForm.get('gstNumber').value;
 
-        if (gstVal.length !== 15) {
-            gstForm.get('partyType').reset('NOT APPLICABLE');
-        }
+        if (gstVal.length) {
+            if (gstVal.length !== 15) {
+                gstForm.get('partyType').reset('NOT APPLICABLE');
+            }
 
-        if (gstVal.length >= 2) {
-            this.statesSource$.pipe(take(1)).subscribe(state => {
-                let stateCode = this.stateGstCode[gstVal.substr(0, 2)];
+            if (gstVal.length >= 2) {
+                this.statesSource$.pipe(take(1)).subscribe(state => {
+                    let stateCode = this.stateGstCode[gstVal.substr(0, 2)];
 
-                let s = state.find(st => st.value === stateCode);
-                // statesEle.setDisabledState(false);
-                if (s) {
-                    gstForm.get('stateCode').patchValue(s.value);
-                    gstForm.get('state').get('code').patchValue(s.value);
-                    // statesEle.setDisabledState(true);
-                } else {
-                    if (this.isIndia) {
-                        gstForm.get('stateCode').patchValue(null);
-                        gstForm.get('state').get('code').patchValue(null);
-                    }
+                    let s = state.find(st => st.value === stateCode);
                     // statesEle.setDisabledState(false);
-                    this._toaster.clearAllToaster();
-                    if (this.formFields['taxName']) {
-                        this._toaster.errorToast(`Invalid ${this.formFields['taxName'].label}`);
+                    if (s) {
+                        gstForm.get('stateCode').patchValue(s.value);
+                        gstForm.get('state').get('code').patchValue(s.value);
+                        // statesEle.setDisabledState(true);
+                    } else {
+                        if (this.isIndia) {
+                            gstForm.get('stateCode').patchValue(null);
+                            gstForm.get('state').get('code').patchValue(null);
+                        }
+                        // statesEle.setDisabledState(false);
+                        this._toaster.clearAllToaster();
+                        if (this.formFields['taxName']) {
+                            this._toaster.errorToast(`Invalid ${this.formFields['taxName'].label}`);
+                        }
                     }
+                });
+            } else {
+                // statesEle.setDisabledState(false);
+                if (this.isIndia) {
+                    gstForm.get('stateCode').patchValue(null);
+                    gstForm.get('state').get('code').patchValue(null);
                 }
-            });
-        } else {
-            // statesEle.setDisabledState(false);
-            if (this.isIndia) {
-                gstForm.get('stateCode').patchValue(null);
-                gstForm.get('state').get('code').patchValue(null);
             }
         }
     }

--- a/apps/web-giddh/src/app/shared/header/components/account-update-new-details/account-update-new-details.component.ts
+++ b/apps/web-giddh/src/app/shared/header/components/account-update-new-details/account-update-new-details.component.ts
@@ -707,38 +707,37 @@ export class AccountUpdateNewDetailsComponent implements OnInit, OnDestroy, OnCh
     public getStateCode(gstForm: FormGroup, statesEle: ShSelectComponent) {
         let gstVal: string = gstForm.get('gstNumber').value;
 
-        if (gstVal.length !== 15) {
-            gstForm.get('partyType').reset('NOT APPLICABLE');
-        }
-
-        if (gstVal.length >= 2) {
-            this.statesSource$.pipe(take(1)).subscribe(state => {
-                let stateCode = this.stateGstCode[gstVal.substr(0, 2)];
-
-                let s = state.find(st => st.value === stateCode);
-                if (s) {
-                    gstForm.get('stateCode').patchValue(s.value);
-                    gstForm.get('state').get('code').patchValue(s.value);
-
-                } else {
-                    if (this.isIndia) {
-                        gstForm.get('stateCode').patchValue(null);
-                        gstForm.get('state').get('code').patchValue(null);
-                    }
-                    this._toaster.clearAllToaster();
-                    if (this.formFields['taxName']) {
-                        this._toaster.errorToast(`Invalid ${this.formFields['taxName'].label}`);
-                    }
-                }
-            });
-        } else {
-            // statesEle.setDisabledState(false);
-            if (this.isIndia) {
-                gstForm.get('stateCode').patchValue(null);
-                gstForm.get('state').get('code').patchValue(null);
+        if (gstVal.length) {
+            if (gstVal.length !== 15) {
+                gstForm.get('partyType').reset('NOT APPLICABLE');
             }
 
+            if (gstVal.length >= 2) {
+                this.statesSource$.pipe(take(1)).subscribe(state => {
+                    let stateCode = this.stateGstCode[gstVal.substr(0, 2)];
 
+                    let currentState = state.find(st => st.value === stateCode);
+                    if (currentState) {
+                        gstForm.get('stateCode').patchValue(currentState.value);
+                        gstForm.get('state').get('code').patchValue(currentState.value);
+
+                    } else {
+                        if (this.isIndia) {
+                            gstForm.get('stateCode').patchValue(null);
+                            gstForm.get('state').get('code').patchValue(null);
+                        }
+                        this._toaster.clearAllToaster();
+                        if (this.formFields['taxName']) {
+                            this._toaster.errorToast(`Invalid ${this.formFields['taxName'].label}`);
+                        }
+                    }
+                });
+            } else {
+                if (this.isIndia) {
+                    gstForm.get('stateCode').patchValue(null);
+                    gstForm.get('state').get('code').patchValue(null);
+                }
+            }
         }
     }
 

--- a/apps/web-giddh/src/app/theme/ng-virtual-select/sh-select.component.ts
+++ b/apps/web-giddh/src/app/theme/ng-virtual-select/sh-select.component.ts
@@ -93,6 +93,7 @@ export class ShSelectComponent implements ControlValueAccessor, OnInit, AfterVie
     @Input() set options(val: IOption[]) {
         this._options = val;
         this.updateRows(val);
+        this.selectedValues = [this.filter];
     }
 
     get selectedValues(): any[] {


### PR DESCRIPTION

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
It checks for GST length if it is 0 then no checks are applied as the issue occurs when GST length is neither equal to 15 nor greater than 2 and country is India then state code is set to null which invalidates the form and hence the issue


* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Other information**:
