### PR TITLE
Divyanshu | Prod | Prod - Attachment + voucher is getting download when downloading attachment only

### DIFF
--- a/apps/web-giddh/src/app/vouchers/download-voucher/download-voucher.component.html
+++ b/apps/web-giddh/src/app/vouchers/download-voucher/download-voucher.component.html
@@ -9,7 +9,14 @@
             <hr />
         </ng-container>
         <div class="mt-2">
-            <mat-checkbox name="originalCopy" formControlName="isOriginal" color="primary" value="Original" [checked]="true">
+            <mat-checkbox
+                name="originalCopy"
+                formControlName="isOriginal"
+                color="primary"
+                value="Original"
+                [checked]="true"
+                (change)="invoiceTypeChanged($event)"
+            >
                 {{ voucherType === 'purchase' ? commonLocaleData?.app_purchase_bill : localeData?.invoice_copy_options?.original }}
             </mat-checkbox>
         </div>

--- a/apps/web-giddh/src/app/vouchers/download-voucher/download-voucher.component.ts
+++ b/apps/web-giddh/src/app/vouchers/download-voucher/download-voucher.component.ts
@@ -109,7 +109,7 @@ export class DownloadVoucherComponent implements OnInit, OnDestroy {
         let downloadOption = "";
         this.fileType = "pdf";
         if (this.downloadForm?.get('isAttachment').value) {
-            if (this.invoiceType?.length > 0) {
+            if (this.invoiceType?.length > 1) {
                 downloadOption = "ALL";
             } else {
                 downloadOption = "ATTACHMENT";


### PR DESCRIPTION
## **User description**
https://app.clickup.com/t/86d1jrmn4


___

## **CodeAnt-AI Description**
**Ensure downloading "Attachment only" fetches only attachment and not voucher**

### What Changed
- Selecting only attachment now downloads just the attachment; the system no longer includes the voucher file when a single attachment option is chosen.
- The download option logic now distinguishes between "single attachment" and "multiple invoice parts", producing "ATTACHMENT" (base64) for single attachments and "ALL" for multiple selections.
- Checkboxes for original copy and transport now trigger immediate selection updates so the chosen download type reflects the current UI state.

### Impact
`✅ Clearer attachment-only downloads`
`✅ Fewer accidental voucher downloads`
`✅ Correct file format for attachments (base64 when only attachment requested)`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
