### PR TITLE
Ankit | Test | Prod - Payment provide is mandatory for subscribing free plan/trial

### DIFF
--- a/apps/web-giddh/src/app/subscription/buy-plan/buy-plan.component.html
+++ b/apps/web-giddh/src/app/subscription/buy-plan/buy-plan.component.html
@@ -599,7 +599,7 @@
                                                     [label]="localeData?.billing_name + '*'"
                                                     [placeholder]="localeData?.billing_name"
                                                     formControlName="billingName"
-                                                    [showError]="isFormSubmitted && !secondStepForm.get('billingName')?.value"
+                                                    [showError]="isFormSubmitted() && !secondStepForm.get('billingName')?.value"
                                                     [autocomplete]="'subscriptionBillingName' + currentTimeStamp"
                                                 ></input-field>
                                             </div>
@@ -610,7 +610,7 @@
                                                     [label]="commonLocaleData?.app_company_name + '*'"
                                                     formControlName="companyName"
                                                     [placeholder]="commonLocaleData?.app_company_name"
-                                                    [showError]="isFormSubmitted && !secondStepForm.get('companyName')?.value"
+                                                    [showError]="isFormSubmitted() && !secondStepForm.get('companyName')?.value"
                                                     [autocomplete]="'subscriptionCompanyName' + currentTimeStamp"
                                                 ></input-field>
                                             </div>
@@ -622,7 +622,7 @@
                                                     formControlName="email"
                                                     [placeholder]="commonLocaleData?.app_email"
                                                     [showError]="
-                                                        isFormSubmitted &&
+                                                        isFormSubmitted() &&
                                                         (!secondStepForm.get('email')?.value ||
                                                             secondStepForm.get('email')?.errors?.pattern)
                                                     "
@@ -659,7 +659,7 @@
                                                         [options]="commonCountrySource"
                                                         (selectedOption)="selectCountry($event)"
                                                         [labelValue]="selectedCountry"
-                                                        [showError]="isFormSubmitted && !secondStepForm.get('country')?.value"
+                                                        [showError]="isFormSubmitted() && !secondStepForm.get('country')?.value"
                                                         [autocomplete]="'subscriptionCountry' + currentTimeStamp"
                                                     ></reactive-dropdown-field>
                                                 </div>
@@ -671,7 +671,7 @@
                                                     [type]="'text'"
                                                     formControlName="taxNumber"
                                                     [showError]="
-                                                        (isFormSubmitted && !secondStepForm.get('taxNumber')?.value) || !isGstinValid
+                                                        (isFormSubmitted() && !secondStepForm.get('taxNumber')?.value) || !isGstinValid
                                                     "
                                                     [label]="formFields['taxName']?.label ?? commonLocaleData?.app_tax_number"
                                                     [maxlength]="15"
@@ -686,7 +686,7 @@
                                                         [label]="commonLocaleData?.app_state + '*'"
                                                         [placeholder]="commonLocaleData?.app_state"
                                                         [options]="states"
-                                                        [showError]="isFormSubmitted && !secondStepForm.get('state')?.value"
+                                                        [showError]="isFormSubmitted() && !secondStepForm.get('state')?.value"
                                                         [readonly]="disabledState"
                                                         [labelValue]="selectedState"
                                                         (selectedOption)="selectState($event)"
@@ -700,7 +700,7 @@
                                                         [label]="commonLocaleData?.app_region + '*'"
                                                         [placeholder]="commonLocaleData?.app_select_region"
                                                         [options]="countyList"
-                                                        [showError]="isFormSubmitted && !secondStepForm.get('state')?.value"
+                                                        [showError]="isFormSubmitted() && !secondStepForm.get('state')?.value"
                                                         [labelValue]="selectedState"
                                                         (selectedOption)="selectState($event)"
                                                         [autocomplete]="'subscriptionCounty' + currentTimeStamp"
@@ -774,7 +774,12 @@
                                                     [options]="filteredPaymentProviders"
                                                     formControlName="paymentProvider"
                                                     (onClear)="thirdStepForm.get('paymentProvider')?.patchValue(null)"
-                                                    [showError]="isFormSubmitted && !thirdStepForm.get('paymentProvider')?.value"
+                                                    [required]="payType === 'buy'"
+                                                    [showError]="
+                                                        payType === 'buy' &&
+                                                        isFormSubmitted() &&
+                                                        !thirdStepForm.get('paymentProvider')?.value
+                                                    "
                                                 ></reactive-dropdown-field>
                                             </div>
                                             <ng-container

--- a/apps/web-giddh/src/app/subscription/buy-plan/buy-plan.component.ts
+++ b/apps/web-giddh/src/app/subscription/buy-plan/buy-plan.component.ts
@@ -1,5 +1,5 @@
 import { ViewSubscriptionComponentStore } from './../view-subscription/utility/view-subscription.store';
-import { ChangeDetectorRef, Component, ElementRef, Inject, OnDestroy, OnInit, ViewChild } from '@angular/core';
+import { ChangeDetectorRef, Component, ElementRef, Inject, OnDestroy, OnInit, ViewChild, signal } from '@angular/core';
 import { FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms';
 import { MatDialog } from '@angular/material/dialog';
 import { ActivateDialogComponent } from '../activate-dialog/activate-dialog.component';
@@ -107,8 +107,8 @@ export class BuyPlanComponent implements OnInit, OnDestroy {
         addresses: null,
         giddhBalanceDecimalPlaces: 2
     };
-    /** True if form is submitted to show error if available */
-    public isFormSubmitted: boolean = false;
+    /** Signal to track if form is submitted to show error if available */
+    public isFormSubmitted = signal<boolean>(false);
     /** Hold selected plan*/
     public selectedPlan: any;
     /** Hold session source observable*/
@@ -1229,17 +1229,17 @@ export class BuyPlanComponent implements OnInit, OnDestroy {
      * @memberof BuyPlanComponent
      */
     public nextStepForm(): void {
-        this.isFormSubmitted = false;
+        this.isFormSubmitted.set(false);
         if (this.selectedStep === 0 && this.firstStepForm.invalid) {
-            this.isFormSubmitted = true;
+            this.isFormSubmitted.set(true);
             return;
         }
         if (this.selectedStep === 1 && this.secondStepForm.invalid) {
-            this.isFormSubmitted = true;
+            this.isFormSubmitted.set(true);
             return;
         }
         if (this.selectedStep === 2 && this.thirdStepForm.invalid) {
-            this.isFormSubmitted = true;
+            this.isFormSubmitted.set(true);
             return;
         }
 
@@ -1472,57 +1472,70 @@ export class BuyPlanComponent implements OnInit, OnDestroy {
      */
     public onSubmit(type: string): void {
         this.payType = type;
-        this.isFormSubmitted = false;
-        if (this.subscriptionForm.invalid) {
-            this.isFormSubmitted = true;
-            return;
+        this.isFormSubmitted.set(false);
+        
+        const isPaymentProviderRequired = this.payType === 'buy' && !this.subscriptionForm.value.thirdStepForm?.paymentProvider;
+        
+        if (isPaymentProviderRequired) {
+            this.thirdStepForm.get('paymentProvider')?.setErrors({ required: true });
+            this.thirdStepForm.get('paymentProvider')?.markAsTouched();
+        } else {
+            this.thirdStepForm.get('paymentProvider')?.setErrors(null);
+            this.thirdStepForm.get('paymentProvider')?.updateValueAndValidity();
         }
-        let mobileNumber = this.subscriptionForm.value.secondStepForm.mobileNumber?.replace(/\+/g, '');
-        let request = {
-            planUniqueName: this.subscriptionForm.value.firstStepForm.planUniqueName,
-            duration: this.subscriptionForm.value.firstStepForm.duration,
-            userUniqueName: null,
-            billingAccount: {
-                billingName: this.subscriptionForm.value.secondStepForm.billingName,
-                companyName: this.subscriptionForm.value.secondStepForm.companyName,
-                taxNumber: this.subscriptionForm.value.secondStepForm.taxNumber,
-                email: this.subscriptionForm.value.secondStepForm.email,
-                pincode: this.subscriptionForm.value.secondStepForm.pincode,
-                mobileNumber: mobileNumber,
-                country: {
-                    name: this.subscriptionForm.value.secondStepForm.country.label ? this.subscriptionForm.value.secondStepForm.country.label : this.subscriptionForm.value.secondStepForm.country.name,
-                    code: this.subscriptionForm.value.secondStepForm.country.value ? this.subscriptionForm.value.secondStepForm.country.value : this.subscriptionForm.value.secondStepForm.country.code
+        
+        setTimeout(() => {
+            if (this.subscriptionForm.invalid) {
+                this.isFormSubmitted.set(true);
+                return;
+            }
+            let mobileNumber = this.subscriptionForm.value.secondStepForm.mobileNumber?.replace(/\+/g, '');
+            let request = {
+                planUniqueName: this.subscriptionForm.value.firstStepForm.planUniqueName,
+                duration: this.subscriptionForm.value.firstStepForm.duration,
+                userUniqueName: null,
+                billingAccount: {
+                    billingName: this.subscriptionForm.value.secondStepForm.billingName,
+                    companyName: this.subscriptionForm.value.secondStepForm.companyName,
+                    taxNumber: this.subscriptionForm.value.secondStepForm.taxNumber,
+                    email: this.subscriptionForm.value.secondStepForm.email,
+                    pincode: this.subscriptionForm.value.secondStepForm.pincode,
+                    mobileNumber: mobileNumber,
+                    country: {
+                        name: this.subscriptionForm.value.secondStepForm.country.label ? this.subscriptionForm.value.secondStepForm.country.label : this.subscriptionForm.value.secondStepForm.country.name,
+                        code: this.subscriptionForm.value.secondStepForm.country.value ? this.subscriptionForm.value.secondStepForm.country.value : this.subscriptionForm.value.secondStepForm.country.code
+                    },
+                    address: this.subscriptionForm.value.secondStepForm.address
                 },
-                address: this.subscriptionForm.value.secondStepForm.address
-            },
-            promoCode: this.subscriptionForm.value.firstStepForm.promoCode ? this.subscriptionForm.value.firstStepForm.promoCode : null,
-            paymentProvider: this.thirdStepForm.value.paymentProvider,
-            subscriptionId: null
-        }
-
-        if ((this.firstStepForm.get('duration')?.value === 'MONTHLY' || this.firstStepForm.get('duration')?.value === 'DAILY') && this.selectedPlan?.entityCode !== 'GBR') {
-            request['razorpayAuthType'] = this.subscriptionForm.value.thirdStepForm.razorpayAuthType;
-        }
-
-        if (this.subscriptionForm.value.secondStepForm.country.value === 'GB') {
-            request.billingAccount['county'] = {
-                name: this.subscriptionForm.value.secondStepForm.state.label ? this.subscriptionForm.value.secondStepForm.state.label : this.subscriptionForm.value.secondStepForm.state.name,
-                code: this.subscriptionForm.value.secondStepForm.state.value ? this.subscriptionForm.value.secondStepForm.state.value : this.subscriptionForm.value.secondStepForm.state.code
-            };
-        } else {
-            request.billingAccount['state'] = {
-                name: this.subscriptionForm.value.secondStepForm.state.label ? this.subscriptionForm.value.secondStepForm.state.label : this.subscriptionForm.value.secondStepForm.state.name,
-                code: this.subscriptionForm.value.secondStepForm.state.value ? this.subscriptionForm.value.secondStepForm.state.value : this.subscriptionForm.value.secondStepForm.state.code
-            };
-        }
-        request['payNow'] = (type === 'trial') ? false : true;
-        if (this.subscriptionId && this.isChangePlan) {
-            request.subscriptionId = this.subscriptionId;
-            this.subscriptionRequest = request;
-            this.componentStore.getChangePlanDetails(request);
-        } else {
-            this.componentStore.createSubscription(request);
-        }
+                promoCode: this.subscriptionForm.value.firstStepForm.promoCode ? this.subscriptionForm.value.firstStepForm.promoCode : null,
+                paymentProvider: this.thirdStepForm.value.paymentProvider,
+                subscriptionId: null
+            }
+    
+            if ((this.firstStepForm.get('duration')?.value === 'MONTHLY' || this.firstStepForm.get('duration')?.value === 'DAILY') && this.selectedPlan?.entityCode !== 'GBR') {
+                request['razorpayAuthType'] = this.subscriptionForm.value.thirdStepForm.razorpayAuthType;
+            }
+    
+            if (this.subscriptionForm.value.secondStepForm.country.value === 'GB') {
+                request.billingAccount['county'] = {
+                    name: this.subscriptionForm.value.secondStepForm.state.label ? this.subscriptionForm.value.secondStepForm.state.label : this.subscriptionForm.value.secondStepForm.state.name,
+                    code: this.subscriptionForm.value.secondStepForm.state.value ? this.subscriptionForm.value.secondStepForm.state.value : this.subscriptionForm.value.secondStepForm.state.code
+                };
+            } else {
+                request.billingAccount['state'] = {
+                    name: this.subscriptionForm.value.secondStepForm.state.label ? this.subscriptionForm.value.secondStepForm.state.label : this.subscriptionForm.value.secondStepForm.state.name,
+                    code: this.subscriptionForm.value.secondStepForm.state.value ? this.subscriptionForm.value.secondStepForm.state.value : this.subscriptionForm.value.secondStepForm.state.code
+                };
+            }
+            request['payNow'] = (type === 'trial') ? false : true;
+            if (this.subscriptionId && this.isChangePlan) {
+                request.subscriptionId = this.subscriptionId;
+                this.subscriptionRequest = request;
+                this.componentStore.getChangePlanDetails(request);
+            } else {
+                this.componentStore.createSubscription(request);
+            }
+        }, 100);
     }
 
     /**


### PR DESCRIPTION
## **User description**
https://app.clickup.com/t/86d1ru03t


___

## **CodeAnt-AI Description**
Make payment provider required only for paid purchases and fix form validation display

### What Changed
- The form's "submitted" state is now a reactive signal so error indicators update reliably when the user submits or corrects fields
- Payment provider is enforced only for actual purchases (payType == 'buy'); it is no longer treated as required for trial/free subscriptions
- Submit now marks the payment provider field as required when needed and prevents submission; when not required, submission proceeds as before
- Error messages and "show error" flags in the billing step now reflect the reactive submitted state, so validation errors appear consistently after submit

### Impact
`✅ Clearer payment-provider validation for trial signups`
`✅ Fewer blocked trial/subscription signups due to unnecessary payment requirement`
`✅ More reliable display of form validation errors`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved form validation error display in the subscription purchase form to ensure errors appear at the correct times during user interaction.
  * Added validation for payment provider selection when required, providing clearer feedback to users completing their subscription.

* **Refactor**
  * Enhanced subscription form submission flow with improved validation checks for better form handling and data integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->