### PR TITLE
Ankit | Test | Profit & loss page is blank till open other report and return to profit & loss

### DIFF
--- a/apps/web-giddh/src/app/financial-reports/financial-reports.component.ts
+++ b/apps/web-giddh/src/app/financial-reports/financial-reports.component.ts
@@ -94,7 +94,7 @@ export class FinancialReportsComponent implements OnInit, OnDestroy {
                 this.activeTab = val.tab;
                 this.activeTabIndex = val.tabIndex;
                 this.preventTabChangeWithRoute = true;
-                this.selectTab(val.tabIndex);
+                this.selectTab(Number(val.tabIndex));
             }
         });
     }
@@ -109,6 +109,9 @@ export class FinancialReportsComponent implements OnInit, OnDestroy {
         if (this.staticTabs) {
             this.staticTabs.selectedIndex = id;
             this.selectedTabIndex = id;
+            this.CanTBLoad = id === 0;
+            this.CanPLLoad = id === 1;
+            this.CanBSLoad = id === 2;
         }
     }
 


### PR DESCRIPTION
https://app.clickup.com/t/86czyv9ve

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured the correct tab is selected in Financial Reports when opened via links or route parameters.
  * Added per-tab loading states for Trial Balance, Profit & Loss, and Balance Sheet to improve visibility and reduce flicker.
  * Corrected mobile view to display the appropriate localized heading for the active tab.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->