### PR TITLE
Ankit | Test | Prod - Export button is coming on sales/purchase register page with sales person filter

### DIFF
--- a/apps/web-giddh/src/app/reports/components/purchase-register-component/purchase.register.component.html
+++ b/apps/web-giddh/src/app/reports/components/purchase-register-component/purchase.register.component.html
@@ -259,6 +259,7 @@
             </div>
             <button
                 matButton="filled"
+                *ngIf="showExport()"
                 (click)="export()"
                 color="primary"
                 [matTooltip]="commonLocaleData?.app_export"

--- a/apps/web-giddh/src/app/reports/components/purchase-register-component/purchase.register.component.ts
+++ b/apps/web-giddh/src/app/reports/components/purchase-register-component/purchase.register.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectorRef, Component, OnDestroy, OnInit, ViewChild, signal } from '@angular/core';
+import { ChangeDetectorRef, Component, computed, OnDestroy, OnInit, signal, ViewChild } from '@angular/core';
 import { MatMenuTrigger } from '@angular/material/menu';
 import { Router, NavigationStart, ActivatedRoute } from "@angular/router";
 import { select, Store } from "@ngrx/store";
@@ -146,6 +146,16 @@ export class PurchaseRegisterComponent implements OnInit, OnDestroy {
     public datePickerOptions: any = GIDDH_DATE_RANGE_PICKER_RANGES;
     /* Selected range label */
     public selectedRangeLabel: any = "";
+    /** Supported groupBy values for export functionality */
+    public supportedExportGroupBy = signal<GroupBy[]>([GroupBy.Duration]);
+    /** Current groupBy value selected in the report form */
+    public currentGroupBy = signal<GroupBy>(GroupBy.Duration);
+    /** Computed signal that determines if export button should be visible based on current groupBy */
+    public showExport = computed(() => {
+        const currentGroupBy = this.currentGroupBy();
+        return this.supportedExportGroupBy().includes(currentGroupBy);
+    });
+
 constructor(
         private router: Router,
         private activeRoute: ActivatedRoute,
@@ -765,6 +775,7 @@ constructor(
                     from, 
                     to, 
                     branchUniqueName: this.currentBranch.uniqueName,
+                    groupBy: this.currentGroupBy(),
                     ...(groupByQueryParams[groupByValue] || {})
                 } 
             });
@@ -885,6 +896,7 @@ constructor(
         if (keysToRemove) {
             this.removeKeysFromObject(requestObject, keysToRemove);
         }
+        this.currentGroupBy.set(requestObject.groupBy);
         this.componentStore.getSalesPurchaseList({
             payload: requestObject,
             params: { branchUniqueName: (this.currentBranch ? this.currentBranch.uniqueName : ""), from, to },

--- a/apps/web-giddh/src/app/reports/components/purchase-register-expand-component/purchase.register.expand.component.html
+++ b/apps/web-giddh/src/app/reports/components/purchase-register-expand-component/purchase.register.expand.component.html
@@ -58,6 +58,7 @@
                     </button>
                     <button
                         matButton="filled"
+                        *ngIf="showExport()"
                         (click)="export()"
                         [matTooltip]="commonLocaleData?.app_export"
                         [matTooltipPosition]="'above'"

--- a/apps/web-giddh/src/app/reports/components/purchase-register-expand-component/purchase.register.expand.component.ts
+++ b/apps/web-giddh/src/app/reports/components/purchase-register-expand-component/purchase.register.expand.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ViewChild, ElementRef, ChangeDetectorRef, OnDestroy, TemplateRef, Inject } from '@angular/core';
+import { Component, OnInit, ViewChild, ElementRef, ChangeDetectorRef, OnDestroy, TemplateRef, Inject, signal, computed } from '@angular/core';
 import { MatMenuTrigger } from '@angular/material/menu';
 import { Store, select } from '@ngrx/store';
 import { AppState } from '../../../store';
@@ -22,6 +22,7 @@ import { PageEvent } from '@angular/material/paginator';
 import { Configuration } from '../../../app.constant';
 import { environment } from '../../../../environments/environment.generated';
 import { forEach, includes, map, set } from '../../../lodash-optimized';
+import { GroupBy } from '../../constants/reports.constant';
 
 @Component({
     selector: "purchase-register-expand",
@@ -95,6 +96,15 @@ export class PurchaseRegisterExpandComponent implements OnInit, OnDestroy {
     public dataSource: MatTableDataSource<any> = new MatTableDataSource();
     /** Holds page size options for pagination */
     public pageSizeOptions: number[] = PAGE_SIZE_OPTIONS;
+    /** Supported groupBy values for export functionality */
+    public supportedExportGroupBy = signal<GroupBy[]>([GroupBy.Duration]);
+    /** Current groupBy value selected in the report form */
+    public currentGroupBy = signal<GroupBy | null>(null);
+    /** Computed signal that determines if export button should be visible based on current groupBy */
+    public showExport = computed(() => {
+        const currentGroupBy = this.currentGroupBy();
+        return this.supportedExportGroupBy().includes(currentGroupBy);
+    });
 
     constructor(
         private store: Store<AppState>,
@@ -156,6 +166,7 @@ export class PurchaseRegisterExpandComponent implements OnInit, OnDestroy {
                 this.getDetailedPurchaseRequestFilter.stateCode = params.stateCode;
                 this.getDetailedPurchaseRequestFilter.countryCode = params.countryCode;
                 this.getDetailedPurchaseRequestFilter.accountUniqueNames = registerReportFilters?.accountUniqueNames;
+                this.currentGroupBy.set(params.groupBy);
                 this.params = params;
                 this.setDataPickerDateRange();
                 this.getDetailedPurchaseReport(this.getDetailedPurchaseRequestFilter);

--- a/apps/web-giddh/src/app/reports/components/report-details-components/report.details.component.html
+++ b/apps/web-giddh/src/app/reports/components/report-details-components/report.details.component.html
@@ -256,6 +256,7 @@
             </div>
             <button
                 matButton="filled"
+                *ngIf="showExport()"
                 (click)="export()"
                 color="primary"
                 [matTooltip]="commonLocaleData?.app_export"

--- a/apps/web-giddh/src/app/reports/components/report-details-components/report.details.component.ts
+++ b/apps/web-giddh/src/app/reports/components/report-details-components/report.details.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectorRef, Component, OnDestroy, OnInit, TemplateRef, ViewChild, signal } from '@angular/core';
+import { ChangeDetectorRef, Component, computed, OnDestroy, OnInit, signal, TemplateRef, ViewChild } from '@angular/core';
 import { MatMenuTrigger } from '@angular/material/menu';
 import { Router, NavigationStart, ActivatedRoute } from "@angular/router";
 import { select, Store } from "@ngrx/store";
@@ -144,6 +144,15 @@ export class ReportsDetailsComponent implements OnInit, OnDestroy {
     public datePickerOptions: any = GIDDH_DATE_RANGE_PICKER_RANGES;
     /* Selected range label */
     public selectedRangeLabel: any = "";
+    /** Supported groupBy values for export functionality */
+    public supportedExportGroupBy = signal<GroupBy[]>([GroupBy.Duration]);
+    /** Current groupBy value selected in the report form */
+    public currentGroupBy = signal<GroupBy>(GroupBy.Duration);
+    /** Computed signal that determines if export button should be visible based on current groupBy */
+    public showExport = computed(() => {
+        const currentGroupBy = this.currentGroupBy();
+        return this.supportedExportGroupBy().includes(currentGroupBy);
+    });
 constructor(
         private router: Router,
         private activeRoute: ActivatedRoute,
@@ -776,6 +785,7 @@ constructor(
                     from, 
                     to, 
                     branchUniqueName: this.currentBranch?.uniqueName,
+                    groupBy: this.currentGroupBy(),
                     ...(groupByQueryParams[groupByValue] || {})
                 } 
             });
@@ -896,6 +906,7 @@ constructor(
         if (keysToRemove) {
             this.removeKeysFromObject(requestObject, keysToRemove);
         }
+        this.currentGroupBy.set(requestObject.groupBy);
         this.componentStore.getSalesPurchaseList({
             payload: requestObject,
             params: { branchUniqueName: (this.currentBranch ? this.currentBranch.uniqueName : ""), from, to },

--- a/apps/web-giddh/src/app/reports/components/sales-register-expand-component/sales.register.expand.component.html
+++ b/apps/web-giddh/src/app/reports/components/sales-register-expand-component/sales.register.expand.component.html
@@ -58,6 +58,7 @@
                     </button>
                     <button
                         matButton="filled"
+                        *ngIf="showExport()"
                         (click)="export()"
                         color="primary"
                         [matTooltip]="commonLocaleData?.app_export"

--- a/apps/web-giddh/src/app/reports/components/sales-register-expand-component/sales.register.expand.component.ts
+++ b/apps/web-giddh/src/app/reports/components/sales-register-expand-component/sales.register.expand.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ViewChild, ElementRef, ChangeDetectorRef, OnDestroy, TemplateRef, Inject } from '@angular/core';
+import { Component, OnInit, ViewChild, ElementRef, ChangeDetectorRef, OnDestroy, TemplateRef, Inject, signal, computed } from '@angular/core';
 import { MatMenuTrigger } from '@angular/material/menu';
 import { Store, select } from '@ngrx/store';
 import { AppState } from '../../../store';
@@ -22,6 +22,7 @@ import { PageEvent } from '@angular/material/paginator';
 import { Configuration } from '../../../app.constant';
 import { environment } from '../../../../environments/environment.generated';
 import { forEach, includes, map, set } from '../../../lodash-optimized';
+import { GroupBy } from '../../constants/reports.constant';
 @Component({
     selector: 'sales-register-expand',
     templateUrl: './sales.register.expand.component.html',
@@ -97,6 +98,15 @@ public voucherNumberInput: UntypedFormControl = new UntypedFormControl();
     public dataSource: MatTableDataSource<any> = new MatTableDataSource();
     /** Holds page size options for pagination */
     public pageSizeOptions: number[] = PAGE_SIZE_OPTIONS;
+    /** Supported groupBy values for export functionality */
+    public supportedExportGroupBy = signal<GroupBy[]>([GroupBy.Duration]);
+    /** Current groupBy value selected in the report form */
+    public currentGroupBy = signal<GroupBy | null>(null);
+    /** Computed signal that determines if export button should be visible based on current groupBy */
+    public showExport = computed(() => {
+        const currentGroupBy = this.currentGroupBy();
+        return this.supportedExportGroupBy().includes(currentGroupBy);
+    });
 
     constructor(
         @Inject(ServiceConfig) private serviceConfig,
@@ -145,6 +155,7 @@ public voucherNumberInput: UntypedFormControl = new UntypedFormControl();
                 this.getDetailedsalesRequestFilter.stateCode = params.stateCode;
                 this.getDetailedsalesRequestFilter.countryCode = params.countryCode;
                 this.getDetailedsalesRequestFilter.accountUniqueNames = registerReportFilters?.accountUniqueNames;
+                this.currentGroupBy.set(params.groupBy);
                 this.params = params;
                 this.setDataPickerDateRange();
                 this.getDetailedSalesReport(this.getDetailedsalesRequestFilter);


### PR DESCRIPTION
## **User description**
https://app.clickup.com/t/86d1mub7d. -[Prod - Export button is coming on sales/purchase register page with sales person filter]


___

## **CodeAnt-AI Description**
Show Export button only for Duration grouping and preserve groupBy in register URLs

### What Changed
- Export button is now visible only when the report is grouped by "Duration"
- When navigating to expanded sales or purchase register pages, the current grouping (groupBy) is included in the URL so the expanded view retains the same grouping
- Expanded register pages read groupBy from the URL and enable or disable the export button accordingly

### Impact
`✅ Clearer export availability for reports grouped by Duration`
`✅ Export option persists when opening expanded register pages`
`✅ Fewer confusing export attempts for unsupported groupings`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Export button now displays conditionally based on the selected report grouping option across purchase registers, sales registers, and report details pages
  * Export functionality intelligently adapts to ensure only supported grouping options can be exported

<!-- end of auto-generated comment: release notes by coderabbit.ai -->