### PR TITLE
Divyanshu | Test | GST summary api is not getting called on overview page when changing the month

### DIFF
--- a/apps/web-giddh/src/app/gst/filing/header/filing-header.component.ts
+++ b/apps/web-giddh/src/app/gst/filing/header/filing-header.component.ts
@@ -25,7 +25,7 @@ import { environment } from 'apps/web-giddh/src/environments/environment.generat
     selector: 'filing-header',
     templateUrl: 'filing-header.component.html',
     styleUrls: ['filing-header.component.scss'],
-    standalone:false
+    standalone: false
 })
 export class FilingHeaderComponent implements OnInit, OnChanges, OnDestroy {
     @Input() public currentPeriod: any = null;
@@ -156,18 +156,24 @@ export class FilingHeaderComponent implements OnInit, OnChanges, OnDestroy {
                 this.store.dispatch(this.gstReconcileActions.SetSelectedPeriod(this.currentPeriod));
             }
             this.selectedGst = params['return_type'];
+            if (!this.router.url.includes('transaction') && !this.router.url.includes('hsn-summary')) {
+                this.getOverView();
+            }
         });
+    }
 
+    /**
+     * This will get the overview of the gst
+     * 
+     * @memberof FilingHeaderComponent
+     */
+    protected getOverView(): void {
         let request: GstOverViewRequest = new GstOverViewRequest();
         request.from = this.currentPeriod.from;
         request.to = this.currentPeriod.to;
         request.gstin = this.activeCompanyGstNumber;
-        if (this.selectedGst === GstReport.Gstr1) {
-            this.navigateToOverview();
-            this.store.dispatch(this.reconcileAction.GetOverView(GstReport.Gstr1, request));
-        } else if (this.selectedGst === GstReport.Gstr2) {
-            this.navigateToOverview();
-            this.store.dispatch(this.reconcileAction.GetOverView(GstReport.Gstr2, request));
+        if (this.selectedGst === GstReport.Gstr1 || this.selectedGst === GstReport.Gstr2) {
+            this.store.dispatch(this.reconcileAction.GetOverView(this.selectedGst, request));
         }
     }
 
@@ -235,7 +241,7 @@ export class FilingHeaderComponent implements OnInit, OnChanges, OnDestroy {
         if (selectedService) {
             this.selectedService = selectedService;
         }
-        this.asideAuthenticationDialogRef = this.dialog.open(this.asideAuthenticationDialog, {...ASIDE_PANE_CONFIG, autoFocus: false});
+        this.asideAuthenticationDialogRef = this.dialog.open(this.asideAuthenticationDialog, { ...ASIDE_PANE_CONFIG, autoFocus: false });
     }
 
     /**
@@ -336,11 +342,7 @@ export class FilingHeaderComponent implements OnInit, OnChanges, OnDestroy {
             };
             this.isMonthSelected = true;
             this.store.dispatch(this.reconcileAction.SetSelectedPeriod(this.currentPeriod));
-            if (this.selectedGst === GstReport.Gstr1) {
-                this.navigateToOverview();
-            } else {
-                this.navigateToOverview();
-            }
+            this.navigateToOverview();
         }
 
     }


### PR DESCRIPTION
## **User description**
https://app.clickup.com/t/86d22b836


___

## **CodeAnt-AI Description**
Fix GST overview not refreshing when changing month on the overview page

### What Changed
- The GST overview is fetched automatically when the selected month or period changes, except on transaction and hsn-summary routes
- Overview requests for both GSTR1 and GSTR2 are dispatched using the currently selected GST type (no missing dispatch for GSTR2)
- Navigating the UI now reliably opens the GST overview after a period change so the displayed summary matches the selected month

### Impact
`✅ Fewer missing GST summaries when switching months`
`✅ Automatic GST overview refresh on month change`
`✅ Consistent overview fetch for GSTR1 and GSTR2`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * GST filing now intelligently manages overview data loading based on your current navigation context.
  * Overview data automatically fetches when navigating to relevant filing sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->