### PR TITLE
Fixed G0-6661 | Prod- After login message is displayed please wait

### DIFF
--- a/apps/web-giddh/src/app/actions/login.action.ts
+++ b/apps/web-giddh/src/app/actions/login.action.ts
@@ -275,10 +275,10 @@ export class LoginActions {
     public loginSuccess$: Observable<Action> = this.actions$
         .ofType(LoginActions.LoginSuccess).pipe(
             switchMap((action) => {
-                console.log("YES");
+                console.log("Login Init");
                 return observableZip(this._companyService.getStateDetails(''), this._companyService.CompanyList(), this._companyService.CurrencyList());
             }), map((results: any[]) => {
-                console.log("YES2");
+                console.log("Login Success");
                 /* check if local storage is cleared or not for first time
                  for application menu set up in localstorage */
 
@@ -1054,13 +1054,17 @@ export class LoginActions {
         // now take first company from the companies
         let cArr = companies.body.sort((a, b) => a.name.length - b.name.length);
         let company = cArr[0];
-        respState.body.companyUniqueName = company.uniqueName;
+        if(company) {
+            respState.body.companyUniqueName = company.uniqueName;
+        } else {
+            respState.body.companyUniqueName = "";
+        }
         respState.status = 'success';
         respState.request = '';
         respState.body.lastState = 'home';
         // check for entity and override last state ['GROUP', 'ACCOUNT']
         try {
-            if (company.userEntityRoles && company.userEntityRoles.length) {
+            if (company && company.userEntityRoles && company.userEntityRoles.length) {
                 // find sorted userEntityRoles
                 let entitiesArr = company.userEntityRoles.sort((a, b) => a.entity.name.length - b.entity.name.length);
                 let entityObj = entitiesArr[0].entity;
@@ -1072,6 +1076,8 @@ export class LoginActions {
                 } else {
                     respState.body.lastState = 'home';
                 }
+            } else {
+                respState.body.lastState = 'home';
             }
         } catch (error) {
             respState.body.lastState = 'home';


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fixed G0-6661 | Prod- After login message is displayed please wait


* **What is the current behavior?** (You can also link to an open issue here)
{
 "user_agent": "Mozilla/5.0 (Windows NT 6.1; ) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.129 Safari/537.36",
 "user": "Name: Madhur N. Agrawal Email: madhurna@govpro.in Company Uniquename: ",
 "page": "/token-verify?token=ya29.a0Ae4lvC0vdJx1zMRxWCgDYf9XMY-ahQiMWOmo3P2svfxFIOmhVqDfVSJ2e6dmwlN8iH4_5_xdWNM1V1LnwWbnmjq08zwraAoZ6CiLCNaZPN_gp5nluyZ0K5lWRWWG-s9wizJ0U7j4tF7F0-ilG9j16ANzjx0VfYwQKiQ",
 "error": "TypeError: Cannot read property 'uniqueName' of undefined\n    at e.doSameStuffs (https://app.giddh.com/main.15b6e39a0045fc651d89.js:1:20407)\n    at t.project (https://app.giddh.com/main.15b6e39a0045fc651d89.js:1:6954)\n    at t._next (https://app.giddh.com/main.15b6e39a0045fc651d89.js:1:1213565)\n    at t.next (https://app.giddh.com/main.15b6e39a0045fc651d89.js:1:657909)\n    at t.notifyNext (https://app.giddh.com/main.15b6e39a0045fc651d89.js:1:551385)\n    at t._next (https://app.giddh.com/main.15b6e39a0045fc651d89.js:1:593740)\n    at t.next (https://app.giddh.com/main.15b6e39a0045fc651d89.js:1:657909)\n    at t.checkIterators (https://app.giddh.com/main.15b6e39a0045fc651d89.js:1:828984)\n    at t.notifyNext (https://app.giddh.com/main.15b6e39a0045fc651d89.js:1:830579)\n    at t._next (https://app.giddh.com/main.15b6e39a0045fc651d89.js:1:593740)",
 "env": "PROD"
}