### PR TITLE
Divyanshu | Test | Custom fields are not getting update on account when generating voucher with empty custom field

### DIFF
--- a/apps/web-giddh/src/app/vouchers/create/create.component.ts
+++ b/apps/web-giddh/src/app/vouchers/create/create.component.ts
@@ -5179,10 +5179,12 @@ export class VoucherCreateComponent implements OnInit, OnDestroy, AfterViewInit 
 
         // Filter out custom fields with empty values
         if (invoiceForm.account?.customFields?.length) {
-            invoiceForm.account.customFields = invoiceForm.account.customFields.filter((field: { uniqueName: string; value: any }) => {
-                return field.value !== null && 
-                       field.value !== undefined && 
-                       (typeof field.value !== 'string' || field.value.trim() !== '');
+            invoiceForm.account.customFields = invoiceForm.account.customFields.map((field: { uniqueName: string; value: any }) => {
+                // Clear field value if it's null, undefined, or empty/whitespace string
+                if (field.value == null || (typeof field.value === 'string' && !field.value.trim())) {
+                    field.value = "";
+                }
+                return field;
             });
         } 
 

--- a/apps/web-giddh/src/app/vouchers/utility/vouchers.utility.service.ts
+++ b/apps/web-giddh/src/app/vouchers/utility/vouchers.utility.service.ts
@@ -373,11 +373,14 @@ export class VouchersUtilityService {
 
                 delete entry.otherTax;
             });
+            // Custom fields are not cleaned
+            const customFields = invoiceForm.account?.customFields;
 
             invoiceForm = cleaner?.clean(invoiceForm, {
                 nullCleaner: true
             });
 
+            invoiceForm.account.customFields = customFields;
             return invoiceForm;
         }
     }


### PR DESCRIPTION
## **User description**
https://app.clickup.com/t/86d1k4u8n


___

## **CodeAnt-AI Description**
Preserve account custom fields when generating vouchers and normalize empty values to empty strings

### What Changed
- Custom fields on the account are no longer removed during voucher creation; they are preserved and restored after form cleaning
- Fields that had null, undefined, or only whitespace values are kept but their value is set to an empty string instead of being filtered out
- Vouchers generated for accounts now include the same custom field entries that existed before form cleaning

### Impact
`✅ Fewer missing custom fields on generated vouchers`
`✅ Clearer voucher data when users enter empty custom field values`
`✅ Prevents accidental loss of account custom fields during voucher creation`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of custom fields in vouchers to ensure they are preserved during save and cleanup operations instead of being removed. Empty field values are now normalized consistently while retaining the field structure.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->