### PR TITLE
Ankit | TEST  | Prod - Authenticate button on GSTR2 and connect HMRC button on VAT report page is not disable even when plan has tax filing restriction

### DIFF
--- a/apps/web-giddh/src/app/gst/filing/header/filing-header.component.html
+++ b/apps/web-giddh/src/app/gst/filing/header/filing-header.component.html
@@ -88,45 +88,53 @@
                 <div class="font-xs text-middle normal">{{ localeData?.inward_supplies_details }}</div>
             </div>
         </div>
-        <div class="d-flex column-gap1 align-items-center">
-            <div class="d-inline-flex align-items-center column-gap1">
-                <watch-video [cssClass]="'text-primary pd-r15'" [moduleName]="'GSTR2'"></watch-video>
-                <button
-                    mat-stroked-button
-                    color="primary"
-                    aria-labelledby="button-triggers-manual"
-                    [matMenuTriggerFor]="downloadMenu"
-                >
-                    <i class="icon-download"></i>
-                    {{ commonLocaleData?.app_download }}
-                </button>
-                <mat-menu #downloadMenu="matMenu">
-                    <button mat-menu-item aria-label="download"  (click)="onDownloadSheetGSTR('main')">
-                        {{ localeData?.filing?.download_sheet }}
+        <div class="d-flex flex-column">
+            <div class="d-flex column-gap1 justify-content-end align-items-center">
+                <div class="d-inline-flex align-items-center column-gap1">
+                    <watch-video [cssClass]="'text-primary pd-r15'" [moduleName]="'GSTR2'"></watch-video>
+                    <button
+                        mat-stroked-button
+                        color="primary"
+                        aria-labelledby="button-triggers-manual"
+                        [matMenuTriggerFor]="downloadMenu"
+                    >
+                        <i class="icon-download"></i>
+                        {{ commonLocaleData?.app_download }}
                     </button>
-                    <button mat-menu-item aria-label="download" (click)="onDownloadSheetGSTR('error')">
-                        {{ localeData?.filing?.download_error_sheet }}
+                    <mat-menu #downloadMenu="matMenu">
+                        <button mat-menu-item aria-label="download"  (click)="onDownloadSheetGSTR('main')">
+                            {{ localeData?.filing?.download_sheet }}
+                        </button>
+                        <button mat-menu-item aria-label="download" (click)="onDownloadSheetGSTR('error')">
+                            {{ localeData?.filing?.download_error_sheet }}
+                        </button>
+                    </mat-menu>
+                </div>
+                <div *ngIf="(isCompany || isConsolidatedBranch) && showGstFiling" class="d-inline-flex column-gap1 align-items-center">
+                    <button
+                        mat-stroked-button
+                        color="primary"
+                        [ngClass]="{ 'btn-success': gstAuthenticated }"
+                        (click)="!gstAuthenticated ? openSettingAsidePane($event, taxServiceEnum.TAXPRO) : ''"
+                        [disabled]="(activeCompany$ | async)?.subscription?.planDetails?.restrictedModules.hasOwnProperty(restrictedModules.TaxFilling)"               
+                    >
+                        {{ gstAuthenticated ? localeData?.filing?.authenticated : localeData?.filing?.authenticate }}
                     </button>
-                </mat-menu>
+                    <button
+                        mat-stroked-button
+                        color="primary"
+                        [disabled]="!gstAuthenticated"
+                        (click)="pullFromGstIn($event)"
+                        *ngIf="showTaxPro"
+                    >
+                        {{ localeData?.filing?.pull_from_gstn }}
+                    </button>
+                </div>
             </div>
-            <div *ngIf="(isCompany || isConsolidatedBranch) && showGstFiling" class="d-inline-flex column-gap1 align-items-center">
-                <button
-                    mat-stroked-button
-                    color="primary"
-                    [ngClass]="{ 'btn-success': gstAuthenticated }"
-                    (click)="!gstAuthenticated ? openSettingAsidePane($event, taxServiceEnum.TAXPRO) : ''"               
-                >
-                    {{ gstAuthenticated ? localeData?.filing?.authenticated : localeData?.filing?.authenticate }}
-                </button>
-                <button
-                    mat-stroked-button
-                    color="primary"
-                    [disabled]="!gstAuthenticated"
-                    (click)="pullFromGstIn($event)"
-                    *ngIf="showTaxPro"
-                >
-                    {{ localeData?.filing?.pull_from_gstn }}
-                </button>
+            <div class="d-flex justify-content-end filling-header-message">
+                <restricted-module-message [restrictedModule]="restrictedModules.TaxFilling"
+                    (onUpgradePlan)="buyPlan($event)">
+                </restricted-module-message>
             </div>
         </div>
     </div>

--- a/apps/web-giddh/src/app/vat-report/obligations/obligations.component.html
+++ b/apps/web-giddh/src/app/vat-report/obligations/obligations.component.html
@@ -101,12 +101,17 @@
                     </table>
                     <section *ngIf="!tableDataSource?.length">
                         <div *ngIf="getFormControl('taxNumber').value">
-                            <div *ngIf="connectToHMRCUrl" class="position-center position-absolute">
-                                <a mat-stroked-button color="primary" [href]="connectToHMRCUrl">
-                                    {{ localeData?.connect_to_hmrc }}
-                                </a>
+                            <div *ngIf="connectToHMRCUrl || activeCompany?.subscription?.planDetails?.restrictedModules.hasOwnProperty(restrictedModules.TaxFilling)" class="position-center position-absolute">
+                                <div class="text-center">
+                                    <a [disabled]="activeCompany?.subscription?.planDetails?.restrictedModules.hasOwnProperty(restrictedModules.TaxFilling)" mat-stroked-button color="primary" [href]="connectToHMRCUrl">
+                                        {{ localeData?.connect_to_hmrc }}
+                                    </a>
+                                </div>
+                                <restricted-module-message [restrictedModule]="restrictedModules.TaxFilling"
+                                    (onUpgradePlan)="buyPlan($event)">
+                                </restricted-module-message>
                             </div>
-                            <div class="no-data"  *ngIf="!connectToHMRCUrl">
+                            <div class="no-data"  *ngIf="!connectToHMRCUrl && !activeCompany?.subscription?.planDetails?.restrictedModules.hasOwnProperty(restrictedModules.TaxFilling)">
                                 <h1>{{ commonLocaleData?.app_no_data_found }}</h1>
                             </div>
                         </div>

--- a/apps/web-giddh/src/app/vat-report/obligations/obligations.component.html
+++ b/apps/web-giddh/src/app/vat-report/obligations/obligations.component.html
@@ -101,9 +101,9 @@
                     </table>
                     <section *ngIf="!tableDataSource?.length">
                         <div *ngIf="getFormControl('taxNumber').value">
-                            <div *ngIf="connectToHMRCUrl || activeCompany?.subscription?.planDetails?.restrictedModules.hasOwnProperty(restrictedModules.TaxFilling)" class="position-center position-absolute">
+                            <div *ngIf="connectToHMRCUrl || isTaxRestrictedModule" class="position-center position-absolute">
                                 <div class="text-center">
-                                    <a [disabled]="activeCompany?.subscription?.planDetails?.restrictedModules.hasOwnProperty(restrictedModules.TaxFilling)" mat-stroked-button color="primary" [href]="connectToHMRCUrl">
+                                    <a [disabled]="isTaxRestrictedModule" mat-stroked-button color="primary" [href]="connectToHMRCUrl">
                                         {{ localeData?.connect_to_hmrc }}
                                     </a>
                                 </div>
@@ -111,7 +111,7 @@
                                     (onUpgradePlan)="buyPlan($event)">
                                 </restricted-module-message>
                             </div>
-                            <div class="no-data"  *ngIf="!connectToHMRCUrl && !activeCompany?.subscription?.planDetails?.restrictedModules.hasOwnProperty(restrictedModules.TaxFilling)">
+                            <div class="no-data"  *ngIf="!connectToHMRCUrl && !isTaxRestrictedModule">
                                 <h1>{{ commonLocaleData?.app_no_data_found }}</h1>
                             </div>
                         </div>

--- a/apps/web-giddh/src/app/vat-report/obligations/obligations.component.ts
+++ b/apps/web-giddh/src/app/vat-report/obligations/obligations.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnDestroy, OnInit, TemplateRef, ViewChild } from '@angular/core';
 import { merge, Observable, ReplaySubject, take, takeUntil } from 'rxjs';
-import { GIDDH_DATE_RANGE_PICKER_RANGES } from '../../app.constant';
+import { GIDDH_DATE_RANGE_PICKER_RANGES, RestrictedModules } from '../../app.constant';
 import { BsModalRef, BsModalService } from 'ngx-bootstrap/modal';
 import { GIDDH_DATE_FORMAT, GIDDH_NEW_DATE_FORMAT_UI } from '../../shared/helpers/defaultDateFormat';
 import * as dayjs from 'dayjs';
@@ -83,6 +83,10 @@ export class ObligationsComponent implements OnInit, OnDestroy {
     public connectToHMRCUrl$ = this.componentStore.select(state => state.connectToHMRCUrl);
     /** Observable to store the data of obligation */
     public obligationList$ = this.componentStore.select(state => state.obligationList);
+    /** Stores the current company */
+    public activeCompany: any = {};
+    /** Enum for restricted modules */
+    public restrictedModules: any = RestrictedModules;
 
     constructor(
         private formBuilder: UntypedFormBuilder,
@@ -98,6 +102,7 @@ export class ObligationsComponent implements OnInit, OnDestroy {
         this.store.pipe(select(state => state.session.activeCompany), takeUntil(this.destroyed$)).subscribe(activeCompany => {
             if (activeCompany) {
                 this.companyUniqueName = activeCompany.uniqueName;
+                this.activeCompany = activeCompany;
             }
         });
     }
@@ -156,7 +161,9 @@ export class ObligationsComponent implements OnInit, OnDestroy {
                 if (this.isCompanyMode || this.isConsolidatedBranch) {
                     this.hasTaxNumber = true;
                 }
-                this.getURLHMRCAuthorization();
+                if (!this.activeCompany?.subscription?.planDetails?.restrictedModules.hasOwnProperty(this.restrictedModules.TaxFilling)) {
+                    this.getURLHMRCAuthorization();
+                }
             }
         });
 
@@ -204,6 +211,17 @@ export class ObligationsComponent implements OnInit, OnDestroy {
                 }
             }
         });
+    }
+
+    /**
+     * Navigates to the page for buy plan.
+     * @param subscriptionId
+     * @memberof  ObligationsComponent
+     */
+    public buyPlan(subscriptionId: string): void {
+        if (subscriptionId) {
+            this.route.navigate(['pages', 'user-details', 'subscription', 'buy-plan', subscriptionId]);
+        }
     }
 
     /**

--- a/apps/web-giddh/src/app/vat-report/obligations/obligations.component.ts
+++ b/apps/web-giddh/src/app/vat-report/obligations/obligations.component.ts
@@ -87,6 +87,8 @@ export class ObligationsComponent implements OnInit, OnDestroy {
     public activeCompany: any = {};
     /** Enum for restricted modules */
     public restrictedModules: any = RestrictedModules;
+    /** True if tax modules is restricted */
+    public isTaxRestrictedModule: boolean = true;
 
     constructor(
         private formBuilder: UntypedFormBuilder,
@@ -103,6 +105,7 @@ export class ObligationsComponent implements OnInit, OnDestroy {
             if (activeCompany) {
                 this.companyUniqueName = activeCompany.uniqueName;
                 this.activeCompany = activeCompany;
+                this.isTaxRestrictedModule = activeCompany?.subscription?.planDetails?.restrictedModules.hasOwnProperty(this.restrictedModules.TaxFilling);
             }
         });
     }
@@ -161,7 +164,7 @@ export class ObligationsComponent implements OnInit, OnDestroy {
                 if (this.isCompanyMode || this.isConsolidatedBranch) {
                     this.hasTaxNumber = true;
                 }
-                if (!this.activeCompany?.subscription?.planDetails?.restrictedModules.hasOwnProperty(this.restrictedModules.TaxFilling)) {
+                if (!this.isTaxRestrictedModule) {
                     this.getURLHMRCAuthorization();
                 }
             }

--- a/apps/web-giddh/src/app/vat-report/vat-liabilities-payments/vat-liabilities-payments.component.html
+++ b/apps/web-giddh/src/app/vat-report/vat-liabilities-payments/vat-liabilities-payments.component.html
@@ -149,12 +149,17 @@
                         <tr mat-row *matRowDef="let row; columns: displayColumns"></tr>
                     </table>
                     <div *ngIf="!dataSource.length && hasTaxNumber">
-                        <div *ngIf="connectToHMRCUrl" class="position-center position-absolute">
-                            <a mat-stroked-button color="primary" [href]="connectToHMRCUrl">
-                                {{ localeData?.connect_to_hmrc }}
-                            </a>
+                        <div *ngIf="connectToHMRCUrl || activeCompany?.subscription?.planDetails?.restrictedModules.hasOwnProperty(restrictedModules.TaxFilling)" class="position-center position-absolute">
+                            <div class="text-center">
+                                <a [disabled]="activeCompany?.subscription?.planDetails?.restrictedModules.hasOwnProperty(restrictedModules.TaxFilling)" mat-stroked-button color="primary" [href]="connectToHMRCUrl">
+                                    {{ localeData?.connect_to_hmrc }}
+                                </a>
+                            </div>
+                            <restricted-module-message [restrictedModule]="restrictedModules.TaxFilling"
+                                (onUpgradePlan)="buyPlan($event)">
+                            </restricted-module-message>
                         </div>
-                        <div class="no-data" *ngIf="!connectToHMRCUrl" >
+                        <div class="no-data" *ngIf="!connectToHMRCUrl && !activeCompany?.subscription?.planDetails?.restrictedModules.hasOwnProperty(restrictedModules.TaxFilling)" >
                             <h1>{{ commonLocaleData?.app_no_data_found }}</h1>
                         </div>
                     </div>

--- a/apps/web-giddh/src/app/vat-report/vat-liabilities-payments/vat-liabilities-payments.component.html
+++ b/apps/web-giddh/src/app/vat-report/vat-liabilities-payments/vat-liabilities-payments.component.html
@@ -149,9 +149,9 @@
                         <tr mat-row *matRowDef="let row; columns: displayColumns"></tr>
                     </table>
                     <div *ngIf="!dataSource.length && hasTaxNumber">
-                        <div *ngIf="connectToHMRCUrl || activeCompany?.subscription?.planDetails?.restrictedModules.hasOwnProperty(restrictedModules.TaxFilling)" class="position-center position-absolute">
+                        <div *ngIf="connectToHMRCUrl || isTaxRestrictedModule" class="position-center position-absolute">
                             <div class="text-center">
-                                <a [disabled]="activeCompany?.subscription?.planDetails?.restrictedModules.hasOwnProperty(restrictedModules.TaxFilling)" mat-stroked-button color="primary" [href]="connectToHMRCUrl">
+                                <a [disabled]="isTaxRestrictedModule" mat-stroked-button color="primary" [href]="connectToHMRCUrl">
                                     {{ localeData?.connect_to_hmrc }}
                                 </a>
                             </div>
@@ -159,7 +159,7 @@
                                 (onUpgradePlan)="buyPlan($event)">
                             </restricted-module-message>
                         </div>
-                        <div class="no-data" *ngIf="!connectToHMRCUrl && !activeCompany?.subscription?.planDetails?.restrictedModules.hasOwnProperty(restrictedModules.TaxFilling)" >
+                        <div class="no-data" *ngIf="!connectToHMRCUrl && !isTaxRestrictedModule" >
                             <h1>{{ commonLocaleData?.app_no_data_found }}</h1>
                         </div>
                     </div>

--- a/apps/web-giddh/src/app/vat-report/vat-liabilities-payments/vat-liabilities-payments.component.ts
+++ b/apps/web-giddh/src/app/vat-report/vat-liabilities-payments/vat-liabilities-payments.component.ts
@@ -88,6 +88,8 @@ export class VatLiabilitiesPayments implements OnInit, OnDestroy {
     public connectToHMRCUrl$ = this.componentStore.select(state => state.connectToHMRCUrl);
     /** Enum for restricted modules */
     public restrictedModules: any = RestrictedModules;
+    /** True if tax modules is restricted */
+    public isTaxRestrictedModule: boolean = true;
 
     constructor(
         private activatedRoute: ActivatedRoute,
@@ -103,6 +105,7 @@ export class VatLiabilitiesPayments implements OnInit, OnDestroy {
         this.componentStore.activeCompany$.pipe(takeUntil(this.destroyed$)).subscribe(activeCompany => {
             if (activeCompany) {
                 this.activeCompany = activeCompany;
+                this.isTaxRestrictedModule = activeCompany?.subscription?.planDetails?.restrictedModules.hasOwnProperty(this.restrictedModules.TaxFilling);
                 this.getFormControl('companyUniqueName').patchValue(activeCompany.uniqueName);
             }
         });
@@ -175,7 +178,7 @@ export class VatLiabilitiesPayments implements OnInit, OnDestroy {
                 if (this.isCompanyMode || this.isConsolidatedBranch) {
                     this.hasTaxNumber = true;
                 }
-                if (!this.activeCompany?.subscription?.planDetails?.restrictedModules.hasOwnProperty(this.restrictedModules.TaxFilling)) {
+                if (!this.isTaxRestrictedModule) {
                     this.getURLHMRCAuthorization();
                 }
             }

--- a/apps/web-giddh/src/app/vat-report/vat-liabilities-payments/vat-liabilities-payments.component.ts
+++ b/apps/web-giddh/src/app/vat-report/vat-liabilities-payments/vat-liabilities-payments.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnDestroy, OnInit, TemplateRef, ViewChild } from '@angular/core';
 import { merge, Observable, ReplaySubject, takeUntil } from 'rxjs';
-import { GIDDH_DATE_RANGE_PICKER_RANGES } from '../../app.constant';
+import { GIDDH_DATE_RANGE_PICKER_RANGES, RestrictedModules } from '../../app.constant';
 import { BsModalRef, BsModalService } from 'ngx-bootstrap/modal';
 import { GIDDH_DATE_FORMAT, GIDDH_NEW_DATE_FORMAT_UI } from '../../shared/helpers/defaultDateFormat';
 import * as dayjs from 'dayjs';
@@ -86,6 +86,8 @@ export class VatLiabilitiesPayments implements OnInit, OnDestroy {
     public isLoading: boolean;
     /** Observable to store the HMRC portal url */
     public connectToHMRCUrl$ = this.componentStore.select(state => state.connectToHMRCUrl);
+    /** Enum for restricted modules */
+    public restrictedModules: any = RestrictedModules;
 
     constructor(
         private activatedRoute: ActivatedRoute,
@@ -173,7 +175,9 @@ export class VatLiabilitiesPayments implements OnInit, OnDestroy {
                 if (this.isCompanyMode || this.isConsolidatedBranch) {
                     this.hasTaxNumber = true;
                 }
-                this.getURLHMRCAuthorization();
+                if (!this.activeCompany?.subscription?.planDetails?.restrictedModules.hasOwnProperty(this.restrictedModules.TaxFilling)) {
+                    this.getURLHMRCAuthorization();
+                }
             }
         });
 
@@ -191,6 +195,17 @@ export class VatLiabilitiesPayments implements OnInit, OnDestroy {
             .pipe(takeUntil(this.destroyed$)).subscribe((response) => {
                 this.isLoading = response;
             });
+    }
+
+    /**
+     * Navigates to the page for buy plan.
+     * @param subscriptionId
+     * @memberof  VatLiabilitiesPayments
+     */
+    public buyPlan(subscriptionId: string): void {
+        if (subscriptionId) {
+            this.router.navigate(['pages', 'user-details', 'subscription', 'buy-plan', subscriptionId]);
+        }
     }
     /**
     * Get Current company branches information

--- a/apps/web-giddh/src/app/vat-report/vat-report-filters/vat-report-filters.component.html
+++ b/apps/web-giddh/src/app/vat-report/vat-report-filters/vat-report-filters.component.html
@@ -57,15 +57,20 @@
             </button>
         </div>
         <div *ngIf="isUKCompany">
-            <a mat-stroked-button color="primary" class="text-right" [href]="connectToHMRCUrl"
-                [disabled]="!connectToHMRCUrl">
-                <ng-container *ngIf="connectToHMRCUrl">
-                    {{ localeData?.connect_to_hmrc }}
-                </ng-container>
-                <ng-container *ngIf="!connectToHMRCUrl">
-                    {{ localeData?.connected_to_hmrc }}
-                </ng-container>
-            </a>
+            <div class="text-right">
+                <a mat-stroked-button color="primary" [href]="connectToHMRCUrl"
+                    [disabled]="!connectToHMRCUrl || activeCompany?.subscription?.planDetails?.restrictedModules.hasOwnProperty(restrictedModules.TaxFilling) && connectToHMRCUrl">
+                    <ng-container *ngIf="connectToHMRCUrl || activeCompany?.subscription?.planDetails?.restrictedModules.hasOwnProperty(restrictedModules.TaxFilling)">
+                        {{ localeData?.connect_to_hmrc }}
+                    </ng-container>
+                    <ng-container *ngIf="!connectToHMRCUrl && !activeCompany?.subscription?.planDetails?.restrictedModules.hasOwnProperty(restrictedModules.TaxFilling)">
+                        {{ localeData?.connected_to_hmrc }}
+                    </ng-container>
+                </a>
+            </div>
+            <restricted-module-message [restrictedModule]="restrictedModules.TaxFilling"
+                (onUpgradePlan)="buyPlan($event)">
+            </restricted-module-message>
         </div>
     </div>
 </div>

--- a/apps/web-giddh/src/app/vat-report/vat-report-filters/vat-report-filters.component.html
+++ b/apps/web-giddh/src/app/vat-report/vat-report-filters/vat-report-filters.component.html
@@ -59,11 +59,11 @@
         <div *ngIf="isUKCompany">
             <div class="text-right">
                 <a mat-stroked-button color="primary" [href]="connectToHMRCUrl"
-                    [disabled]="!connectToHMRCUrl || activeCompany?.subscription?.planDetails?.restrictedModules.hasOwnProperty(restrictedModules.TaxFilling) && connectToHMRCUrl">
-                    <ng-container *ngIf="connectToHMRCUrl || activeCompany?.subscription?.planDetails?.restrictedModules.hasOwnProperty(restrictedModules.TaxFilling)">
+                    [disabled]="!connectToHMRCUrl || isTaxRestrictedModule">
+                    <ng-container *ngIf="connectToHMRCUrl || isTaxRestrictedModule">
                         {{ localeData?.connect_to_hmrc }}
                     </ng-container>
-                    <ng-container *ngIf="!connectToHMRCUrl && !activeCompany?.subscription?.planDetails?.restrictedModules.hasOwnProperty(restrictedModules.TaxFilling)">
+                    <ng-container *ngIf="!connectToHMRCUrl && !isTaxRestrictedModule">
                         {{ localeData?.connected_to_hmrc }}
                     </ng-container>
                 </a>

--- a/apps/web-giddh/src/app/vat-report/vat-report-filters/vat-report-filters.component.ts
+++ b/apps/web-giddh/src/app/vat-report/vat-report-filters/vat-report-filters.component.ts
@@ -181,6 +181,8 @@ export class VatReportFiltersComponent implements OnInit, OnChanges {
     public isConsolidatedBranch: boolean;
     /** Enum for restricted modules */
     public restrictedModules: any = RestrictedModules;
+    /** True if tax modules is restricted */
+    public isTaxRestrictedModule: boolean = true;
 
     constructor(
         private store: Store<AppState>,
@@ -213,6 +215,7 @@ export class VatReportFiltersComponent implements OnInit, OnChanges {
                 this.isConsolidatedBranch = response.isBranchConsolidated;
             }
         });
+        this.isTaxRestrictedModule = this.activeCompany?.subscription?.planDetails?.restrictedModules.hasOwnProperty(this.restrictedModules.TaxFilling);
         this.isSalesTaxRateWise = SalesTaxReport.TaxWise === this.salesTaxReportType;
         this.isSalesTaxAccountWise = SalesTaxReport.AccountWise === this.salesTaxReportType;
         this.isVatReport = this.moduleType === "VAT_REPORT";

--- a/apps/web-giddh/src/app/vat-report/vat-report-filters/vat-report-filters.component.ts
+++ b/apps/web-giddh/src/app/vat-report/vat-report-filters/vat-report-filters.component.ts
@@ -7,7 +7,7 @@ import { BsModalRef, BsModalService } from 'ngx-bootstrap/modal';
 import { SettingsFinancialYearService } from '../../services/settings.financial-year.service';
 import { Observable, ReplaySubject, take, takeUntil } from 'rxjs';
 import { IOption } from '../../theme/ng-virtual-select/sh-options.interface';
-import { BranchHierarchyType, GIDDH_DATE_RANGE_PICKER_RANGES, SALES_TAX_SUPPORTED_COUNTRIES, TRN_SUPPORTED_COUNTRIES, VAT_SUPPORTED_COUNTRIES } from '../../app.constant';
+import { BranchHierarchyType, GIDDH_DATE_RANGE_PICKER_RANGES, RestrictedModules, SALES_TAX_SUPPORTED_COUNTRIES, TRN_SUPPORTED_COUNTRIES, VAT_SUPPORTED_COUNTRIES } from '../../app.constant';
 import * as dayjs from 'dayjs';
 import { GIDDH_DATE_FORMAT, GIDDH_DATE_FORMAT_YYYY_MM_DD, GIDDH_NEW_DATE_FORMAT_UI } from '../../shared/helpers/defaultDateFormat';
 import { OrganizationType } from '../../models/user-login-state';
@@ -15,7 +15,7 @@ import { cloneDeep } from '../../lodash-optimized';
 import { GstReconcileService } from '../../services/gst-reconcile.service';
 import { CommonService } from '../../services/common.service';
 import { ToasterService } from '../../services/toaster.service';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { SettingsTaxesActions } from '../../actions/settings/taxes/settings.taxes.action';
 import { SalesTaxReport } from '../../theme/tax-authority/utility/tax-authority.const';
 import { CompanyActions } from '../../actions/company.actions';
@@ -179,6 +179,8 @@ export class VatReportFiltersComponent implements OnInit, OnChanges {
     }
     /** True if consolidated branch */
     public isConsolidatedBranch: boolean;
+    /** Enum for restricted modules */
+    public restrictedModules: any = RestrictedModules;
 
     constructor(
         private store: Store<AppState>,
@@ -192,7 +194,8 @@ export class VatReportFiltersComponent implements OnInit, OnChanges {
         private route: ActivatedRoute,
         private settingsTaxesActions: SettingsTaxesActions,
         private companyActions: CompanyActions,
-        private componentStore: TaxAuthorityComponentStore
+        private componentStore: TaxAuthorityComponentStore,
+        private router: Router
     ) {
         this.getFinancialYears();
     }
@@ -272,6 +275,16 @@ export class VatReportFiltersComponent implements OnInit, OnChanges {
         }
     }
 
+    /**
+     * Navigates to the page for buy plan.
+     * @param subscriptionId
+     * @memberof  ShareGroupModalComponent
+     */
+    public buyPlan(subscriptionId: string): void {
+        if (subscriptionId) {
+            this.router.navigate(['pages', 'user-details', 'subscription', 'buy-plan', subscriptionId]);
+        }
+    }
     /**
     * On Change of input properties
     *

--- a/apps/web-giddh/src/app/vat-report/vat-report.component.ts
+++ b/apps/web-giddh/src/app/vat-report/vat-report.component.ts
@@ -10,6 +10,7 @@ import { ToasterService } from '../services/toaster.service';
 import { VatService } from "../services/vat.service";
 import { saveAs } from "file-saver";
 import { SettingsFinancialYearService } from '../services/settings.financial-year.service';
+import { RestrictedModules } from '../app.constant';
 @Component({
     selector: 'app-vat-report',
     styleUrls: ['./vat-report.component.scss'],
@@ -67,6 +68,8 @@ export class VatReportComponent implements OnInit, OnDestroy {
     public vatReportCurrencySymbol: string = 'P';
     /** Holds Current Currency Map Amount Decimal currency wise for Zimbabwe report */
     public vatReportCurrencyMap: string[];
+    /** Enum for restricted modules */
+    public restrictedModules: any = RestrictedModules;
 
     constructor(
         private store: Store<AppState>,
@@ -85,7 +88,7 @@ export class VatReportComponent implements OnInit, OnDestroy {
                 this.isUKCompany = this.activeCompany?.countryV2?.alpha2CountryCode === 'GB';
                 this.isZimbabweCompany = this.activeCompany?.countryV2?.alpha2CountryCode === 'ZW';
                 this.isKenyaCompany = this.activeCompany?.countryV2?.alpha2CountryCode === 'KE';
-                if (this.isUKCompany) {
+                if (this.isUKCompany && !this.activeCompany?.subscription?.planDetails?.restrictedModules.hasOwnProperty(this.restrictedModules.TaxFilling)) {
                     this.getURLHMRCAuthorization();
                 }
             }
@@ -134,7 +137,7 @@ export class VatReportComponent implements OnInit, OnDestroy {
                             this.vatReport = res.body?.sections;
                             this.cdRef.detectChanges();
                         } else {
-                            this.toasty.showSnackBar('error',res.message);
+                            this.toasty.showSnackBar('error', res.message);
                         }
                     }
                 });
@@ -151,7 +154,7 @@ export class VatReportComponent implements OnInit, OnDestroy {
 
                             this.cdRef.detectChanges();
                         } else {
-                            this.toasty.showSnackBar('error',res.message);
+                            this.toasty.showSnackBar('error', res.message);
                         }
                     }
                 });
@@ -183,7 +186,7 @@ export class VatReportComponent implements OnInit, OnDestroy {
                 return saveAs(blob, `VatReport${this.isKenyaCompany ? '.csv' : '.xlsx'}`);
             } else {
                 this.toasty.clearAllToaster();
-                this.toasty.showSnackBar('error',res?.message);
+                this.toasty.showSnackBar('error', res?.message);
             }
         });
     }


### PR DESCRIPTION
https://app.clickup.com/t/86cxub2kt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added subscription plan restriction checks for tax filing modules.
	- Introduced `restricted-module-message` component to inform users about module limitations.

- **Improvements**
	- Enhanced user interface for HMRC connection links.
	- Added conditional rendering for connection and upgrade options based on subscription status.
	- Implemented `buyPlan` method to navigate to subscription purchase page.
	- Improved layout organization for GSTR2 section.

- **Bug Fixes**
	- Refined logic for displaying "no data" messages.
	- Added more precise control over HMRC authorization URL retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->