### PR TITLE
Divyanshu | Test | Hot fix on unused css class

### DIFF
--- a/apps/web-giddh/src/assets/css/style-1.scss
+++ b/apps/web-giddh/src/assets/css/style-1.scss
@@ -466,9 +466,7 @@ aside-menu-account .container-fluid {
 .column-gap4 {
     column-gap: 40px !important;
 }
-.column-gap5 {
-    column-gap: 50px !important;
-}
+
 .row-gap5 {
     row-gap: 5px !important;
 }


### PR DESCRIPTION
By Self

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Removed the `.column-gap5` utility class, which previously applied a 50px column gap. Existing layouts using this class may be affected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->