### PR TITLE
Ankit | Test | Prod - "Register under composition scheme" text is coming on voucher pdf without any setting on template

### DIFF
--- a/apps/web-giddh/src/app/invoice/templates/edit-template/edit.invoice.component.ts
+++ b/apps/web-giddh/src/app/invoice/templates/edit-template/edit.invoice.component.ts
@@ -971,7 +971,11 @@ export class EditInvoiceComponent implements OnInit, OnChanges, OnDestroy {
             customCreatedTemplates = ss.customCreatedTemplates;
             defaultTemplate = ss.defaultTemplate;
         });
-
+        customCreatedTemplates.forEach((template) => {
+            if (template.sections.header.data?.gstComposition?.label.length === 0) {
+                template.sections.header.data.gstComposition.label = 'Registered under Composition Scheme';
+            }
+        });
         this.transactionMode = 'update';
         this._invoiceUiDataService.setTemplateUniqueName(template?.uniqueName, 'update', customCreatedTemplates, defaultTemplate);
         this.selectedTemplateUniqueName = template.copyFrom;

--- a/apps/web-giddh/src/app/invoice/templates/edit-template/filters-container/content-filters/content.filters.component.html
+++ b/apps/web-giddh/src/app/invoice/templates/edit-template/filters-container/content-filters/content.filters.component.html
@@ -300,7 +300,11 @@
                             type="checkbox"
                             name="gstCompositionLabel"
                             [(ngModel)]="customTemplate.sections['header'].data['gstComposition'].display"
-                            (ngModelChange)="onChangeFieldVisibility(null, null, null)"
+                            (ngModelChange)="onChangeFieldVisibility(null, null, null); 
+                                customTemplate.sections['header'].data['gstComposition'].display 
+                                && customTemplate.sections['header'].data['gstComposition'].label.length === 0 
+                                ? customTemplate.sections['header'].data['gstComposition'].label = 'Registered under Composition Scheme'
+                                : customTemplate.sections['header'].data['gstComposition'].label"
                             checked
                         />
                         <span>
@@ -312,6 +316,7 @@
                                 #gstComposition="hasFocus"
                                 type="text"
                                 name="gstComposition"
+                                placeholder="Registered under Composition Scheme"
                                 [(ngModel)]="customTemplate.sections['header'].data['gstComposition'].label"
                                 (ngModelChange)="onFieldChange(null, null, null)"
                                 [disabled]="!customTemplate.sections['header'].data['gstComposition'].display"


### PR DESCRIPTION
https://app.clickup.com/t/86czk6pyd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured that the GST Composition label in invoice templates defaults to "Registered under Composition Scheme" when left empty.
  * Improved checkbox behavior so that enabling GST Composition automatically sets a default label if none is provided.
* **Style**
  * Added a placeholder text "Registered under Composition Scheme" for the GST Composition label input field in the template editor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->