### PR TITLE
Divyanshu | Prod | Getting incorrect response on ledger Statement view

### DIFF
--- a/apps/web-giddh/src/app/ledger/ledger.component.ts
+++ b/apps/web-giddh/src/app/ledger/ledger.component.ts
@@ -1202,7 +1202,6 @@ export class LedgerComponent implements OnInit, OnDestroy {
 
         this.ledgerComponentStore.isLedgerViewChange$.pipe(takeUntil(this.destroyed$)).subscribe(response => {
             if (response) {
-                this.trxRequest.isTView = this.ledgerView === LedgerViewEnum.TView;
                 if (this.isAdvanceSearchImplemented && !this.trxRequest.q?.length) {
                     this.getAdvanceSearchTxn();
                 } else {

--- a/apps/web-giddh/src/app/ledger/ledger.component.ts
+++ b/apps/web-giddh/src/app/ledger/ledger.component.ts
@@ -1202,6 +1202,7 @@ export class LedgerComponent implements OnInit, OnDestroy {
 
         this.ledgerComponentStore.isLedgerViewChange$.pipe(takeUntil(this.destroyed$)).subscribe(response => {
             if (response) {
+                this.trxRequest.isTView = this.ledgerView === LedgerViewEnum.TView;
                 if (this.isAdvanceSearchImplemented && !this.trxRequest.q?.length) {
                     this.getAdvanceSearchTxn();
                 } else {

--- a/apps/web-giddh/src/app/models/api-models/Ledger.ts
+++ b/apps/web-giddh/src/app/models/api-models/Ledger.ts
@@ -249,7 +249,6 @@ export class TransactionsRequest {
     public accountCurrency: boolean = false;
     public branchUniqueName?: string;
     public paginationToken?: string = '';
-    public isTView?: boolean = false;
 }
 
 export interface ReconcileRequest {

--- a/apps/web-giddh/src/app/services/apiurls/ledger.api.ts
+++ b/apps/web-giddh/src/app/services/apiurls/ledger.api.ts
@@ -31,7 +31,7 @@ export const LEDGER_API = {
     MULTIPLE_DELETE: 'company/:companyUniqueName/accounts/:accountUniqueName/entries',
     CURRENCY_CONVERTER: 'company/:companyUniqueName/currency-converter/:fromCurrency/:toCurrency',
     DELETE_BANK_TRANSACTION: 'company/:companyUniqueName/yodlee/eledgers?transactionId=:transactionId',
-    NEW_GET_LEDGER: 'company/:companyUniqueName/accounts/:accountUniqueName/giddh-ledger?count=:count&from=:from&page=:page&q=:q&reversePage=:reversePage&sort=:sort&to=:to&accountCurrency=:accountCurrency&isTView=:isTView',
+    NEW_GET_LEDGER: 'company/:companyUniqueName/accounts/:accountUniqueName/giddh-ledger?count=:count&from=:from&page=:page&q=:q&reversePage=:reversePage&sort=:sort&to=:to&accountCurrency=:accountCurrency',
     GET_BALANCE: 'v2/company/:companyUniqueName/accounts/:accountUniqueName/balance?q=:q&from=:from&to=:to&accountCurrency=:accountCurrency',
     GET_CURRENCY_RATE: 'currency/rate?from=:from&to=:to&date=:date',
 

--- a/apps/web-giddh/src/app/services/ledger.service.ts
+++ b/apps/web-giddh/src/app/services/ledger.service.ts
@@ -82,7 +82,6 @@ export class LedgerService {
             ?.replace(':sort', encodeURIComponent(request.sort))
             ?.replace(':to', encodeURIComponent(request.to))
             ?.replace(':reversePage', request.reversePage?.toString())
-            ?.replace(':isTView', request.isTView?.toString() || '')
             ?.replace(':accountCurrency', request.accountCurrency?.toString());
         if (request.branchUniqueName) {
             request.branchUniqueName = request.branchUniqueName !== this.companyUniqueName ? request.branchUniqueName : '';

--- a/apps/web-giddh/src/app/shared/ledger-statement-t-view/ledger-statement.component.ts
+++ b/apps/web-giddh/src/app/shared/ledger-statement-t-view/ledger-statement.component.ts
@@ -455,7 +455,6 @@ export class LedgerStatementComponent implements OnInit, OnDestroy {
             const toDate = this.to;
             this.trxRequest.from = fromDate;
             this.trxRequest.to = toDate;
-            this.trxRequest.isTView = true;
             if (this.branchUniqueName) {
                 this.trxRequest.branchUniqueName = this.branchUniqueName;
             }


### PR DESCRIPTION
## **User description**
https://app.clickup.com/t/86d1wekz6


___

## **CodeAnt-AI Description**
Remove T-view flag from ledger transaction requests and API

### What Changed
- The ledger transaction request no longer includes the removed T-view flag, and the ledger API URL no longer accepts an isTView parameter
- The ledger statement view stopped explicitly setting a T-view flag when fetching transactions, so all transaction fetches use the same request parameters as other flows
- Observable result: switching ledger view will no longer send a dangling/unsupported T-view parameter with requests, preventing mismatched or incorrect transaction responses after toggling views

### Impact
`✅ Fewer incorrect ledger responses after switching views`
`✅ More consistent transaction lists when toggling ledger view`
`✅ Clearer ledger statements when viewing T-style statements`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
