### PR TITLE
Divyanshu | Test | Prod - Mobile number field is not getting disable after verify number in create company flow

### DIFF
--- a/apps/web-giddh/src/app/add-company/add-company.component.html
+++ b/apps/web-giddh/src/app/add-company/add-company.component.html
@@ -67,6 +67,7 @@
                                     formControlName="mobile"
                                     [label]="commonLocaleData?.app_mobile_number"
                                     [required]="true"
+                                    [disabled]="isMobileNumberVerified"
                                     [useImageFlags]="true"
                                 ></mobile-number-input>
                             </div>

--- a/apps/web-giddh/src/app/shared/mobile-number-input/mobile-number-input.component.html
+++ b/apps/web-giddh/src/app/shared/mobile-number-input/mobile-number-input.component.html
@@ -12,6 +12,7 @@
             <div class="country-select-wrapper" (click)="$event.stopPropagation()">
                 <mat-select
                     #countrySelect
+                    [disabled]="disabled"
                     cdkMonitorElementFocus
                     [formControl]="countryControl"
                     panelWidth="400px"
@@ -74,6 +75,7 @@
                 (focus)="onMobileFocus()"
                 (click)="$event.stopPropagation()"
                 autocomplete="tel"
+                [disabled]="disabled"
             />
         </div>
         <!-- <mat-error *ngIf="mobileControl.hasError('required')">


### PR DESCRIPTION
## **User description**
https://app.clickup.com/t/86d16kwcf


___

## **CodeAnt-AI Description**
Disable mobile number and country selector after verification in Create Company flow

### What Changed
- Mobile number input and country selector become disabled when the component's disabled state is true.
- In the Create Company form, the mobile field is now disabled once the number is verified (bound to the verification flag).
- Prevents further edits to the verified phone number and its country dialing code in the create-company flow.

### Impact
`✅ Prevent edits to verified mobile numbers`
`✅ Fewer accidental country code changes during verification`
`✅ Clearer verified-state behavior in company creation`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Mobile number input field and country selector now disable automatically when mobile number verification is complete, preventing further edits
  * Added ability to control the disabled state of mobile number input controls from parent components

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->