### PR TITLE
Divyanshu | Test | Prod - Edit icon is not displaying on inventory report when stock/group/variant name is large

### DIFF
--- a/apps/web-giddh/src/app/new-inventory/component/reports/reports.component.html
+++ b/apps/web-giddh/src/app/new-inventory/component/reports/reports.component.html
@@ -357,8 +357,10 @@
                                     [matTooltipPosition]="'above'"
                                     [matTooltip]="element?.stockGroup?.name ? element?.stockGroup?.name : ''"
                                 >
-                                    <div class="v-align-center">
-                                        {{ element?.stockGroup?.name ?? "-" }}
+                                    <div class="v-align-center w-100">
+                                        <span class="text-ellipsis flex-grow-1">{{
+                                            element?.stockGroup?.name ?? "-"
+                                        }}</span>
                                         <a
                                             (click)="editGroup(element)"
                                             class="edit-icon pl-1"
@@ -382,8 +384,10 @@
                                     [matTooltipPosition]="'above'"
                                     [matTooltip]="element?.stock?.name ? element?.stock?.name : ''"
                                 >
-                                    <div class="v-align-center">
-                                        {{ element?.stock?.name ?? "-" }}
+                                    <div class="v-align-center w-100">
+                                        <span class="text-ellipsis flex-grow-1">
+                                            {{ element?.stock?.name ?? "-" }}
+                                        </span>
                                         <a
                                             (click)="editStock(element)"
                                             class="edit-icon pl-1"
@@ -407,8 +411,10 @@
                                     [matTooltipPosition]="'above'"
                                     [matTooltip]="element?.variant?.name ? element?.variant?.name : ''"
                                 >
-                                    <div class="v-align-center">
-                                        {{ element?.variant?.name ?? "-" }}
+                                    <div class="v-align-center w-100">
+                                        <span class="text-ellipsis flex-grow-1">
+                                            {{ element?.variant?.name ?? "-" }}
+                                        </span>
                                         <a
                                             (click)="editVariant(element)"
                                             class="edit-icon pl-1"


### PR DESCRIPTION
https://app.clickup.com/t/86d13yuzm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text display in inventory reports table to prevent overflow. Long product names, group names, and variant names now display with ellipsis when needed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->