### PR TITLE
fix: GIDK-#2ne6a4 | Prateek | Test | Prod - Shipping address field should be enable by default on sales/cash invoice creation page

### DIFF
--- a/apps/web-giddh/src/app/proforma-invoice/proforma-invoice.component.html
+++ b/apps/web-giddh/src/app/proforma-invoice/proforma-invoice.component.html
@@ -315,9 +315,9 @@
                                                             <div class="form-group p-0 width-100">
                                                                 <div class="d-flex align-items-center pb-1">
                                                                     <span class="pb-0 pd-r15">
-                                                                        <input type="checkbox" autocomplete="None"
+                                                                        <input type="checkbox"
                                                                             (change)="autoFillShippingDetails()"
-                                                                            name="autoFillShipping"
+                                                                            name="autoFillShipping" [ngModelOptions]="{standalone: true}"
                                                                             [(ngModel)]="autoFillShipping"> {{localeData?.shipping_billing_same}}
                                                                     </span>
                                                                     <span>


### PR DESCRIPTION
…

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
https://app.clickup.com/t/2ne6a4


* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Other information**:
