### PR TITLE
Divyanshu | Test | Prod - Attachment + voucher is getting download when downloading attachment only

### DIFF
--- a/apps/web-giddh/src/app/vouchers/download-voucher/download-voucher.component.html
+++ b/apps/web-giddh/src/app/vouchers/download-voucher/download-voucher.component.html
@@ -9,7 +9,14 @@
             <hr />
         </ng-container>
         <div class="mt-2">
-            <mat-checkbox name="originalCopy" formControlName="isOriginal" color="primary" value="Original" [checked]="true">
+            <mat-checkbox
+                name="originalCopy"
+                formControlName="isOriginal"
+                color="primary"
+                value="Original"
+                [checked]="true"
+                (change)="invoiceTypeChanged($event)"
+            >
                 {{ voucherType === 'purchase' ? commonLocaleData?.app_purchase_bill : localeData?.invoice_copy_options?.original }}
             </mat-checkbox>
         </div>

--- a/apps/web-giddh/src/app/vouchers/download-voucher/download-voucher.component.ts
+++ b/apps/web-giddh/src/app/vouchers/download-voucher/download-voucher.component.ts
@@ -109,7 +109,7 @@ export class DownloadVoucherComponent implements OnInit, OnDestroy {
         let downloadOption = "";
         this.fileType = "pdf";
         if (this.downloadForm?.get('isAttachment').value) {
-            if (this.invoiceType?.length > 0) {
+            if (this.invoiceType?.length > 1) {
                 downloadOption = "ALL";
             } else {
                 downloadOption = "ATTACHMENT";


### PR DESCRIPTION
## **User description**
https://app.clickup.com/t/86d1jrmn4


___

## **CodeAnt-AI Description**
Fix attachment-only downloads to avoid also downloading voucher PDF

### What Changed
- When a user chooses to download only the attachment, the system now downloads just the attachment (previously it could include the voucher PDF as well)
- Selecting invoice copy options (original/transport) now updates the chosen download option immediately
- If only attachment is selected the attachment is returned in base64; selecting multiple invoice options triggers a combined "ALL" download

### Impact
`✅ Fewer incorrect combined downloads`
`✅ Clearer attachment-only download behavior`
`✅ Correct file format for attachment-only downloads`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Original copy checkbox interaction now properly updates and reflects changes in the download configuration.
  * Voucher download behavior refined to provide more intelligent handling when dealing with single versus multiple invoice type selections.
  * When a single invoice type is selected, the download now uses ATTACHMENT format instead of the previous ALL format default.
  * Download option selection logic now adapts its behavior based on the total count of invoice types you have selected.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->