### PR TITLE
Ravinder | Test | On Petty cash landing page, when clicking on “Approve” the expense category is by default selected as “Others”. It shows error on approving it. I should have the change the expense account outside itself, via popup. To quicken the approval process.

### DIFF
--- a/apps/web-giddh/src/app/expenses/components/approve-petty-cash-entry-confirm-dialog/approve-petty-cash-entry-confirm-dialog.component.ts
+++ b/apps/web-giddh/src/app/expenses/components/approve-petty-cash-entry-confirm-dialog/approve-petty-cash-entry-confirm-dialog.component.ts
@@ -99,6 +99,7 @@ export class ApprovePettyCashEntryConfirmDialogComponent implements OnInit {
      */
     public ngOnInit(): void {
         if (this.showCategoryOption) {
+            this.selectedEntryForApprove.particular = this.selectedEntryForApprove.baseAccount;
             this.prepareEntryAgainstObject(this.selectedEntryForApprove);
         }
         this.buildCreatorString();


### PR DESCRIPTION
https://app.clickup.com/t/6mxecu