### PR TITLE
Divyanshu | Prod | Prod - Unable to file UK - VAT report, continuous loader coming on VAT obligation > File return pop up 

### DIFF
--- a/apps/web-giddh/src/app/vat-report/file-return/file-return.component.html
+++ b/apps/web-giddh/src/app/vat-report/file-return/file-return.component.html
@@ -80,7 +80,7 @@
                 </div>
             </div>
         </div>
-    } @else if (vatReport?.length === 0) {
+    } @else if (!isLoading() && vatReport?.length === 0) {
         <div class="no-data no-report">
             <h2>{{ localeData?.no_vrn_available }}</h2>
         </div>

--- a/apps/web-giddh/src/app/vat-report/file-return/file-return.component.html
+++ b/apps/web-giddh/src/app/vat-report/file-return/file-return.component.html
@@ -5,11 +5,13 @@
     </button>
 </div>
 <mat-dialog-content class="dialog-body" tabindex="0">
-    <div class="no-data" *ngIf="isLoading">
-        <giddh-page-loader></giddh-page-loader>
-    </div>
+    @if (isLoading()) {
+        <div class="no-data">
+            <giddh-page-loader></giddh-page-loader>
+        </div>
+    }
 
-    <ng-container *ngIf="!isLoading && vatReport?.length">
+    @if (!isLoading() && vatReport?.length) {
         <div *ngFor="let report of vatReport; let i = index" class="p-3">
             <div class="white-box" *ngIf="i < 2">
                 <div class="d-flex justify-content-between align-items-center">
@@ -78,12 +80,13 @@
                 </div>
             </div>
         </div>
-        <div *ngIf="!vatReport?.length" class="no-data no-report">
+    } @else if (vatReport?.length === 0) {
+        <div class="no-data no-report">
             <h2>{{ localeData?.no_vrn_available }}</h2>
         </div>
-    </ng-container>
+    }
     <div class="d-flex justify-content-end column-gap-1 mt-3">
-        <button matButton="filled" [disabled]="isLoading" (click)="submitVatReturn()">{{ localeData?.submit_file_return }}</button>
+        <button matButton="filled" [disabled]="isLoading()" (click)="submitVatReturn()">{{ localeData?.submit_file_return }}</button>
         <button matButton="outlined" mat-dialog-close>{{ commonLocaleData?.app_cancel }}</button>
     </div>
 </mat-dialog-content>

--- a/apps/web-giddh/src/app/vat-report/file-return/file-return.component.ts
+++ b/apps/web-giddh/src/app/vat-report/file-return/file-return.component.ts
@@ -1,7 +1,7 @@
-import { Component, Inject, OnDestroy, OnInit } from '@angular/core';
+import { Component, Inject, OnDestroy, OnInit, signal } from '@angular/core';
 import { MAT_DIALOG_DATA, MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { VatService } from '../../services/vat.service';
-import { ReplaySubject, take, takeUntil } from 'rxjs';
+import { ReplaySubject, takeUntil } from 'rxjs';
 import { VatReportRequest } from '../../models/api-models/Vat';
 import { Store, select } from '@ngrx/store';
 import { AppState } from '../../store';
@@ -24,7 +24,7 @@ export class FileReturnComponent implements OnInit, OnDestroy {
     /** This will hold common JSON data */
     public commonLocaleData: any = {};
     /** True if API Call is in progress */
-    public isLoading: boolean;
+    public isLoading = signal<boolean>(false);
     /** Holds table data for VAT Report */
     public vatReport: any[] = [];
     /** Hold table displayed columns */
@@ -74,15 +74,16 @@ export class FileReturnComponent implements OnInit, OnDestroy {
         vatReportRequest.taxNumber = this.inputData.taxNumber;
         vatReportRequest.branchUniqueName = this.inputData.branchUniqueName;
 
-        this.isLoading = true;
+        this.isLoading.set(true);
         this.vatService.getCountryWiseVatReport(vatReportRequest).pipe(takeUntil(this.destroyed$)).subscribe((res) => {
-            this.isLoading = false;
-            if (res.status === 'success' && res.body?.sections) {
-                this.vatReport = res.body?.sections;
+            this.isLoading.set(false);
+            if (res.status === 'success' && res.body?.sections?.length) {
+                this.vatReport = res.body.sections;
             } else {
                 if (res?.message) {
                     this.toaster.showSnackBar('error', res.message);
                 }
+                 this.vatReport = [];
                 this.dialogRef.close(res);
             }
         });

--- a/apps/web-giddh/src/assets/styles/base/_global.scss
+++ b/apps/web-giddh/src/assets/styles/base/_global.scss
@@ -2174,6 +2174,12 @@ aside-create-group {
     margin: 15px auto;
     box-shadow: 0px 3px 6px var(--color-shadow-light);
     max-width: calc(var(--center-content-max-width) - 30px);
+
+    table {
+        &.mat-mdc-table {
+            background-color: var(--table-background-color);
+        }
+    }
 }
 
 .vat-report .tab-content {


### PR DESCRIPTION
## **User description**
https://app.clickup.com/t/86d1u0dr7


___

## **CodeAnt-AI Description**
Fix stuck loader and empty-report handling in UK VAT File Return modal

### What Changed
- The File Return dialog no longer shows an endless loader: loading state is tracked reactively so the loader hides when the report request completes or fails.
- When the VAT report API returns no sections, the dialog shows the "no VRN available" message and clears the report list instead of leaving stale data.
- The Submit button is disabled while a load is in progress and enabled again after completion.
- VAT report tables use the correct background styling so table areas match the dialog appearance.

### Impact
`✅ No more stuck loader when opening File Return`
`✅ Clear "no VRN available" shown for empty reports`
`✅ Disabled submit during report loading`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
