### PR TITLE
DIlpreet | Test | Prod - .toggleAccountAsidePane is not a function on click on plus icon for customer/vendor in left sidebar

### DIFF
--- a/apps/web-giddh/src/app/shared/primary-sidebar/primary-sidebar.component.html
+++ b/apps/web-giddh/src/app/shared/primary-sidebar/primary-sidebar.component.html
@@ -239,7 +239,7 @@
                                                                         item?.additional?.createNew?.queryParams?.addCustomer
                                                                         ? 'sundrydebtors'
                                                                         : 'sundrycreditors';
-                                                                        toggleAccountAsidePane()"
+                                                                        openAccountAsidePane()"
                                                                     >
                                                                         {{ item?.additional?.createNew?.label }}
                                                                     </strong>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the sidebar’s account creation trigger so that clicking the label now consistently opens the account panel instead of toggling its visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->