### PR TITLE
Ankit | Prod | Prod - Remove label from adjustment/amount field and foucs should be on adjustment voucher dropdown in adjust voucher box in ledger

### DIFF
--- a/apps/web-giddh/src/app/shared/advance-receipt-adjustment/advance-receipt-adjustment.component.ts
+++ b/apps/web-giddh/src/app/shared/advance-receipt-adjustment/advance-receipt-adjustment.component.ts
@@ -53,8 +53,6 @@ export class AdvanceReceiptAdjustmentComponent implements OnInit, OnDestroy {
     public currentVoucherLabel: string;
     @ViewChild('tdsTypeBox', { static: true }) public tdsTypeBox: ElementRef;
     @ViewChild('tdsAmountBox', { static: true }) public tdsAmountBox: ElementRef;
-    /** Flag to control dropdown opening after data is loaded */
-    public shouldOpenDropdown: boolean = false;
 
     public adjustPayment: AdjustAdvancePaymentModal = {
         customerName: '',
@@ -119,6 +117,17 @@ export class AdvanceReceiptAdjustmentComponent implements OnInit, OnDestroy {
     private paginationLimit: number = PAGINATION_LIMIT;
     /** Decimal places from company settings */
     public giddhBalanceDecimalPlaces: number = 2;
+
+    /**
+     * Determines if dropdown should open automatically
+     * Returns true if there is exactly one adjustment and it has no uniqueName
+     *
+     * @returns {boolean}
+     * @memberof AdvanceReceiptAdjustmentComponent
+     */
+    protected get shouldOpenDropdown(): boolean {
+        return this.adjustVoucherForm?.adjustments?.length === 1 && !this.adjustVoucherForm?.adjustments?.[0]?.uniqueName;
+    }
 
     constructor(
         private store: Store<AppState>,
@@ -1197,7 +1206,7 @@ export class AdvanceReceiptAdjustmentComponent implements OnInit, OnDestroy {
 
                 }
             }
-            this.shouldOpenDropdown = !this.adjustVoucherForm?.adjustments?.[0]?.uniqueName && this.adjustVoucherForm?.adjustments?.length === 1;
+            
             this.changeDetectionRef.detectChanges();
         });
     }

--- a/apps/web-giddh/src/app/vouchers/adjust-payment-dialog/adjust-payment-dialog.component.ts
+++ b/apps/web-giddh/src/app/vouchers/adjust-payment-dialog/adjust-payment-dialog.component.ts
@@ -131,8 +131,17 @@ export class AdjustPaymentDialogComponent implements OnInit, OnDestroy {
     private globalKeydownListener?: (event: KeyboardEvent) => void;
     private globalMousedownListener?: () => void;
     private globalClickListener?: () => void;
-    /** Flag to control dropdown opening after view init */
-    public shouldOpenDropdown: boolean = false;
+
+    /**
+     * Determines if dropdown should open automatically
+     * Returns true if there is exactly one adjustment and it has no uniqueName
+     *
+     * @returns {boolean}
+     * @memberof AdjustPaymentDialogComponent
+     */
+    protected get shouldOpenDropdown(): boolean {
+        return this.adjustVoucherForm?.adjustments?.length === 1 && !this.adjustVoucherForm?.adjustments?.[0]?.uniqueName;
+    }
 
     constructor(
         private componentStore: VoucherComponentStore,
@@ -1167,7 +1176,6 @@ export class AdjustPaymentDialogComponent implements OnInit, OnDestroy {
                     this.adjustVoucherOptions$ = of(this.adjustVoucherOptions);
                 }
             }
-            this.shouldOpenDropdown = !this.adjustVoucherForm?.adjustments?.[0]?.uniqueName && this.adjustVoucherForm?.adjustments?.length === 1;
             this.changeDetectorRef.detectChanges();
         });
     }


### PR DESCRIPTION
## **User description**
https://app.clickup.com/t/86d1k3d2p. -[Prod - Remove label from adjustment/amount field and foucs should be on adjustment voucher dropdown in adjust voucher box in ledger]


___

## **CodeAnt-AI Description**
Make adjustment dropdown auto-open only when there is a single empty adjustment

### What Changed
- The adjustment dropdown now opens automatically only when there is exactly one adjustment row and that row has no selected voucher (no uniqueName)
- Replaced the mutable dropdown flag with a computed check in both advance-receipt and adjust-payment dialogs so the auto-open decision is evaluated from the current form state
- Removed explicit assignments to the old flag to avoid incorrect dropdown openings after voucher data loads

### Impact
`✅ Consistent auto-opening of adjustment dropdown when appropriate`
`✅ Fewer accidental dropdown openings after voucher data loads`
`✅ More reliable focus on the adjustment selection step`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
