### PR TITLE
Dilpreet | Test | Prod - provide support in template header for company address in credit/debit voucher template setting

### DIFF
--- a/apps/web-giddh/src/app/vouchers/template/template-edit-filter/template-edit-filter.component.html
+++ b/apps/web-giddh/src/app/vouchers/template/template-edit-filter/template-edit-filter.component.html
@@ -563,7 +563,7 @@
                                                     ((customTemplate?.templateType === templateTypeEnum.GstTemplateA ||
                                                         customTemplate?.templateType ===
                                                             templateTypeEnum.ThermalTemplate) &&
-                                                        voucherType === voucherTypeEnum.sales &&
+                                                        (voucherType === voucherTypeEnum.sales || voucherType === voucherTypeEnum.voucher) &&
                                                         customTemplate?.sections?.['header']?.data?.['showCompanyAddress']) ||
                                                     customTemplate?.templateType === templateTypeEnum.TallyTemplate
                                                 "


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Company address now displays for both Sales and Voucher types when using GST Template A or Tally Template, provided “Show company address” is enabled. Previously, it appeared only for Sales. This ensures consistent visibility of company address across applicable voucher types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->