### PR TITLE
Ankit | Test | Prod - Exception - Cannot read properties of undefined (reading 'display') when open credit note template in edit mode

### DIFF
--- a/apps/web-giddh/src/app/vouchers/template/template-edit-filter/template-edit-filter.component.html
+++ b/apps/web-giddh/src/app/vouchers/template/template-edit-filter/template-edit-filter.component.html
@@ -650,7 +650,7 @@
                                                                   ].label = 'Registered under Composition Scheme')
                                                                 : customTemplate.sections['header'].data[
                                                                       'gstComposition'
-                                                                  ].label
+                                                                  ]?.label || ''
                                                         "
                                                     >
                                                     </mat-checkbox>
@@ -678,7 +678,7 @@
                                                                 [readonly]="
                                                                     !customTemplate.sections['header'].data[
                                                                         'gstComposition'
-                                                                    ].display
+                                                                    ]?.display
                                                                 "
                                                             ></input-field>
                                                         </div>
@@ -744,7 +744,7 @@
                                                                     [readonly]="
                                                                         !customTemplate.sections['header'].data[
                                                                             'invoiceDate'
-                                                                        ].display
+                                                                        ]?.display
                                                                     "
                                                                     [label]="
                                                                         templateType === voucherTypeEnum.purchase_order
@@ -820,7 +820,7 @@
                                                                     [readonly]="
                                                                         !customTemplate.sections['header'].data[
                                                                             'invoiceNumber'
-                                                                        ].display
+                                                                        ]?.display
                                                                     "
                                                                     [label]="
                                                                         templateType === voucherTypeEnum.purchase_order
@@ -893,7 +893,7 @@
                                                                     [readonly]="
                                                                         !customTemplate.sections['header'].data[
                                                                             'voucherDate'
-                                                                        ].display
+                                                                        ]?.display
                                                                     "
                                                                     [label]="localeData?.voucher_date"
                                                                 ></input-field>
@@ -941,7 +941,7 @@
                                                                     [readonly]="
                                                                         !customTemplate.sections['header'].data[
                                                                             'voucherNumber'
-                                                                        ].display
+                                                                        ]?.display
                                                                     "
                                                                     [label]="localeData?.voucher_number"
                                                                 ></input-field>
@@ -1057,7 +1057,7 @@
                                                                     [readonly]="
                                                                         !customTemplate.sections['header'].data[
                                                                             'formNameInvoice'
-                                                                        ].display
+                                                                        ]?.display
                                                                     "
                                                                     [cssClass]="'form-control'"
                                                                     maxlength="15"
@@ -1092,7 +1092,7 @@
                                                                     [readonly]="
                                                                         !customTemplate.sections['header'].data[
                                                                             'formNameTaxInvoice'
-                                                                        ].display
+                                                                        ]?.display
                                                                     "
                                                                 ></input-field>
                                                             </div>
@@ -1239,7 +1239,7 @@
                                                                 [readonly]="
                                                                     !customTemplate.sections['header'].data[
                                                                         'billingAddress'
-                                                                    ].display
+                                                                    ]?.display
                                                                 "
                                                             ></input-field>
                                                         </div>
@@ -1313,7 +1313,7 @@
                                                                     [label]="
                                                                         customTemplate.sections['header'].data[
                                                                             'billingGstin'
-                                                                        ].label
+                                                                        ]?.label || ''
                                                                     "
                                                                     maxlength="15"
                                                                     cssClass="form-control"
@@ -1326,10 +1326,10 @@
                                                                     [readonly]="
                                                                         !customTemplate.sections['header'].data[
                                                                             'billingAddress'
-                                                                        ].display ||
+                                                                        ]?.display ||
                                                                         !customTemplate.sections['header'].data[
                                                                             'billingGstin'
-                                                                        ].display
+                                                                        ]?.display
                                                                     "
                                                                 ></input-field>
                                                             </div>
@@ -1404,7 +1404,7 @@
                                                                 [readonly]="
                                                                     !customTemplate.sections['header'].data[
                                                                         'shippingAddress'
-                                                                    ].display
+                                                                    ]?.display
                                                                 "
                                                             ></input-field>
                                                         </div>
@@ -1466,7 +1466,7 @@
                                                                 [label]="
                                                                     customTemplate.sections['header'].data[
                                                                         'shippingGstin'
-                                                                    ].label
+                                                                    ]?.label || ''
                                                                 "
                                                                 name="shippingGstin"
                                                                 maxlength="15"
@@ -1480,10 +1480,10 @@
                                                                 [readonly]="
                                                                     !customTemplate.sections['header'].data[
                                                                         'shippingAddress'
-                                                                    ].display ||
+                                                                    ]?.display ||
                                                                     !customTemplate.sections['header'].data[
                                                                         'shippingGstin'
-                                                                    ].display
+                                                                    ]?.display
                                                                 "
                                                             ></input-field>
                                                         </div>
@@ -1548,7 +1548,7 @@
                                                                         [readonly]="
                                                                             !customTemplate.sections['header'].data[
                                                                                 'shippingDate'
-                                                                            ].display
+                                                                            ]?.display
                                                                         "
                                                                         maxlength="15"
                                                                         [cssClass]="'form-control'"
@@ -1598,7 +1598,7 @@
                                                                         [disabled]="
                                                                             !customTemplate.sections['header'].data[
                                                                                 'shippedVia'
-                                                                            ].display
+                                                                            ]?.display
                                                                         "
                                                                         maxlength="15"
                                                                         [cssClass]="'form-control'"
@@ -1656,7 +1656,7 @@
                                                                         [readonly]="
                                                                             !customTemplate.sections['header'].data[
                                                                                 'trackingNumber'
-                                                                            ].display
+                                                                            ]?.display
                                                                         "
                                                                         [cssClass]="'form-control'"
                                                                         maxlength="15"
@@ -1672,7 +1672,7 @@
                                                                                 15,
                                                                                 customTemplate.sections["header"].data[
                                                                                     "trackingNumber"
-                                                                                ].label
+                                                                                ]?.label || ''
                                                                             )
                                                                         }}
                                                                     </p>
@@ -1727,7 +1727,7 @@
                                                                         [readonly]="
                                                                             !customTemplate.sections['header'].data[
                                                                                 'customField1'
-                                                                            ].display
+                                                                            ]?.display
                                                                         "
                                                                         [cssClass]="'form-control'"
                                                                         maxlength="15"
@@ -1743,7 +1743,7 @@
                                                                                 15,
                                                                                 customTemplate.sections["header"].data[
                                                                                     "customField1"
-                                                                                ].label
+                                                                                ]?.label || ''
                                                                             )
                                                                         }}
                                                                     </p>
@@ -1781,7 +1781,7 @@
                                                                         [readonly]="
                                                                             !customTemplate.sections['header'].data[
                                                                                 'customField2'
-                                                                            ].display
+                                                                            ]?.display
                                                                         "
                                                                     ></input-field>
                                                                 </div>
@@ -1795,7 +1795,7 @@
                                                                                 15,
                                                                                 customTemplate.sections["header"].data[
                                                                                     "customField2"
-                                                                                ].label
+                                                                                ]?.label || ''
                                                                             )
                                                                         }}
                                                                     </p>
@@ -1833,7 +1833,7 @@
                                                                         [readonly]="
                                                                             !customTemplate.sections['header'].data[
                                                                                 'customField3'
-                                                                            ].display
+                                                                            ]?.display
                                                                         "
                                                                     ></input-field>
                                                                 </div>
@@ -1847,7 +1847,7 @@
                                                                                 15,
                                                                                 customTemplate.sections["header"].data[
                                                                                     "customField3"
-                                                                                ].label
+                                                                                ]?.label || ''
                                                                             )
                                                                         }}
                                                                     </p>
@@ -1904,7 +1904,7 @@
                                                             "
                                                             (ngModelChange)="onChangeFieldVisibility()"
                                                             [readonly]="
-                                                                !customTemplate.sections['table'].data['sNo'].display
+                                                                !customTemplate.sections['table'].data['sNo']?.display
                                                             "
                                                         ></input-field>
                                                     </div>
@@ -1916,7 +1916,7 @@
                                                             {{
                                                                 getRemainingCharacters(
                                                                     10,
-                                                                    customTemplate.sections["table"].data["sNo"].label
+                                                                    customTemplate.sections["table"].data["sNo"]?.label || ''
                                                                 )
                                                             }}
                                                         </p>
@@ -1987,7 +1987,7 @@
                                                             "
                                                             (ngModelChange)="onChangeFieldVisibility()"
                                                             [readonly]="
-                                                                !customTemplate.sections['table'].data['date'].display
+                                                                !customTemplate.sections['table'].data['date']?.display
                                                             "
                                                         ></input-field>
                                                     </div>
@@ -2004,7 +2004,7 @@
                                                             {{
                                                                 getRemainingCharacters(
                                                                     10,
-                                                                    customTemplate.sections["table"].data["date"].label
+                                                                    customTemplate.sections["table"].data["date"]?.label || ''
                                                                 )
                                                             }}
                                                         </p>
@@ -2093,7 +2093,7 @@
                                                             "
                                                             (ngModelChange)="onChangeFieldVisibility()"
                                                             [readonly]="
-                                                                !customTemplate.sections['table'].data['item'].display
+                                                                !customTemplate.sections['table'].data['item']?.display
                                                             "
                                                         ></input-field>
                                                     </div>
@@ -2107,7 +2107,7 @@
                                                                     customTemplate.templateType === "tally_template"
                                                                         ? 20
                                                                         : 12,
-                                                                    customTemplate.sections["table"].data["item"].label
+                                                                    customTemplate.sections["table"].data["item"]?.label || ''
                                                                 )
                                                             }}
                                                         </p>
@@ -2117,7 +2117,7 @@
                                         </div>
                                         <div
                                             *ngIf="
-                                                customTemplate.sections['table'].data['item'].display &&
+                                                customTemplate.sections['table'].data['item']?.display &&
                                                 customTemplate.sections['table'].data['showDescriptionInRows'] &&
                                                 customTemplate.templateType !== templateTypeEnum.ThermalTemplate &&
                                                 customTemplate.templateType !== templateTypeEnum.TallyTemplate
@@ -2166,7 +2166,7 @@
                                                             "
                                                             (ngModelChange)="onChangeFieldVisibility()"
                                                             [readonly]="
-                                                                !customTemplate.sections['table'].data['hsnSac'].display
+                                                                !customTemplate.sections['table'].data['hsnSac']?.display
                                                             "
                                                         ></input-field>
                                                     </div>
@@ -2242,7 +2242,7 @@
                                                                             : 6,
                                                                         customTemplate.sections["table"].data[
                                                                             "quantity"
-                                                                        ].label
+                                                                        ]?.label || ''
                                                                     )
                                                                 }}
                                                             </p>
@@ -2410,7 +2410,7 @@
                                                             "
                                                             (ngModelChange)="onChangeFieldVisibility()"
                                                             [readonly]="
-                                                                !customTemplate.sections['table'].data['rate'].display
+                                                                !customTemplate.sections['table'].data['rate']?.display
                                                             "
                                                         ></input-field>
                                                     </div>
@@ -2422,7 +2422,7 @@
                                                             {{
                                                                 getRemainingCharacters(
                                                                     10,
-                                                                    customTemplate.sections["table"].data["rate"].label
+                                                                    customTemplate.sections["table"].data["rate"]?.label || ''
                                                                 )
                                                             }}
                                                         </p>
@@ -2549,7 +2549,7 @@
                                                                     14,
                                                                     customTemplate.sections["table"].data[
                                                                         "taxableValue"
-                                                                    ].label
+                                                                    ]?.label || ''
                                                                 )
                                                             }}
                                                         </p>
@@ -2579,7 +2579,7 @@
                                                             "
                                                             (ngModelChange)="onChangeFieldVisibility()"
                                                             [readonly]="
-                                                                !customTemplate.sections['table'].data['tax'].display
+                                                                !customTemplate.sections['table'].data['tax']?.display
                                                             "
                                                         ></input-field>
                                                     </div>
@@ -2591,7 +2591,7 @@
                                                             {{
                                                                 getRemainingCharacters(
                                                                     10,
-                                                                    customTemplate.sections["table"].data["tax"].label
+                                                                    customTemplate.sections["table"].data["tax"]?.label || ''
                                                                 )
                                                             }}
                                                         </p>
@@ -2634,7 +2634,7 @@
                                                             "
                                                             (ngModelChange)="onChangeFieldVisibility()"
                                                             [readonly]="
-                                                                !customTemplate.sections['table'].data['total'].display
+                                                                !customTemplate.sections['table'].data['total']?.display
                                                             "
                                                         ></input-field>
                                                     </div>
@@ -2752,7 +2752,7 @@
                                                 [(ngModel)]="
                                                     customTemplate.sections['table'].data['totalQuantity'].display
                                                 "
-                                                [disabled]="!customTemplate.sections['table'].data['quantity'].display"
+                                                [disabled]="!customTemplate.sections['table'].data['quantity']?.display"
                                                 (ngModelChange)="onChangeFieldVisibility()"
                                             >
                                                 <span class="ml-2">{{ localeData?.total_quantity }}</span>
@@ -2896,7 +2896,7 @@
                                                                             10,
                                                                             customTemplate.sections["footer"].data[
                                                                                 "tcs"
-                                                                            ].label
+                                                                            ]?.label || ''
                                                                         )
                                                                     }}
                                                                 </p>
@@ -2950,7 +2950,7 @@
                                                                             10,
                                                                             customTemplate.sections["footer"].data[
                                                                                 "tds"
-                                                                            ].label
+                                                                            ]?.label || ''
                                                                         )
                                                                     }}
                                                                 </p>
@@ -2994,7 +2994,7 @@
                                                                     [readonly]="
                                                                         !customTemplate.sections['footer'].data[
                                                                             'totalDue'
-                                                                        ].display
+                                                                        ]?.display
                                                                     "
                                                                 ></input-field>
                                                             </div>
@@ -3008,7 +3008,7 @@
                                                                             40,
                                                                             customTemplate.sections["footer"].data[
                                                                                 "totalDue"
-                                                                            ].label
+                                                                            ]?.label || ''
                                                                         )
                                                                     }}
                                                                 </p>
@@ -3060,7 +3060,7 @@
                                                                 [readonly]="
                                                                     !customTemplate.sections['footer'].data[
                                                                         'companyName'
-                                                                    ].display
+                                                                    ]?.display
                                                                 "
                                                             ></input-field>
                                                         </div>
@@ -3081,7 +3081,7 @@
                                                                         50,
                                                                         customTemplate.sections["footer"].data[
                                                                             "companyName"
-                                                                        ].label
+                                                                        ]?.label || ''
                                                                     )
                                                                 }}
                                                             </p>
@@ -3147,7 +3147,7 @@
                                                                     [disabled]="
                                                                         !customTemplate.sections['footer'].data[
                                                                             'companyAddress'
-                                                                        ].display
+                                                                        ]?.display
                                                                     "
                                                                 ></textarea>
                                                             </mat-form-field>
@@ -3162,7 +3162,7 @@
                                                                         124,
                                                                         customTemplate.sections["footer"].data[
                                                                             "companyAddress"
-                                                                        ].label
+                                                                        ]?.label || ''
                                                                     )
                                                                 }}
                                                             </p>
@@ -3244,7 +3244,7 @@
                                                                         13,
                                                                         customTemplate.sections["table"].data[
                                                                             "totalQuantity"
-                                                                        ].label
+                                                                        ]?.label || ''
                                                                     )
                                                                 }}
                                                             </p>
@@ -3298,7 +3298,7 @@
                                                                         10,
                                                                         customTemplate.sections["table"].data[
                                                                             "discount"
-                                                                        ].label
+                                                                        ]?.label || ''
                                                                     )
                                                                 }}
                                                             </p>
@@ -3329,7 +3329,7 @@
                                                             <input-field
                                                                 [label]="customTemplate.sections['footer'].data[
                                                                 'taxableAmount'
-                                                            ].label"
+                                                            ]?.label || ''"
                                                                 [type]="'text'"
                                                                 maxlength="14"
                                                                 [cssClass]="'form-control'"
@@ -3343,7 +3343,7 @@
                                                                 [readonly]="
                                                                     !customTemplate.sections['footer'].data[
                                                                         'taxableAmount'
-                                                                    ].display
+                                                                    ]?.display
                                                                 "
                                                             ></input-field>
                                                         </div>
@@ -3357,7 +3357,7 @@
                                                                         14,
                                                                         customTemplate.sections["footer"].data[
                                                                             "taxableAmount"
-                                                                        ].label
+                                                                        ]?.label || ''
                                                                     )
                                                                 }}
                                                             </p>
@@ -3423,7 +3423,7 @@
                                                 <div
                                                     class="ml-4"
                                                     *ngIf="
-                                                        customTemplate.sections['footer'].data['taxBifurcation'].display
+                                                        customTemplate.sections['footer'].data['taxBifurcation']?.display
                                                     "
                                                 >
                                                     <mat-radio-group>
@@ -3442,7 +3442,7 @@
                                                             [disabled]="
                                                                 !customTemplate.sections['footer'].data[
                                                                     'taxBifurcation'
-                                                                ].display
+                                                                ]?.display
                                                             "
                                                             >{{ commonLocaleData?.app_tax_rate }}</mat-radio-button
                                                         >
@@ -3459,7 +3459,7 @@
                                                             [disabled]="
                                                                 !customTemplate.sections['footer'].data[
                                                                     'taxBifurcation'
-                                                                ].display
+                                                                ]?.display
                                                             "
                                                             >{{ localeData?.hsn_sac }}</mat-radio-button
                                                         >
@@ -3568,7 +3568,7 @@
                                                 <div
                                                     class="ml-4"
                                                     *ngIf="
-                                                        customTemplate.sections['footer'].data['taxBifurcation'].display
+                                                        customTemplate.sections['footer'].data['taxBifurcation']?.display
                                                     "
                                                 >
                                                     <mat-radio-group>
@@ -3587,7 +3587,7 @@
                                                             [disabled]="
                                                                 !customTemplate.sections['footer'].data[
                                                                     'taxBifurcation'
-                                                                ].display
+                                                                ]?.display
                                                             "
                                                             >{{ commonLocaleData?.app_tax_rate }}</mat-radio-button
                                                         >
@@ -3628,7 +3628,7 @@
                                                                             200,
                                                                             customTemplate.sections['footer'].data[
                                                                                 'message1'
-                                                                            ].label
+                                                                            ]?.label || ''
                                                                         )
                                                                     "
                                                                     [placeholder]="localeData?.footer_text"
@@ -3642,7 +3642,7 @@
                                                                     [disabled]="
                                                                         !customTemplate.sections['footer'].data[
                                                                             'message1'
-                                                                        ].display
+                                                                        ]?.display
                                                                     "
                                                                     [appTributeMention]="{
                                                                         trigger: '{',
@@ -3657,7 +3657,7 @@
                                                             *ngIf="
                                                                 !customTemplate.sections['footer'].data[
                                                                     'showNotesAtLastPage'
-                                                                ].display
+                                                                ]?.display
                                                             "
                                                         >
                                                             <p class="mt-1">
@@ -3669,7 +3669,7 @@
                                                                         200,
                                                                         customTemplate.sections["footer"].data[
                                                                             "message1"
-                                                                        ].label
+                                                                        ]?.label || ''
                                                                     )
                                                                 }}
                                                             </p>
@@ -3814,7 +3814,7 @@
                                                                         50,
                                                                         customTemplate.sections["footer"].data[
                                                                             "textUnderSlogan"
-                                                                        ].label
+                                                                        ]?.label || ''
                                                                     )
                                                                 }}
                                                             </p>
@@ -3963,7 +3963,7 @@
                                                                                     30,
                                                                                     customTemplate.sections[
                                                                                         "footer"
-                                                                                    ].data["slogan"].label
+                                                                                    ].data["slogan"]?.label || ''
                                                                                 )
                                                                             }}</span>
                                                                         </div>


### PR DESCRIPTION
https://app.clickup.com/t/86d0hb28f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented occasional errors when editing voucher templates with missing sections or fields.
  * Improved stability of read-only/disabled states and display conditions across template elements.
  * Ensured labels and values render gracefully with sensible fallbacks when data is absent.

* **Refactor**
  * Increased null-safety in template bindings to guard against undefined data, reducing runtime issues without changing UI behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->