### PR TITLE
Divyanshu | Test | Prod - Value is not getting set from dropddown with long press on any field

### DIFF
--- a/apps/web-giddh/src/app/ledger/ledger.component.ts
+++ b/apps/web-giddh/src/app/ledger/ledger.component.ts
@@ -3861,7 +3861,7 @@ export class LedgerComponent implements OnInit, OnDestroy {
      * @memberof LedgerComponent
      */
     public closeAllAccountDropdown(): void {
-        (Array.isArray(this.dropdowns) ? this.dropdowns : []).forEach((alertInstance, i) => alertInstance?.closeDropdownPanel());
+        (this.dropdowns?.length ? this.dropdowns.toArray() : []).forEach((alertInstance, i) => alertInstance?.closeDropdownPanel());
     }
 
     /**

--- a/apps/web-giddh/src/app/search/components/search-filter/search-filter.component.html
+++ b/apps/web-giddh/src/app/search/components/search-filter/search-filter.component.html
@@ -66,7 +66,6 @@
                         <!--By and To: Not required in paginated API -->
                         <span class="position-relative form-group option-value-field" *ngIf="item?.value.queryType === 'openingBalance'">
                             <select-field
-                                [closeOnFocusOut]="true"
                                 class="width-balance-type"
                                 [options]="balType"
                                 (selectedOption)="item?.get('openingBalanceType').patchValue($event.value)"
@@ -79,7 +78,6 @@
                         </span>
                         <span class="position-relative form-group option-value-field" *ngIf="item?.value.queryType === 'closingBalance'">
                             <select-field
-                                [closeOnFocusOut]="true"
                                 class="width-balance-type"
                                 [options]="balType"
                                 (selectedOption)="item?.get('closingBalanceType').patchValue($event.value)"

--- a/apps/web-giddh/src/app/theme/form-fields/reactive-dropdown-field/reactive-dropdown-field.component.ts
+++ b/apps/web-giddh/src/app/theme/form-fields/reactive-dropdown-field/reactive-dropdown-field.component.ts
@@ -68,8 +68,6 @@ export class ReactiveDropdownFieldComponent implements ControlValueAccessor, OnI
     @Input() public labelValue: string = '';
     /** Holds label of value to show in the field */
     public controlLabelValue: string = this.labelValue;
-    /** Close autocomplete on focus out if true - Need to set closeOnFocusOut = true if parent element contains event stop propogation on click */
-    @Input() public closeOnFocusOut: boolean = false;
     /** If we need to clear form control on force clear */
     @Input() public forceClear: boolean = false;
     /** Show or Hide Label */
@@ -800,19 +798,16 @@ export class ReactiveDropdownFieldComponent implements ControlValueAccessor, OnI
      */
     public onBlur(): void {
         setTimeout(() => {
-            // Handle closeOnFocusOut functionality - for sidebarListView, closeOnFocusOut, or normal mat-autocomplete
-            if (this.sidebarListView || this.closeOnFocusOut || !this.sidebarListView) {
-                this.closeDropdownPanel();
-            }
-
-            if (this.allowCustomDropdownValue && !this.searchFormControl?.value && !this.controlLabelValue) {
-                this.selectedOption.emit({ label: '', value: '' });
-            }
-
-            if (this.allowCustomDropdownValue && this.searchFormControl?.value && typeof this.searchFormControl?.value !== "object") {
-                this.value = this.searchFormControl?.value;
-                this.selectedOption.emit({ label: this.value, value: this.value });
-                this.searchFormControl.next('');
+            if (this.allowCustomDropdownValue) {
+                if (!this.searchFormControl?.value && !this.controlLabelValue) {
+                    this.selectedOption.emit({ label: '', value: '' });
+                }
+    
+                if (this.searchFormControl?.value && typeof this.searchFormControl?.value !== "object") {
+                    this.value = this.searchFormControl?.value;
+                    this.selectedOption.emit({ label: this.value, value: this.value });
+                    this.searchFormControl.next('');
+                }
             }
         }, 200);
     }


### PR DESCRIPTION
## **User description**
https://app.clickup.com/t/86d1vkjqv


___

## **CodeAnt-AI Description**
Stop forcing dropdown panels to close on blur and make dropdown closing safer

### What Changed
- Dropdown fields no longer unconditionally close their panel on blur; typed custom values are still captured and emitted when present
- Bulk close of account dropdowns now safely no-ops when there are no dropdown instances instead of throwing
- Removed the now-unused "close on focus out" option from select fields in the search filter so those controls no longer depend on that flag

### Impact
`✅ Fewer unexpected dropdown closures when interacting with long-press or complex UI`
`✅ No errors when closing account dropdowns with no open panels`
`✅ Typed custom dropdown entries are still preserved and emitted on blur`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dropdown closing behavior in ledger view
  * Refined focus handling for balance type fields in search filters
  * Enhanced custom dropdown value handling with simplified internal logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->