### PR TITLE
Ankit | Test | User is able to add alpha numeric value in HSN/SAC code on inventory

### DIFF
--- a/apps/web-giddh/src/app/new-inventory/component/stock-create-edit/stock-create-edit.component.html
+++ b/apps/web-giddh/src/app/new-inventory/component/stock-create-edit/stock-create-edit.component.html
@@ -1549,7 +1549,7 @@
                                                     <input-field
                                                         *ngIf="hsnSac === 'HSN'"
                                                         [name]="'hsnNumber'"
-                                                        [type]="'text'"
+                                                        [type]="'number'"
                                                         [placeholder]="localeData?.enter_hsn_code"
                                                         [(ngModel)]="stockForm.hsnNumber"
                                                     >
@@ -1557,7 +1557,7 @@
                                                     <input-field
                                                         *ngIf="hsnSac === 'SAC'"
                                                         [name]="'sacNumber'"
-                                                        [type]="'text'"
+                                                        [type]="'number'"
                                                         [placeholder]="localeData?.enter_sac_code"
                                                         [(ngModel)]="stockForm.sacNumber"
                                                     >

--- a/apps/web-giddh/src/app/new-inventory/component/stock-create-edit/stock-create-edit.component.html
+++ b/apps/web-giddh/src/app/new-inventory/component/stock-create-edit/stock-create-edit.component.html
@@ -1552,6 +1552,7 @@
                                                         [type]="'number'"
                                                         [placeholder]="localeData?.enter_hsn_code"
                                                         [(ngModel)]="stockForm.hsnNumber"
+                                                        [allowDigitsOnly]="true"
                                                     >
                                                     </input-field>
                                                     <input-field
@@ -1560,6 +1561,7 @@
                                                         [type]="'number'"
                                                         [placeholder]="localeData?.enter_sac_code"
                                                         [(ngModel)]="stockForm.sacNumber"
+                                                        [allowDigitsOnly]="true"
                                                     >
                                                     </input-field>
                                                 </div>


### PR DESCRIPTION
https://app.clickup.com/t/86d0x7r3e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * HSN and SAC number fields now enforce numeric-only input, preventing non-digit characters and improving data accuracy.
  * Numeric input behavior is applied conditionally so the fields only switch to number mode when appropriate, reducing entry errors and improving validation feedback during inventory creation/editing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->