### PR TITLE
Ankit | Test | UI :- VERSION 1to4 Purchase Register Overview/Detailed - Country & State Filter

### DIFF
--- a/apps/web-giddh/src/app/reports/components/purchase-register-component/purchase.register.component.ts
+++ b/apps/web-giddh/src/app/reports/components/purchase-register-component/purchase.register.component.ts
@@ -301,6 +301,32 @@ constructor(
                 this.selectedDateRangeUi = dayjs(response[0]).format(GIDDH_NEW_DATE_FORMAT_UI) + " - " + dayjs(response[1]).format(GIDDH_NEW_DATE_FORMAT_UI);
             }
         });
+        this.store.pipe(
+            select(state => state.general.states),
+            filter(Boolean),
+            takeUntil(this.destroyed$)
+        ).subscribe(states => {
+            if (states && (states.stateList ?? states.countyList)) {
+                this.stateList.set((states.stateList ?? states.countyList).map(state => ({
+                    label: state.name,
+                    value: state.code
+                })));
+                this.filteredStateList.set(this.stateList());
+            }
+        });
+
+        // Subscribe to countryCode changes to automatically load states
+        this.reportForm.get('countryCode')?.valueChanges.pipe(
+            filter(Boolean),
+            takeUntil(this.destroyed$)
+        ).subscribe(countryCode => {
+            if (countryCode) {
+                this.loadStates(countryCode);
+            } else {
+                this.stateList.set([]);
+                this.filteredStateList.set([]);
+            }
+        });
     }
     /**
      * Handle group by change
@@ -313,14 +339,14 @@ constructor(
         this.reportForm.get('countryCodes')?.setValue([]);
         this.reportForm.get('stateCodes')?.setValue([]);
 
-        if (response?.value === GroupBy.SalesPerson) {
+        if (response?.value && response.value !== GroupBy.Duration) {
             this.dateRange.from = dayjs(this.selectedDateRange?.startDate).format(GIDDH_DATE_FORMAT);
             this.dateRange.to = dayjs(this.selectedDateRange?.endDate).format(GIDDH_DATE_FORMAT);
+            if (response.value === GroupBy.State) {
+                this.reportForm.get('countryCode')?.setValue(this.activeCompany.countryV2?.alpha2CountryCode);
+            }
             this.getPurchaseRegister(this.dateRange.from, this.dateRange.to);
-        } else if (response?.value === GroupBy.State || response?.value === GroupBy.Country) {
-            this.dateRange.from = dayjs(this.selectedDateRange?.startDate).format(GIDDH_DATE_FORMAT);
-            this.dateRange.to = dayjs(this.selectedDateRange?.endDate).format(GIDDH_DATE_FORMAT);
-        } else {
+        } else if (response?.value === GroupBy.Duration) {
             this.populateRecords(this.interval, this.selectedMonth);
         }
     }
@@ -486,9 +512,6 @@ constructor(
                 this.reportForm.get('countryCode').patchValue(currentCountryCode);
                 this.reportForm.get('countryCodes').patchValue(currentCountryCodes);
                 this.reportForm.get('stateCodes').patchValue(currentStateCodes);
-                if (!this.stateList().length && this.reportForm.get('groupBy')?.value === GroupBy.State && this.reportForm.get('countryCode')?.value) {
-                    this.loadStates(this.reportForm.get('countryCode')?.value);
-                }
                 this.populateRecords(this.selectedType, this.selectedMonth);
                 this.purchaseRegisterTotal.particular = this.getCustomParticular();
                 this.changeDetectorRef.detectChanges();
@@ -864,7 +887,7 @@ constructor(
             return;
         }
         this.savePreferences();
-        const requestObject = this.reportForm.value;
+        const requestObject = cloneDeep(this.reportForm.value);
         const groupByValue = this.reportForm?.get('groupBy')?.value;
 
         /** Map of keys to remove for each group by type */
@@ -947,20 +970,6 @@ constructor(
     private loadStates(countryCode: string): void {
         const statesRequest = { country: countryCode };
         this.store.dispatch(this.generalActions.getAllState(statesRequest));
-
-        this.store.pipe(
-            select(state => state.general.states),
-            filter(Boolean),
-            take(1)
-        ).subscribe(states => {
-            if (states && (states.stateList ?? states.countyList)) {
-                this.stateList.set((states.stateList ?? states.countyList).map(state => ({
-                    label: state.name,
-                    value: state.code
-                })));
-                this.filteredStateList.set(this.stateList());
-            }
-        });
     }
 
     /**
@@ -971,8 +980,8 @@ constructor(
      */
     public handleCountrySelection(event: IOption): void {
         if (event?.value) {
-            this.loadStates(event.value);
             this.reportForm.get('stateCodes')?.setValue([]);
+            this.getPurchaseRegister();
         }
     }
 }

--- a/apps/web-giddh/src/app/reports/components/report-details-components/report.details.component.ts
+++ b/apps/web-giddh/src/app/reports/components/report-details-components/report.details.component.ts
@@ -299,6 +299,32 @@ constructor(
                 this.selectedDateRangeUi = dayjs(response[0]).format(GIDDH_NEW_DATE_FORMAT_UI) + " - " + dayjs(response[1]).format(GIDDH_NEW_DATE_FORMAT_UI);
             }
         });
+        this.store.pipe(
+            select(state => state.general.states),
+            filter(Boolean),
+            takeUntil(this.destroyed$)
+        ).subscribe(states => {
+            if (states && (states.stateList ?? states.countyList)) {
+                this.stateList.set((states.stateList ?? states.countyList).map(state => ({
+                    label: state.name,
+                    value: state.code
+                })));
+                this.filteredStateList.set(this.stateList());
+            }
+        });
+
+        // Subscribe to countryCode changes to automatically load states
+        this.reportForm.get('countryCode')?.valueChanges.pipe(
+            filter(Boolean),
+            takeUntil(this.destroyed$)
+        ).subscribe(countryCode => {
+            if (countryCode) {
+                this.loadStates(countryCode);
+            } else {
+                this.stateList.set([]);
+                this.filteredStateList.set([]);
+            }
+        });
     }
 
     /**
@@ -312,14 +338,14 @@ constructor(
         this.reportForm.get('countryCodes')?.setValue([]);
         this.reportForm.get('stateCodes')?.setValue([]);
 
-        if (response?.value === GroupBy.SalesPerson) {
+        if (response?.value && response.value !== GroupBy.Duration) {
             this.dateRange.from = dayjs(this.selectedDateRange?.startDate).format(GIDDH_DATE_FORMAT);
             this.dateRange.to = dayjs(this.selectedDateRange?.endDate).format(GIDDH_DATE_FORMAT);
+            if (response.value === GroupBy.State) {
+                this.reportForm.get('countryCode')?.setValue(this.activeCompany.countryV2?.alpha2CountryCode);
+            }
             this.getSalesRegister(this.dateRange.from, this.dateRange.to);
-        } else if (response?.value === GroupBy.State || response?.value === GroupBy.Country) {
-            this.dateRange.from = dayjs(this.selectedDateRange?.startDate).format(GIDDH_DATE_FORMAT);
-            this.dateRange.to = dayjs(this.selectedDateRange?.endDate).format(GIDDH_DATE_FORMAT);
-        } else {
+        } else if (response?.value === GroupBy.Duration) {
             this.populateRecords(this.interval, this.selectedMonth);
         }
     }
@@ -485,9 +511,6 @@ constructor(
                 this.reportForm.get('countryCodes').patchValue(currentCountryCodes);
                 this.reportForm.get('countryCode').patchValue(currentCountryCode);
                 this.reportForm.get('stateCodes').patchValue(currentStateCodes);
-                if (!this.stateList().length && this.reportForm.get('groupBy')?.value === GroupBy.State && this.reportForm.get('countryCode')?.value) {
-                    this.loadStates(this.reportForm.get('countryCode')?.value);
-                }
                 this.populateRecords(this.selectedType, this.selectedMonth);
                 this.salesRegisterTotal.particular = this.getCustomParticular();
                 this.changeDetectorRef.detectChanges();
@@ -875,7 +898,7 @@ constructor(
             return;
         }
         this.savePreferences();
-        const requestObject = this.reportForm.value;
+        const requestObject = cloneDeep(this.reportForm.value);
         const groupByValue = this.reportForm?.get('groupBy')?.value;
 
         /** Map of keys to remove for each group by type */
@@ -963,20 +986,6 @@ constructor(
     private loadStates(countryCode: string): void {
         const statesRequest = { country: countryCode };
         this.store.dispatch(this.generalActions.getAllState(statesRequest));
-
-        this.store.pipe(
-            select(state => state.general.states),
-            filter(Boolean),
-            take(1)
-        ).subscribe(states => {
-            if (states && (states.stateList ?? states.countyList)) {
-                this.stateList.set((states.stateList ?? states.countyList).map(state => ({
-                    label: state.name,
-                    value: state.code
-                })));
-                this.filteredStateList.set(this.stateList());
-            }
-        });
     }
 
     /**
@@ -987,8 +996,8 @@ constructor(
      */
     public handleCountrySelection(event: IOption): void {
         if (event?.value) {
-            this.loadStates(event.value);
             this.reportForm.get('stateCodes')?.setValue([]);
+            this.getSalesRegister();
         }
     }
 }


### PR DESCRIPTION
## **User description**
https://app.clickup.com/t/86d1qkrce


___

## **CodeAnt-AI Description**
Auto-load states on country change and auto-set country when grouping by State in reports

### What Changed
- Report pages now populate the state dropdown from the shared store and keep it updated automatically.
- Selecting or changing the country in report filters automatically loads and shows the relevant states; clearing the country clears state options.
- Choosing "Group by: State" automatically selects the company's country so state options appear and the register is fetched.
- Changing country in the filter now immediately refreshes the displayed report (sales or purchase) and clears selected states.
- Form values are cloned when building the report request to avoid unintended mutations.

### Impact
`✅ Automatic state options when changing country`
`✅ Reports refresh immediately after country selection`
`✅ Fewer missing state options when grouping by State`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Purchase and sales reports now intelligently auto-populate available state options when you select a country, eliminating redundant manual updates
  * Country and state selections are now better synchronized across all report types and grouping options for consistent results
  * Enhanced data handling ensures improved reliability, accuracy, and consistency when working with location-based report filters and grouped views

<!-- end of auto-generated comment: release notes by coderabbit.ai -->