### PR TITLE
Ankit | Test | Prod - Customer module is not getting open in expanded form when going on any sub-module

### DIFF
--- a/apps/web-giddh/src/app/shared/primary-sidebar/primary-sidebar.component.html
+++ b/apps/web-giddh/src/app/shared/primary-sidebar/primary-sidebar.component.html
@@ -151,7 +151,6 @@
                                     </span>
                                 </div>
                             </cdk-tree-node>
-
                             <!-- Child nodes (leaf nodes) -->
                             <cdk-tree-node
                                 *cdkTreeNodeDef="let node"
@@ -160,7 +159,7 @@
                                 role="menu"
                                 class="has-no-child"
                                 [ngClass]="{
-                                    'active': isActiveRoute() === node?.link && node?.additional?.queryParams?.tabIndex == queryParams(),
+                                    'active': node?.isActive,
                                 }"
                             >
                                 <!-- Parent menu without children -->

--- a/apps/web-giddh/src/app/shared/primary-sidebar/primary-sidebar.component.ts
+++ b/apps/web-giddh/src/app/shared/primary-sidebar/primary-sidebar.component.ts
@@ -413,7 +413,7 @@ export class PrimarySidebarComponent implements OnInit, OnChanges, OnDestroy {
             this.genericAsideMenuAccountDialogRef?.close();
             this.showManageGroupsModal(e[1]?.name);
         } else if (e[0] === "account") {
-            this.selectedGroupForCreateAccount = e[1]?.uniqueName;
+            this.selectedGroupForCreateAccount.set(e[1]?.uniqueName);
             this.openAccountAsidePane();
         }
     }
@@ -434,9 +434,9 @@ export class PrimarySidebarComponent implements OnInit, OnChanges, OnDestroy {
         }
         if (dbResult) {
             if (window.innerWidth > 1440 && window.innerHeight > 717) {
-                this.accountItemsFromIndexDB = (dbResult && dbResult?.aidata) ? slice(dbResult.aidata.accounts, 0, 7) : [];
+                this.accountItemsFromIndexDB.set((dbResult && dbResult?.aidata) ? slice(dbResult.aidata.accounts, 0, 7) : []);
             } else {
-                this.accountItemsFromIndexDB = (dbResult && dbResult?.aidata) ? slice(dbResult.aidata.accounts, 0, 5) : [];
+                this.accountItemsFromIndexDB.set((dbResult && dbResult?.aidata) ? slice(dbResult.aidata.accounts, 0, 5) : []);
             }
         } else {
             if (!this.activeCompanyForDb) {

--- a/apps/web-giddh/src/app/shared/primary-sidebar/primary-sidebar.component.ts
+++ b/apps/web-giddh/src/app/shared/primary-sidebar/primary-sidebar.component.ts
@@ -235,7 +235,7 @@ export class PrimarySidebarComponent implements OnInit, OnChanges, OnDestroy {
 
         /**Subscribe to queryParams */
         this.activateRoute.queryParams.pipe(takeUntil(this.destroyed$)).subscribe((queryParams: any) => {
-            this.queryParams.set(queryParams?.tabIndex);
+            this.queryParams.set(queryParams);
         })
         /** If this is true, it means we are in branch consolidated mode.  */
         this.store.pipe(select(select => select.branchConsolidated), takeUntil(this.destroyed$)).subscribe(response => {
@@ -676,9 +676,23 @@ export class PrimarySidebarComponent implements OnInit, OnChanges, OnDestroy {
             return;
         }
         
+        // Extract base path without query parameters for comparison
+        const baseUrlWithoutParams = decodeURI(baseUrl).split('?')[0];
+        const currentQueryParams = this.queryParams();
+        
         // First pass: mark active items
         items.forEach(item => {
-            item.isActive = (item.link === decodeURI(baseUrl) || item?.additionalRoutes?.includes(decodeURI(baseUrl)));
+            const itemLink = item.link ? item.link.split('?')[0] : '';
+            let isPathMatch = baseUrlWithoutParams.includes(itemLink) || item?.additionalRoutes?.some(route => route.split('?')[0] === baseUrlWithoutParams);
+            
+            // If item has query params defined, also check if they match current query params
+            if (isPathMatch && item?.additional?.queryParams && currentQueryParams?.tab) {
+                const itemQueryParams = item.additional.queryParams.tabIndex;
+                // Check if all item query params match current query params
+                isPathMatch = itemQueryParams === Number(currentQueryParams?.tabIndex);
+            }
+            
+            item.isActive = isPathMatch;
         });
         
         // Second pass: collapse all parents first (accordion behavior)


### PR DESCRIPTION
## **User description**
https://app.clickup.com/t/86d1mudbj


___

## **CodeAnt-AI Description**
Select and expand correct sidebar item based on route and tab query param

### What Changed
- Sidebar now marks a menu item active by comparing the route path without query parameters and by matching the item's tabIndex against the current tab query param, so the correct item becomes active on navigation.
- Parent menu sections automatically expand to reveal the active child when navigating to sub-modules, fixing cases where a customer sub-module opened but the parent stayed collapsed.
- Component now stores the full route query parameters and updates account/group selection via reactive signals so tab-based navigation and account creation flows reflect immediately in the sidebar.
- Account list loaded from local DB updates the visible accounts immediately after load, improving consistency on different screen sizes.

### Impact
`✅ Correct sidebar expansion when opening sub-modules`
`✅ Correct active menu selection for tabbed pages`
`✅ Faster visible account list updates`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved active state detection in the primary sidebar to accurately reflect the current navigation context.
  * Enhanced tab and query parameter tracking for more reliable navigation state synchronization.
  * Refined nested accordion behavior in sidebar navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->