### PR TITLE
Ankit | Test | Test - getting blank Customer module page on switch to aging report t…

### DIFF
--- a/apps/web-giddh/src/app/contact/contact.component.html
+++ b/apps/web-giddh/src/app/contact/contact.component.html
@@ -20,7 +20,6 @@
             <mat-tab
                 [label]="activeTab === 'customer' ? localeData?.customer : localeData?.vendor"
                 [id]="activeTab !== 'aging-report' ? 'giddh-page-heading' : ''"
-                *ngIf="activeTab !== 'aging-report'"
             >
                 <div class="container-fluid">
                     <div class="header-content-sticky vendor-z-index">
@@ -162,7 +161,7 @@
                                                 <span>{{ commonLocaleData?.app_clear }}</span>
                                             </button>
                                         </div>
-                                        <div class="mr-0" *ngIf="activeTab !== 'aging'">
+                                        <div class="mr-0" *ngIf="activeTab !== 'aging-report'">
                                             <select-table-column
                                                 [moduleType]="moduleType"
                                                 [dynamicCustomColumns]="dynamicCustomColumns"


### PR DESCRIPTION
https://app.clickup.com/t/86d0a4duf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * First tab now consistently renders within the tab group, avoiding disappearance when switching to the Aging Report tab.
  * Column selection panel remains visible across all tabs except Aging Report, ensuring consistent access where applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->