### PR TITLE
Divyanshu | Test | Prod - particular entry is not getting change from stock to service on voucher

### DIFF
--- a/apps/web-giddh/src/app/vouchers/create/create.component.ts
+++ b/apps/web-giddh/src/app/vouchers/create/create.component.ts
@@ -2674,7 +2674,7 @@ export class VoucherCreateComponent implements OnInit, OnDestroy, AfterViewInit 
         try {
             const accountName = transaction?.get('account.name')?.value;
             const stockName = transaction?.get('stock.name')?.value;
-
+            
             if (accountName) {
                 return stockName ? `${accountName} (${stockName})` : accountName;
             }
@@ -2747,6 +2747,10 @@ export class VoucherCreateComponent implements OnInit, OnDestroy, AfterViewInit 
             if (event?.additional?.stock?.uniqueName) {
                 transactionFormGroup.get("stock.name")?.patchValue(event?.additional?.stock?.name);
                 transactionFormGroup.get("stock.uniqueName")?.patchValue(event?.additional?.stock?.uniqueName);
+            } else {
+                const stockFormGroup = transactionFormGroup.get("stock") as FormGroup;
+                const newStockFormGroup = this.getStockFormGroup();
+                stockFormGroup.patchValue(newStockFormGroup.value);
             }
 
             if (event?.additional?.hasVariants) {
@@ -3270,62 +3274,7 @@ export class VoucherCreateComponent implements OnInit, OnDestroy, AfterViewInit 
                         amountForCompany: [entryData ? entryData?.transactions[0]?.amount?.amountForCompany : 0],
                         type: ["DEBIT"],
                     }),
-                    stock: this.formBuilder.group({
-                        name: [entryData ? entryData?.transactions[0]?.stock?.name : ""],
-                        quantity: [entryData ? entryData?.transactions[0]?.stock?.quantity : 1],
-                        maxQuantity: [this.getStockMaxQuantity(entryData)], //temp (for PO linking in PB)
-                        rate: this.formBuilder.group({
-                            rateForAccount: [
-                                entryData
-                                    ? entryData?.transactions[0]?.stock?.rate?.rateForAccount ??
-                                    entryData?.transactions[0]?.stock?.rate?.amountForAccount
-                                    : 1,
-                            ],
-                        }),
-                        stockUnit: this.formBuilder.group({
-                            code: [entryData ? entryData?.transactions[0]?.stock?.stockUnit?.code : ""],
-                            uniqueName: [entryData ? entryData?.transactions[0]?.stock?.stockUnit?.uniqueName : ""],
-                        }),
-                        variant: this.formBuilder.group({
-                            name: [entryData ? entryData?.transactions[0]?.stock?.variant?.name : ""],
-                            uniqueName: [entryData ? entryData?.transactions[0]?.stock?.variant?.uniqueName : ""],
-                            salesTaxInclusive: [
-                                entryData ? entryData?.transactions[0]?.stock?.variant?.salesTaxInclusive : false,
-                            ],
-                            purchaseTaxInclusive: [
-                                entryData ? entryData?.transactions[0]?.stock?.variant?.purchaseTaxInclusive : false,
-                            ],
-                            getParticular: [true],
-                        }),
-                        skuCodeHeading: [entryData ? entryData?.transactions[0]?.stock?.skuCodeHeading : ""],
-                        skuCode: [entryData ? entryData?.transactions[0]?.stock?.sku : ""],
-                        uniqueName: [entryData ? entryData?.transactions[0]?.stock?.uniqueName : ""],
-                        customField1: this.formBuilder.group({
-                            key: [
-                                entryData?.transactions[0]?.stock?.customField1?.value
-                                    ? entryData?.transactions[0]?.stock?.customField1?.key
-                                    : "",
-                            ],
-                            value: [
-                                entryData?.transactions[0]?.stock?.customField1?.value
-                                    ? entryData?.transactions[0]?.stock?.customField1?.value
-                                    : "",
-                            ],
-                        }),
-                        customField2: this.formBuilder.group({
-                            key: [
-                                entryData?.transactions[0]?.stock?.customField2?.value
-                                    ? entryData?.transactions[0]?.stock?.customField2?.key
-                                    : "",
-                            ],
-                            value: [
-                                entryData?.transactions[0]?.stock?.customField2?.value
-                                    ? entryData?.transactions[0]?.stock?.customField2?.value
-                                    : "",
-                            ],
-                        }),
-                        hasVariants: [entryData ? entryData?.transactions[0]?.stock?.hasVariants : false],
-                    }),
+                    stock: this.getStockFormGroup(entryData),
                 }),
             ]),
             total: this.formBuilder.group({
@@ -3360,6 +3309,73 @@ export class VoucherCreateComponent implements OnInit, OnDestroy, AfterViewInit 
             name: [discount?.name],
             particular: [""],
             uniqueName: [discount?.uniqueName],
+        });
+    }
+
+    /**
+     * Returns stock form group
+     *
+     * @private
+     * @param {*} [entryData] - Entry data for initialization
+     * @return {*}  {FormGroup}
+     * @memberof VoucherCreateComponent
+     */
+    private getStockFormGroup(entryData?: any): FormGroup {
+        return this.formBuilder.group({
+            name: [entryData ? entryData?.transactions[0]?.stock?.name : ""],
+            quantity: [entryData ? entryData?.transactions[0]?.stock?.quantity : 1],
+            maxQuantity: [this.getStockMaxQuantity(entryData)], //temp (for PO linking in PB)
+            rate: this.formBuilder.group({
+                rateForAccount: [
+                    entryData
+                        ? entryData?.transactions[0]?.stock?.rate?.rateForAccount ??
+                        entryData?.transactions[0]?.stock?.rate?.amountForAccount
+                        : 1,
+                ],
+            }),
+            stockUnit: this.formBuilder.group({
+                code: [entryData ? entryData?.transactions[0]?.stock?.stockUnit?.code : ""],
+                uniqueName: [entryData ? entryData?.transactions[0]?.stock?.stockUnit?.uniqueName : ""],
+            }),
+            variant: this.formBuilder.group({
+                name: [entryData ? entryData?.transactions[0]?.stock?.variant?.name : ""],
+                uniqueName: [entryData ? entryData?.transactions[0]?.stock?.variant?.uniqueName : ""],
+                salesTaxInclusive: [
+                    entryData ? entryData?.transactions[0]?.stock?.variant?.salesTaxInclusive : false,
+                ],
+                purchaseTaxInclusive: [
+                    entryData ? entryData?.transactions[0]?.stock?.variant?.purchaseTaxInclusive : false,
+                ],
+                getParticular: [true],
+            }),
+            skuCodeHeading: [entryData ? entryData?.transactions[0]?.stock?.skuCodeHeading : ""],
+            skuCode: [entryData ? entryData?.transactions[0]?.stock?.sku : ""],
+            uniqueName: [entryData ? entryData?.transactions[0]?.stock?.uniqueName : ""],
+            customField1: this.formBuilder.group({
+                key: [
+                    entryData?.transactions[0]?.stock?.customField1?.value
+                        ? entryData?.transactions[0]?.stock?.customField1?.key
+                        : "",
+                ],
+                value: [
+                    entryData?.transactions[0]?.stock?.customField1?.value
+                        ? entryData?.transactions[0]?.stock?.customField1?.value
+                        : "",
+                ],
+            }),
+            customField2: this.formBuilder.group({
+                key: [
+                    entryData?.transactions[0]?.stock?.customField2?.value
+                        ? entryData?.transactions[0]?.stock?.customField2?.key
+                        : "",
+                ],
+                value: [
+                    entryData?.transactions[0]?.stock?.customField2?.value
+                        ? entryData?.transactions[0]?.stock?.customField2?.value
+                        : "",
+                ],
+            }),
+            hasVariants: [entryData ? entryData?.transactions[0]?.stock?.hasVariants : false],
         });
     }
 


### PR DESCRIPTION
## **User description**
https://app.clickup.com/t/86d1t6dq8


___

## **CodeAnt-AI Description**
Fix voucher line not switching from stock to service when selecting an account without stock

### What Changed
- When an account is selected that has no associated stock, the voucher line's stock fields are reset to default empty values so the line becomes a service (no leftover stock name/quantity/rate).
- New shared initialization for the stock section ensures newly added or restored lines start with consistent stock defaults whether loaded from data or created blank.
- Small fix to account display label handling to avoid unexpected errors and return an empty label if data is missing.

### Impact
`✅ Voucher lines convert from stock to service correctly when choosing non-stock accounts`
`✅ Fewer incorrect leftover stock values on service lines`
`✅ More consistent initialization for new or restored voucher entries`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of stock-related form initialization and date value processing for voucher creation, ensuring more consistent data structure handling when stock information is present or absent.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->