### PR TITLE
Ankit | Prod | Prod - Customer module is not getting open in expanded form when going on any sub-module

### DIFF
--- a/apps/web-giddh/src/app/shared/helpers/allItems.ts
+++ b/apps/web-giddh/src/app/shared/helpers/allItems.ts
@@ -12,11 +12,13 @@ export interface AllItem {
 export interface AllItems {
     label: string;
     icon: string;
-    items: AllItem[];
+    items?: AllItem[];
     link?: string;
     isActive?: boolean;
     hide?: boolean;
     expandable?: boolean;
     level?: number;
     isExpanded?: boolean;
+    additionalRoutes?: any;
+    additional?: any;
 }

--- a/apps/web-giddh/src/app/shared/primary-sidebar/primary-sidebar.component.html
+++ b/apps/web-giddh/src/app/shared/primary-sidebar/primary-sidebar.component.html
@@ -1,14 +1,14 @@
 <div
     appTranslate
     [file]="'sidebar-menu'"
-    (localeData)="localeData = $event"
-    (commonLocaleData)="commonLocaleData = $event"
+    (localeData)="localeData.set($event)"
+    (commonLocaleData)="commonLocaleData.set($event)"
     (translationComplete)="translationComplete($event)"
 >
     <div class="primary-sidebar py-3 position-relative" (clickOutside)="hidePrimarySidebarCompanyList()">
         <div
             class="company-branch-block pl-4 pr-4 position-relative"
-            [ngClass]="{ 'padding-14': !currentBranch && (currentCompanyBranches$ | async)?.length > 1 }"
+            [ngClass]="{ 'padding-14': !currentBranch() && (currentCompanyBranches$ | async)?.length > 1 }"
         >
             <ul
                 class="list-style-none branch-connection dropdown-toggle"
@@ -22,24 +22,24 @@
                     <h3 class="font-size-15 d-flex flex-column cursor-pointer" [checkPermission]="['MENU', 'MANAGE']">
                         <div class="d-flex flex-column">
                             <div class="d-flex align-items-center">
-                                <span class="company-alice mr-1 text-uppercase">{{ companyInitials }}</span>
+                                <span class="company-alice mr-1 text-uppercase">{{ companyInitials() }}</span>
                                 <span class="d-flex justify-content-between w-100 company-full-name flex-column">
-                                    <span class="company-ellipsis" [matTooltip]="selectedCompanyDetails?.name" matTooltipPosition="above">
-                                        {{ selectedCompanyDetails?.name }}
+                                    <span class="company-ellipsis" [matTooltip]="selectedCompanyDetails()?.name" matTooltipPosition="above">
+                                        {{ selectedCompanyDetails()?.name }}
                                     </span>
-                                    <span class="branch-ellipsis" *ngIf="currentBranch && (currentCompanyBranches$ | async)?.length > 1">
-                                        <span>{{ currentBranch?.name }}</span>
+                                    <span class="branch-ellipsis" *ngIf="currentBranch() && (currentCompanyBranches$ | async)?.length > 1">
+                                        <span>{{ currentBranch()?.name }}</span>
                                     </span>
                                     <i
                                         class="icon-branch-connect"
-                                        *ngIf="currentBranch && (currentCompanyBranches$ | async)?.length > 1"
+                                        *ngIf="currentBranch() && (currentCompanyBranches$ | async)?.length > 1"
                                     ></i>
                                 </span>
                                 <button matIconButton class="ml-1 toggle-btn text-color-inherit">
                                     <i
                                         [ngClass]="{
-                                            'icon-cross font-size-15': showCompanyBranchSwitch,
-                                            'icon-down-new': !showCompanyBranchSwitch,
+                                            'icon-cross font-size-15': showCompanyBranchSwitch(),
+                                            'icon-down-new': !showCompanyBranchSwitch(),
                                         }"
                                     ></i>
                                 </button>
@@ -48,32 +48,32 @@
                     </h3>
                 </li>
             </ul>
-            <div class="dropdown-menu company-branch-nav left-0" *ngIf="showCompanyBranchSwitch">
+            <div class="dropdown-menu company-branch-nav left-0" *ngIf="showCompanyBranchSwitch()">
                 <company-branch
-                    [localeData]="localeData"
-                    [commonLocaleData]="commonLocaleData"
+                    [localeData]="localeData()"
+                    [commonLocaleData]="commonLocaleData()"
                     [isGoToBranch]="isGoToBranch"
                 ></company-branch>
             </div>
         </div>
         <div>
             <div class="wrap-menus mt-3">
-                <div class="account-block mb-4 pl-4 pr-4" *ngIf="accountItemsFromIndexDB?.length > 0">
+                <div class="account-block mb-4 pl-4 pr-4" *ngIf="accountItemsFromIndexDB()?.length > 0">
                     <div class="account-collapse">
                         <p class="font-size-12 d-flex justify-content-between">
-                            {{ localeData?.accounts }}
+                            {{ localeData()?.accounts }}
                             <i class="icon-add-new cursor-pointer" (click)="showManageGroupsModal()"></i>
                         </p>
                         <ul class="left-fixed-header list-style-none font-size-15 lh33 mt-1">
-                            <li *ngFor="let acc of accountItemsFromIndexDB">
+                            <li *ngFor="let acc of accountItemsFromIndexDB()">
                                 <a
                                     aria-label="account"
                                     [routerLinkActive]="['active']"
                                     class="cursor-pointer"
-                                    [class.active]="isLedgerAccSelected && selectedLedgerName === acc?.uniqueName"
+                                    [class.active]="isLedgerAccSelected() && selectedLedgerName() === acc?.uniqueName"
                                     (click)="analyzeAccounts($event, acc); $event.stopPropagation()"
                                 >
-                                    {{ acc.name }} {{ commonLocaleData?.app_ac }}
+                                    {{ acc.name }} {{ commonLocaleData()?.app_ac }}
                                 </a>
                             </li>
                             <li>
@@ -83,14 +83,14 @@
                                     (click)="showNavigationModal()"
                                     class="show-more cursor-pointer"
                                 >
-                                    {{ localeData?.show_more }}
+                                    {{ localeData()?.show_more }}
                                 </a>
                             </li>
                         </ul>
                     </div>
                     <div class="account-dropdown btn-group" [attr.container]="!isOpen ? 'body' : ''">
                         <a href="javascript:void(0);" aria-label="account-icon" id="button-basic-01" type="button" class="dropdown-toggle">
-                            <span [matTooltip]="localeData?.accounts"><i class="icon-accounts-new"></i></span>
+                            <span [matTooltip]="localeData()?.accounts"><i class="icon-accounts-new"></i></span>
                             <i class="icon-right ml-2 font-size-15"></i>
                         </a>
                         <ul
@@ -98,14 +98,14 @@
                             role="menu"
                             aria-labelledby="button-basic-01"
                         >
-                            <li *ngFor="let acc of accountItemsFromIndexDB" role="menuitem">
+                            <li *ngFor="let acc of accountItemsFromIndexDB()" role="menuitem">
                                 <a
                                     href="javascript:void(0);"
                                     aria-label="account item"
                                     routerLink="ledger/{{ acc?.uniqueName }}"
                                     (click)="analyzeAccounts($event, acc)"
                                 >
-                                    {{ acc.name }} {{ commonLocaleData?.app_ac }}
+                                    {{ acc.name }} {{ commonLocaleData()?.app_ac }}
                                 </a>
                             </li>
                             <li role="menuitem">
@@ -115,7 +115,7 @@
                                     (click)="showNavigationModal()"
                                     class="show-more cursor-pointer"
                                 >
-                                    {{ localeData?.show_more }}
+                                    {{ localeData()?.show_more }}
                                 </a>
                             </li>
                         </ul>
@@ -126,7 +126,7 @@
                         <div class="menu-item pl-4 pr-4">
                             <p class="d-flex align-items-center justify-content-between font-size-12">
                                 <span [routerLink]="['/pages/giddh-all-items']" class="d-inline-flex align-items-center cursor-pointer">
-                                    {{ localeData?.menu }}
+                                    {{ localeData()?.menu }}
                                     <i class="icon-down-new ml-1"></i>
                                 </span>
                                 <span class="text-light cursor-pointer" [routerLink]="['/pages/giddh-all-items']">
@@ -160,7 +160,7 @@
                                 role="menu"
                                 class="has-no-child"
                                 [ngClass]="{
-                                    'active': isActiveRoute === node?.link && node?.additional?.queryParams?.tabIndex == queryParams,
+                                    'active': isActiveRoute() === node?.link && node?.additional?.queryParams?.tabIndex == queryParams(),
                                 }"
                             >
                                 <!-- Parent menu without children -->
@@ -201,7 +201,8 @@
                                         </span>
                                         <ng-container
                                             *ngIf="
-                                                !isConsolidatedBranch && (currentOrganizationType === 'BRANCH' || isCompanyWithoutBranch)
+                                                !isConsolidatedBranch() &&
+                                                (currentOrganizationType() === 'BRANCH' || isCompanyWithoutBranch())
                                             "
                                         >
                                             <ng-container
@@ -232,10 +233,11 @@
                                                     class="ml-auto create-new"
                                                     (click)="
                                                         $event.stopPropagation();
-                                                        selectedGroupForCreateAccount = node?.additional?.createNew?.queryParams
-                                                            ?.addCustomer
-                                                            ? 'sundrydebtors'
-                                                            : 'sundrycreditors';
+                                                        selectedGroupForCreateAccount.set(
+                                                            node?.additional?.createNew?.queryParams?.addCustomer
+                                                                ? 'sundrydebtors'
+                                                                : 'sundrycreditors'
+                                                        );
                                                         openAccountAsidePane()
                                                     "
                                                 >
@@ -266,13 +268,13 @@
         <div class="shortcuts">
             <strong>↑</strong>
             <strong>↓</strong>
-            &nbsp; {{ localeData?.to_navigate }}
-            <strong class="ml-2" [attr.aria-label]="commonLocaleData?.app_return">↵</strong>
+            &nbsp; {{ localeData()?.to_navigate }}
+            <strong class="ml-2" [attr.aria-label]="commonLocaleData()?.app_return">↵</strong>
             &nbsp;
-            {{ localeData?.to_select }}
-            <strong class="ml-2" [attr.aria-label]="commonLocaleData?.app_escape">{{ commonLocaleData?.app_esc }}</strong>
+            {{ localeData()?.to_select }}
+            <strong class="ml-2" [attr.aria-label]="commonLocaleData()?.app_escape">{{ commonLocaleData()?.app_esc }}</strong>
             &nbsp;
-            {{ localeData?.to_dismiss }}
+            {{ localeData()?.to_dismiss }}
         </div>
     </ng-template>
 </div>
@@ -282,7 +284,7 @@
     <generic-aside-menu-account
         (closeAsideEvent)="closeAccountAsidePane($event)"
         (closeAccountModal)="closeAccountAsidePane($event)"
-        [selectedGrpUniqueName]="selectedGroupForCreateAccount"
+        [selectedGrpUniqueName]="selectedGroupForCreateAccount()"
         [createAccountFromCommandK]="true"
         (addEvent)="addNewAccount($event)"
     ></generic-aside-menu-account>

--- a/apps/web-giddh/src/app/shared/primary-sidebar/primary-sidebar.component.html
+++ b/apps/web-giddh/src/app/shared/primary-sidebar/primary-sidebar.component.html
@@ -151,7 +151,6 @@
                                     </span>
                                 </div>
                             </cdk-tree-node>
-
                             <!-- Child nodes (leaf nodes) -->
                             <cdk-tree-node
                                 *cdkTreeNodeDef="let node"
@@ -160,7 +159,7 @@
                                 role="menu"
                                 class="has-no-child"
                                 [ngClass]="{
-                                    'active': isActiveRoute() === node?.link && node?.additional?.queryParams?.tabIndex == queryParams(),
+                                    'active': node?.isActive,
                                 }"
                             >
                                 <!-- Parent menu without children -->

--- a/apps/web-giddh/src/app/shared/primary-sidebar/primary-sidebar.component.ts
+++ b/apps/web-giddh/src/app/shared/primary-sidebar/primary-sidebar.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, HostListener, Input, OnChanges, OnDestroy, OnInit, QueryList, SimpleChanges, TemplateRef, ViewChild, ViewChildren } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, computed, HostListener, Input, OnChanges, OnDestroy, OnInit, QueryList, signal, SimpleChanges, TemplateRef, ViewChild, ViewChildren } from '@angular/core';
 import { ActivatedRoute, NavigationEnd, RouteConfigLoadEnd, Router } from '@angular/router';
 import { select, Store } from '@ngrx/store';
 import { firstValueFrom, Observable, ReplaySubject, Subscription } from 'rxjs';
@@ -37,17 +37,17 @@ export class PrimarySidebarComponent implements OnInit, OnChanges, OnDestroy {
     /** update IndexDb flags observable **/
     public updateIndexDbSuccess$: Observable<boolean>;
     /** Stores the branch list of a company */
-    public currentCompanyBranches: Array<any>;
+    public currentCompanyBranches = signal<Array<any>>([]);
     /** Stores the active ledger account details */
     public activeAccount$: Observable<AccountResponse>;
     /** Stores the active ledger account details */
-    public activeAccount: AccountResponse;
+    public activeAccount = signal<AccountResponse>(null);
     /** Stores the active company details */
-    public selectedCompanyDetails: CompanyResponse;
+    public selectedCompanyDetails = signal<CompanyResponse>(null);
     /** Current organization type */
-    public currentOrganizationType: OrganizationType;
+    public currentOrganizationType = signal<OrganizationType>(null);
     /** Stores the details of the current branch */
-    public currentBranch: any;
+    public currentBranch = signal<any>(null);
     /** Subject to unsubscribe from listeners */
     private destroyed$: ReplaySubject<boolean> = new ReplaySubject(1);
     /** Active company details for indexedDB */
@@ -55,17 +55,17 @@ export class PrimarySidebarComponent implements OnInit, OnChanges, OnDestroy {
     /** Stores the navigation modal event subscriptions */
     private subscriptions: Subscription[] = [];
     /** Current ledger name */
-    public selectedLedgerName: string;
+    public selectedLedgerName = signal<string>('');
     /** True, if ledger account is selected */
-    public isLedgerAccSelected: boolean = false;
+    public isLedgerAccSelected = signal<boolean>(false);
     /** Holds the navigated accounts */
-    public accountItemsFromIndexDB: any[] = [];
+    public accountItemsFromIndexDB = signal<any[]>([]);
     /** Company name initials (upto 2 characters) */
-    public companyInitials: any = '';
+    public companyInitials = signal<string>('');
     /** Stores the total company list */
-    public companyList: CompanyResponse[] = [];
+    public companyList = signal<CompanyResponse[]>([]);
     /** Stores all the menu items to be shown */
-    public allItems: AllItems[] = [];
+    public allItems = signal<AllItems[]>([]);
     /** True, if sidebar needs to be shown */
     @Input() public isOpen: boolean = false;
     /** True, if sidebar needs to be shown */
@@ -81,38 +81,38 @@ export class PrimarySidebarComponent implements OnInit, OnChanges, OnDestroy {
     /** Holds the template reference of generic aside menu account */
     @ViewChild('genericAsideMenuAccountTemplate', { static: true }) public genericAsideMenuAccountTemplate: TemplateRef<any>;
     /* This will hold local JSON data */
-    public localeData: any = {};
+    public localeData = signal<any>({});
     /* This will hold common JSON data */
-    public commonLocaleData: any = {};
+    public commonLocaleData = signal<any>({});
     /** This holds the active locale */
-    public activeLocale: string = "";
+    public activeLocale = signal<string>('');
     /** This will open company branch switch dropdown */
-    public showCompanyBranchSwitch: boolean = false;
+    public showCompanyBranchSwitch = signal<boolean>(false);
     /** This will holds true if we added ledger item in local db once */
-    public isItemAdded: boolean = false;
+    public isItemAdded = signal<boolean>(false);
     /** This will hold group unique name from CMD+k for creating account */
-    public selectedGroupForCreateAccount: any = '';
+    public selectedGroupForCreateAccount = signal<string>('');
     /* Observable for create account success */
     private createAccountIsSuccess$: Observable<boolean>;
     /* This will hold the active route url */
-    public isActiveRoute: string;
+    public isActiveRoute = signal<string>('');
     /** True if account has unsaved changes */
-    public hasUnsavedChanges: boolean = false;
+    public hasUnsavedChanges = signal<boolean>(false);
     public commandkDialogRef: MatDialogRef<any>;
     /** Holds true if company has no branch */
-    public isCompanyWithoutBranch: boolean = false;
+    public isCompanyWithoutBranch = signal<boolean>(false);
     /** True if consolidated branch */
-    public isConsolidatedBranch: boolean;
+    public isConsolidatedBranch = signal<boolean>(false);
     /** Holds generic aside menu account dialog Ref */
     public genericAsideMenuAccountDialogRef: MatDialogRef<any>;
     /** Hold current url */
-    private currentUrl: string = "";
+    private currentUrl = signal<string>('');
     /** Hold previous url */
-    private previousUrl: string = "";
+    private previousUrl = signal<string>('');
     /** Holds active company unique name */
     public ledgerAccount$: Observable<AccountResponse | AccountResponseV2>;
     /** Holds current url queryParams */
-    public queryParams: any = {};
+    public queryParams = signal<any>({});
     /** DataSource for the tree */
     public dataSource = new ArrayDataSource([]);
     /** Function to check if a node has children */
@@ -144,28 +144,28 @@ export class PrimarySidebarComponent implements OnInit, OnChanges, OnDestroy {
             if (organization && organization.details && organization.details.branchDetails) {
                 this.generalService.currentBranchUniqueName = organization.details.branchDetails.uniqueName;
                 this.generalService.currentOrganizationType = organization.type;
-                this.currentOrganizationType = organization.type;
+                this.currentOrganizationType.set(organization.type);
                 if (this.generalService.currentBranchUniqueName) {
                     this.currentCompanyBranches$.pipe(take(1)).subscribe(response => {
                         if (response) {
-                            this.currentBranch = response.find(branch => (branch?.uniqueName === this.generalService.currentBranchUniqueName));
+                            this.currentBranch.set(response.find(branch => (branch?.uniqueName === this.generalService.currentBranchUniqueName)));
                             if (!this.activeCompanyForDb) {
                                 this.activeCompanyForDb = new CompAidataModel();
                             }
-                            this.activeCompanyForDb.name = this.currentBranch ? this.currentBranch.name : '';
-                            this.activeCompanyForDb.uniqueName = this.currentBranch ? this.currentBranch.uniqueName : ''
+                            this.activeCompanyForDb.name = this.currentBranch() ? this.currentBranch().name : '';
+                            this.activeCompanyForDb.uniqueName = this.currentBranch() ? this.currentBranch().uniqueName : ''
                         }
                     });
                 }
             } else {
                 this.generalService.currentOrganizationType = OrganizationType.Company;
-                this.currentOrganizationType = OrganizationType.Company;
+                this.currentOrganizationType.set(OrganizationType.Company);
             }
         });
         this.createAccountIsSuccess$ = this.store.pipe(select(state => state.sales.createAccountSuccess), takeUntil(this.destroyed$));
 
         this.store.pipe(select(state => state.groupwithaccounts.hasUnsavedChanges), takeUntil(this.destroyed$)).subscribe(response => {
-            this.hasUnsavedChanges = response;
+            this.hasUnsavedChanges.set(response);
         });
     }
 
@@ -175,7 +175,7 @@ export class PrimarySidebarComponent implements OnInit, OnChanges, OnDestroy {
         if ((event.metaKey || event.ctrlKey) && (event.which === 75 || event.which === 71)) {
             event.preventDefault();
             event.stopPropagation();
-            if (this.companyList?.length > 0) {
+            if (this.companyList()?.length > 0) {
                 if (this.commandkDialogRef && this.dialog.getDialogById(this.commandkDialogRef.id)) {
                     this.commandkDialogRef.close()
                 }
@@ -195,14 +195,14 @@ export class PrimarySidebarComponent implements OnInit, OnChanges, OnDestroy {
         if (changes?.isGoToBranch?.currentValue) {
             this.openCompanyBranchDropdown();
         }
-        if ('apiMenuItems' in changes && changes.apiMenuItems.previousValue !== changes.apiMenuItems.currentValue && changes.apiMenuItems.currentValue.length && this.localeData?.page_heading) {
+        if ('apiMenuItems' in changes && changes.apiMenuItems.previousValue !== changes.apiMenuItems.currentValue && changes.apiMenuItems.currentValue.length && this.localeData()?.page_heading) {
             this.getVisibleMenuItems();
         }
 
          // Additional check: Try to load menu items if we have apiMenuItems but no allItems yet
-        if ('apiMenuItems' in changes && changes.apiMenuItems.currentValue.length && (!this.allItems || this.allItems.length === 0)) {
+        if ('apiMenuItems' in changes && changes.apiMenuItems.currentValue.length && (!this.allItems() || this.allItems().length === 0)) {
             setTimeout(() => {
-                if (this.localeData?.page_heading && this.apiMenuItems.length > 0) {
+                if (this.localeData()?.page_heading && this.apiMenuItems.length > 0) {
                     this.getVisibleMenuItems();
                 }
             }, 100);
@@ -235,12 +235,12 @@ export class PrimarySidebarComponent implements OnInit, OnChanges, OnDestroy {
 
         /**Subscribe to queryParams */
         this.activateRoute.queryParams.pipe(takeUntil(this.destroyed$)).subscribe((queryParams: any) => {
-            this.queryParams = queryParams?.tabIndex;
+            this.queryParams.set(queryParams?.tabIndex);
         })
         /** If this is true, it means we are in branch consolidated mode.  */
         this.store.pipe(select(select => select.branchConsolidated), takeUntil(this.destroyed$)).subscribe(response => {
             if (response) {
-                this.isConsolidatedBranch = response.isBranchConsolidated;
+                this.isConsolidatedBranch.set(response.isBranchConsolidated);
             }
         });
         // Reset old stored application date
@@ -248,12 +248,12 @@ export class PrimarySidebarComponent implements OnInit, OnChanges, OnDestroy {
         this.updateIndexDbSuccess$ = this.store.pipe(select(appStore => appStore.general.updateIndexDbComplete), takeUntil(this.destroyed$))
         this.store.pipe(select(state => state.session.activeCompany), takeUntil(this.destroyed$)).subscribe(selectedCmp => {
             if (selectedCmp && selectedCmp?.uniqueName === this.generalService.companyUniqueName) {
-                this.selectedCompanyDetails = selectedCmp;
-                this.companyInitials = this.generalService.getInitialsFromString(selectedCmp.name);
+                this.selectedCompanyDetails.set(selectedCmp);
+                this.companyInitials.set(this.generalService.getInitialsFromString(selectedCmp.name));
 
                 this.activeCompanyForDb = new CompAidataModel();
                 if (this.generalService.currentOrganizationType === OrganizationType.Branch) {
-                    this.activeCompanyForDb.name = this.currentBranch ? this.currentBranch.name : '';
+                    this.activeCompanyForDb.name = this.currentBranch() ? this.currentBranch().name : '';
                     this.activeCompanyForDb.uniqueName = this.generalService.currentBranchUniqueName;
                 } else {
                     this.activeCompanyForDb.name = selectedCmp.name;
@@ -263,9 +263,9 @@ export class PrimarySidebarComponent implements OnInit, OnChanges, OnDestroy {
                     this.dbService.getAllItems(this.activeCompanyForDb?.uniqueName, 'accounts').subscribe(accountList => {
                         if (accountList?.length) {
                             if (window.innerWidth > 1440 && window.innerHeight > 717) {
-                                this.accountItemsFromIndexDB = accountList.slice(0, 7);
+                                this.accountItemsFromIndexDB.set(accountList.slice(0, 7));
                             } else {
-                                this.accountItemsFromIndexDB = accountList.slice(0, 5);
+                                this.accountItemsFromIndexDB.set(accountList.slice(0, 5));
                             }
                         }
                         this.changeDetectorRef.detectChanges();
@@ -275,18 +275,18 @@ export class PrimarySidebarComponent implements OnInit, OnChanges, OnDestroy {
         });
         this.currentCompanyBranches$.subscribe(response => {
             if (response && response.length) {
-                this.isCompanyWithoutBranch = response?.length === 1;
-                this.currentCompanyBranches = response;
+                this.isCompanyWithoutBranch.set(response?.length === 1);
+                this.currentCompanyBranches.set(response);
                 if (this.generalService.currentBranchUniqueName) {
-                    this.currentBranch = response.find(branch => (this.generalService.currentBranchUniqueName === branch?.uniqueName)) || {};
+                    this.currentBranch.set(response.find(branch => (this.generalService.currentBranchUniqueName === branch?.uniqueName)) || {});
                     if (!this.activeCompanyForDb) {
                         this.activeCompanyForDb = new CompAidataModel();
                     }
 
-                    this.activeCompanyForDb.name = this.currentBranch ? this.currentBranch.name : '';
-                    this.activeCompanyForDb.uniqueName = this.currentBranch ? this.currentBranch.uniqueName : ''
+                    this.activeCompanyForDb.name = this.currentBranch() ? this.currentBranch().name : '';
+                    this.activeCompanyForDb.uniqueName = this.currentBranch() ? this.currentBranch().uniqueName : ''
                 } else {
-                    this.currentBranch = '';
+                    this.currentBranch.set('');
                 }
             }
         });
@@ -296,7 +296,7 @@ export class PrimarySidebarComponent implements OnInit, OnChanges, OnDestroy {
             }
 
             let orderedCompanies = orderBy(companies, 'name');
-            this.companyList = orderedCompanies;
+            this.companyList.set(orderedCompanies);
         });
         this.updateIndexDbSuccess$.subscribe(res => {
             if (res) {
@@ -311,29 +311,32 @@ export class PrimarySidebarComponent implements OnInit, OnChanges, OnDestroy {
 
         this.router.events.pipe(takeUntil(this.destroyed$)).subscribe(event => {
             if (event instanceof NavigationEnd || event instanceof RouteConfigLoadEnd) {
-                this.previousUrl = this.currentUrl; // store old before updating
-                this.currentUrl = this.getCleanCurrentUrl(); // always clean
+                this.previousUrl.set(this.currentUrl()); // store old before updating
+                this.currentUrl.set(this.getCleanCurrentUrl()); // always clean
                 // Use the clean currentUrl for baseUrl instead of parsing router.url again
-                const baseUrl = this.currentUrl;
-                this.isActiveRoute = baseUrl;
-                (Array.isArray(this.allItems) ? this.allItems : []).forEach(item => item.isActive = (item.link === decodeURI(baseUrl) || item?.items?.some((subItem: AllItem) => {
-                    if (subItem.link === decodeURI(baseUrl) || subItem?.additionalRoutes?.includes(decodeURI(baseUrl))) {
-                        return true;
-                    }
-                })));
-
+                const baseUrl = this.currentUrl();
+                this.isActiveRoute.set(baseUrl);
+                this.updateActiveStates(baseUrl);
                 this.changeDetectorRef.detectChanges();
             }
         });
 
+        // Initialize active route on component load (for page reload scenarios)
+        const initialUrl = this.getCleanCurrentUrl();
+        this.currentUrl.set(initialUrl);
+        this.isActiveRoute.set(initialUrl);
+        if (this.allItems()?.length > 0) {
+            this.updateActiveStates(initialUrl);
+        }
+
         this.store.pipe(select(state => state.session.currentLocale), takeUntil(this.destroyed$)).subscribe(response => {
-            if (this.activeLocale && this.activeLocale !== response?.value) {
+            if (this.activeLocale() && this.activeLocale() !== response?.value) {
                 this.localeService.getLocale('sidebar-menu', response?.value).subscribe(response => {
-                    this.localeData = response;
+                    this.localeData.set(response);
                     this.translationComplete(true);
                 });
             }
-            this.activeLocale = response?.value;
+            this.activeLocale.set(response?.value);
         });
         // if invalid menu item clicked then navigate to default route and remove invalid entry from db
         this.generalService.invalidMenuClicked.pipe(takeUntil(this.destroyed$)).subscribe(data => {
@@ -345,10 +348,10 @@ export class PrimarySidebarComponent implements OnInit, OnChanges, OnDestroy {
         if (this.router.url.includes("/ledger")) {
             this.activeAccount$.pipe(takeUntil(this.destroyed$)).subscribe(account => {
                 if (account) {
-                    this.activeAccount = account;
+                    this.activeAccount.set(account);
                 }
-                if (account && !this.isItemAdded) {
-                    this.isItemAdded = true;
+                if (account && !this.isItemAdded()) {
+                    this.isItemAdded.set(true);
                     // save data to db
                     let item: any = {};
                     item.time = +new Date();
@@ -361,7 +364,7 @@ export class PrimarySidebarComponent implements OnInit, OnChanges, OnDestroy {
             });
 
             this.ledgerAccount$.pipe(takeUntil(this.destroyed$)).subscribe(account => {
-                if (account && account.uniqueName === this.activeAccount?.uniqueName) {
+                if (account && account.uniqueName === this.activeAccount()?.uniqueName) {
                     let item: any = {};
                     item.uniqueName = account?.uniqueName;
                     item.name = account.name;
@@ -500,7 +503,7 @@ export class PrimarySidebarComponent implements OnInit, OnChanges, OnDestroy {
                 // direct account scenario
                 let url = `ledger/${item.uniqueName}`;
                 // Get the redirect URL and clean it if it contains query parameters
-                let redirectUrl = this.previousUrl || this.currentUrl || '/';
+                let redirectUrl = this.previousUrl() || this.currentUrl() || '/';
                 // If redirectUrl contains query parameters, extract only the base path
                 if (redirectUrl.includes('?')) {
                     redirectUrl = redirectUrl.split('?')[0];
@@ -542,7 +545,7 @@ export class PrimarySidebarComponent implements OnInit, OnChanges, OnDestroy {
      * @memberof PrimarySidebarComponent
      */
     public handleItemClick(item: AllItem): void {
-        if (item?.label === this.commonLocaleData?.app_master) {
+        if (item?.label === this.commonLocaleData()?.app_master) {
             this.store.dispatch(this.groupWithAction.OpenAddAndManageFromOutside(''));
         }
     }
@@ -570,10 +573,10 @@ export class PrimarySidebarComponent implements OnInit, OnChanges, OnDestroy {
      */
     private doEntryInDb(entity: string, item: IUlist, fromInvalidState: { next: IUlist, previous: IUlist } = null): void {
         if (entity === 'menus') {
-            this.isLedgerAccSelected = false;
+            this.isLedgerAccSelected.set(false);
         } else if (entity === 'accounts') {
-            this.isLedgerAccSelected = true;
-            this.selectedLedgerName = item?.uniqueName;
+            this.isLedgerAccSelected.set(true);
+            this.selectedLedgerName.set(item?.uniqueName);
         }
 
         if (this.activeCompanyForDb && this.activeCompanyForDb.uniqueName) {
@@ -600,7 +603,7 @@ export class PrimarySidebarComponent implements OnInit, OnChanges, OnDestroy {
                     branches = response || [];
                 });
                 this.dbService.addItem(this.activeCompanyForDb.uniqueName, entity, item, fromInvalidState, isSmallScreen,
-                    this.currentOrganizationType === OrganizationType.Company && branches?.length > 1).then((res) => {
+                    this.currentOrganizationType() === OrganizationType.Company && branches?.length > 1).then((res) => {
                         this.findListFromDb(res);
                     }, (err: any) => {
 
@@ -628,9 +631,9 @@ export class PrimarySidebarComponent implements OnInit, OnChanges, OnDestroy {
      * @memberof PrimarySidebarComponent
      */
     private getVisibleMenuItems(): void {
-        this.allItems = this.generalService.getVisibleMenuItems("sidebar", this.apiMenuItems, this.localeData?.items);
+        this.allItems.set(this.generalService.getVisibleMenuItems("sidebar", this.apiMenuItems, this.localeData()?.items));
         const flattenedItems: AllItems[] = [];
-        this.allItems?.filter(item => !item.hide)?.forEach((menu, index) => {
+        this.allItems()?.filter(item => !item.hide)?.forEach((menu, index) => {
             menu['expandable'] = menu?.items?.length > 0;
             menu['level'] = 0;
             menu['isExpanded'] = false;
@@ -651,9 +654,68 @@ export class PrimarySidebarComponent implements OnInit, OnChanges, OnDestroy {
                 flattenedItems.push(childMenu);
             });
         });
-        this.allItems = flattenedItems;
-        this.dataSource = new ArrayDataSource(this.allItems);
+        this.allItems.set(flattenedItems);
+        this.dataSource = new ArrayDataSource(this.allItems());
+        // Update active states after menu items are loaded
+        if (this.isActiveRoute()) {
+            this.updateActiveStates(this.isActiveRoute());
+        }
         this.changeDetectorRef.detectChanges();
+    }
+
+    /**
+     * Update active states for menu items based on current route
+     *
+     * @private
+     * @param {string} baseUrl Current route URL
+     * @memberof PrimarySidebarComponent
+     */
+    private updateActiveStates(baseUrl: string): void {
+        const items = this.allItems();
+        if (!Array.isArray(items) || items.length === 0) {
+            return;
+        }
+        
+        // First pass: mark active items
+        items.forEach(item => {
+            item.isActive = (item.link === decodeURI(baseUrl) || item?.additionalRoutes?.includes(decodeURI(baseUrl)));
+        });
+        
+        // Second pass: collapse all parents first (accordion behavior)
+        items.forEach(item => {
+            if (item.level === 0) {
+                item.isExpanded = false;
+            }
+        });
+        
+        // Third pass: expand only the parent with active child
+        items.forEach((item, index) => {
+            if (item.level === 0 && item.expandable) {
+                // Check if any following level 1 items (children) are active
+                let hasActiveChild = false;
+                for (let i = index + 1; i < items.length; i++) {
+                    const nextItem = items[i];
+                    // Stop when we hit another level 0 item (next parent)
+                    if (nextItem.level === 0) {
+                        break;
+                    }
+                    // Check if this child is active
+                    if (nextItem.level === 1 && nextItem.isActive) {
+                        hasActiveChild = true;
+                        break;
+                    }
+                }
+                
+                // Auto-expand parent if it has an active child (only one will be expanded)
+                if (hasActiveChild) {
+                    item.isExpanded = true;
+                }
+            }
+        });
+        
+        // Trigger signal update by setting the array again
+        this.allItems.set([...items]);
+        this.dataSource = new ArrayDataSource(this.allItems());
     }
 
     /**
@@ -663,7 +725,7 @@ export class PrimarySidebarComponent implements OnInit, OnChanges, OnDestroy {
      * @memberof PrimarySidebarComponent
      */
     public openCompanyBranchDropdown(): void {
-        this.showCompanyBranchSwitch = !this.showCompanyBranchSwitch;
+        this.showCompanyBranchSwitch.set(!this.showCompanyBranchSwitch());
     }
 
     /**
@@ -703,8 +765,8 @@ export class PrimarySidebarComponent implements OnInit, OnChanges, OnDestroy {
      * @memberof PrimarySidebarComponent
      */
     public hidePrimarySidebarCompanyList(): void {
-        if (this.showCompanyBranchSwitch) {
-            this.showCompanyBranchSwitch = false;
+        if (this.showCompanyBranchSwitch()) {
+            this.showCompanyBranchSwitch.set(false);
         }
     }
 
@@ -727,10 +789,10 @@ export class PrimarySidebarComponent implements OnInit, OnChanges, OnDestroy {
      * @memberof PrimarySidebarComponent
      */
     public getParentNode(node: any): any {
-        const nodeIndex = this.allItems.indexOf(node);
+        const nodeIndex = this.allItems().indexOf(node);
         for (let i = nodeIndex - 1; i >= 0; i--) {
-          if (this.allItems[i].level === node.level - 1) {
-            return this.allItems[i];
+          if (this.allItems()[i].level === node.level - 1) {
+            return this.allItems()[i];
           }
         }
         return null;
@@ -766,14 +828,14 @@ export class PrimarySidebarComponent implements OnInit, OnChanges, OnDestroy {
           if (node.isExpanded) {
             node.isExpanded = false;
           } else {
-            (Array.isArray(this.allItems) ? this.allItems : []).forEach(item => {
+            (Array.isArray(this.allItems()) ? this.allItems() : []).forEach(item => {
               if (item.level === 0 && item !== node) {
                 item.isExpanded = false;
               }
             });
             node.isExpanded = node.expandable;
           }
-          this.dataSource = new ArrayDataSource(this.allItems);
+          this.dataSource = new ArrayDataSource(this.allItems());
         }
       }
 

--- a/apps/web-giddh/src/app/shared/primary-sidebar/primary-sidebar.component.ts
+++ b/apps/web-giddh/src/app/shared/primary-sidebar/primary-sidebar.component.ts
@@ -413,7 +413,7 @@ export class PrimarySidebarComponent implements OnInit, OnChanges, OnDestroy {
             this.genericAsideMenuAccountDialogRef?.close();
             this.showManageGroupsModal(e[1]?.name);
         } else if (e[0] === "account") {
-            this.selectedGroupForCreateAccount = e[1]?.uniqueName;
+            this.selectedGroupForCreateAccount.set(e[1]?.uniqueName);
             this.openAccountAsidePane();
         }
     }
@@ -434,9 +434,9 @@ export class PrimarySidebarComponent implements OnInit, OnChanges, OnDestroy {
         }
         if (dbResult) {
             if (window.innerWidth > 1440 && window.innerHeight > 717) {
-                this.accountItemsFromIndexDB = (dbResult && dbResult?.aidata) ? slice(dbResult.aidata.accounts, 0, 7) : [];
+                this.accountItemsFromIndexDB.set((dbResult && dbResult?.aidata) ? slice(dbResult.aidata.accounts, 0, 7) : []);
             } else {
-                this.accountItemsFromIndexDB = (dbResult && dbResult?.aidata) ? slice(dbResult.aidata.accounts, 0, 5) : [];
+                this.accountItemsFromIndexDB.set((dbResult && dbResult?.aidata) ? slice(dbResult.aidata.accounts, 0, 5) : []);
             }
         } else {
             if (!this.activeCompanyForDb) {

--- a/apps/web-giddh/src/app/shared/primary-sidebar/primary-sidebar.component.ts
+++ b/apps/web-giddh/src/app/shared/primary-sidebar/primary-sidebar.component.ts
@@ -235,7 +235,7 @@ export class PrimarySidebarComponent implements OnInit, OnChanges, OnDestroy {
 
         /**Subscribe to queryParams */
         this.activateRoute.queryParams.pipe(takeUntil(this.destroyed$)).subscribe((queryParams: any) => {
-            this.queryParams.set(queryParams?.tabIndex);
+            this.queryParams.set(queryParams);
         })
         /** If this is true, it means we are in branch consolidated mode.  */
         this.store.pipe(select(select => select.branchConsolidated), takeUntil(this.destroyed$)).subscribe(response => {
@@ -676,9 +676,23 @@ export class PrimarySidebarComponent implements OnInit, OnChanges, OnDestroy {
             return;
         }
         
+        // Extract base path without query parameters for comparison
+        const baseUrlWithoutParams = decodeURI(baseUrl).split('?')[0];
+        const currentQueryParams = this.queryParams();
+        
         // First pass: mark active items
         items.forEach(item => {
-            item.isActive = (item.link === decodeURI(baseUrl) || item?.additionalRoutes?.includes(decodeURI(baseUrl)));
+            const itemLink = item.link ? item.link.split('?')[0] : '';
+            let isPathMatch = baseUrlWithoutParams.includes(itemLink) || item?.additionalRoutes?.some(route => route.split('?')[0] === baseUrlWithoutParams);
+            
+            // If item has query params defined, also check if they match current query params
+            if (isPathMatch && item?.additional?.queryParams && currentQueryParams?.tab) {
+                const itemQueryParams = item.additional.queryParams.tabIndex;
+                // Check if all item query params match current query params
+                isPathMatch = itemQueryParams === Number(currentQueryParams?.tabIndex);
+            }
+            
+            item.isActive = isPathMatch;
         });
         
         // Second pass: collapse all parents first (accordion behavior)


### PR DESCRIPTION
## **User description**
https://app.clickup.com/t/86d1mudbj


___

## **CodeAnt-AI Description**
**Open parent menu for active sub-module and keep sidebar state consistent on load**

### What Changed
- Sidebar now reliably highlights the correct menu or account after navigation or page reload and automatically expands the parent menu so the active sub-module is visible.
- Parent menus behave like an accordion: only one parent is expanded at a time and expanding a parent collapses others.
- Company/branch display, account lists, and localized labels reflect current company, branch and locale on load and when changed; recent accounts and ledger selection persist and navigate with a proper redirect URL.
- Command palette (Cmd/Ctrl+K) and quick account actions show and use up-to-date company/account state; account lists and "show more" links render correctly.

### Impact
`✅ Fewer clicks to find active sub-module`
`✅ Clearer active menu after page reload`
`✅ Predictable branch and account navigation`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
