### PR TITLE
Ankit | Test - Incorrect tax number label displaying in UK vat detailed report

### DIFF
--- a/apps/web-giddh/src/app/vat-report/transactions/vat-report-transactions.component.html
+++ b/apps/web-giddh/src/app/vat-report/transactions/vat-report-transactions.component.html
@@ -83,7 +83,7 @@
                         </td>
                     </ng-container>
                     <ng-container matColumnDef="trn_number">
-                        <th mat-header-cell *matHeaderCellDef>{{ localeData?.trn_number }}</th>
+                        <th mat-header-cell *matHeaderCellDef>{{ vatReportTransactionsRequest.country === 'GB' ? localeData?.vat_amount : localeData?.trn_number }}</th>
                         <td mat-cell *matCellDef="let element">{{ element.trnNumber ? element.trnNumber : "-" }}</td>
                     </ng-container>
                     <ng-container matColumnDef="place_supply">


### PR DESCRIPTION
https://app.clickup.com/t/86d0n0b60

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated VAT report transactions column header to display country-specific labels—now shows VAT amount for UK transactions and transaction number for other regions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->