### PR TITLE
Ankit | test | Test - state /country filter getting removed when returning from detailed report

### DIFF
--- a/apps/web-giddh/src/app/reports/components/purchase-register-component/purchase.register.component.ts
+++ b/apps/web-giddh/src/app/reports/components/purchase-register-component/purchase.register.component.ts
@@ -481,6 +481,13 @@ constructor(
             }))),
             this.activeRoute.queryParams.pipe(distinctUntilChanged()),
         ]).pipe(takeUntil(this.destroyed$)).subscribe(([activeCompany, queryParam]) => {
+            // URL groupBy takes priority over store value
+            if (queryParam?.groupBy && [GroupBy.SalesPerson, GroupBy.State, GroupBy.Country].includes(queryParam.groupBy)) {
+                this.reportForm.get('groupBy').patchValue(queryParam.groupBy);
+            } else {
+                this.reportForm.get('groupBy').patchValue(GroupBy.Duration);
+            }
+
             if (queryParam?.interval || queryParam?.selectedMonth) {
                 this.selectedType = queryParam.interval;
                 this.interval = queryParam.interval;
@@ -489,12 +496,7 @@ constructor(
                 this.router.navigate(['pages', 'reports', 'purchase-register'], { 
                 queryParams: { groupBy: this.reportForm.get('groupBy').value } });
             }
-            // URL groupBy takes priority over store value
-            if (queryParam?.groupBy && [GroupBy.SalesPerson, GroupBy.State, GroupBy.Country].includes(queryParam.groupBy)) {
-                this.reportForm.get('groupBy').patchValue(queryParam.groupBy);
-            } else {
-                this.reportForm.get('groupBy').patchValue(GroupBy.Duration);
-            }
+            
             if (activeCompany) {
                 this.selectedCompany = activeCompany;
                 this.financialOptions = activeCompany.financialYears?.map(response => {

--- a/apps/web-giddh/src/app/reports/components/purchase-register-component/purchase.register.component.ts
+++ b/apps/web-giddh/src/app/reports/components/purchase-register-component/purchase.register.component.ts
@@ -464,7 +464,6 @@ constructor(
         let financialYearChosenInReportUniqueName = '';
         let currentBranchUniqueName = '';
         let currentTimeFilter: DurationEnum = this.selectedType;
-        let currentGroupBy = '';
 
 
         // set financial years based on company financial year
@@ -473,7 +472,6 @@ constructor(
                 financialYearChosenInReportUniqueName = registerReportFilters ? registerReportFilters.financialYearChosenInReport : '';
                 currentBranchUniqueName = registerReportFilters ? registerReportFilters.branchChosenInReport : '';
                 currentTimeFilter = registerReportFilters?.timeFilter?.toLowerCase() ?? '';
-                currentGroupBy = registerReportFilters?.groupBy || GroupBy.Duration;
                 this.reportForm.get('salesPersonUniqueNames').patchValue(registerReportFilters?.salesPersonUniqueNames ?? []);
                 this.reportForm.get('accountUniqueNames').patchValue(registerReportFilters?.accountUniqueNames ?? []);
                 this.reportForm.get('countryCodes').patchValue(registerReportFilters?.countryCodes ?? []);
@@ -488,13 +486,15 @@ constructor(
                 this.interval = queryParam.interval;
                 this.reportForm.get('interval').patchValue(queryParam.interval);
                 this.selectedMonth = queryParam.selectedMonth;
-                this.router.navigate(['pages', 'reports', 'purchase-register']);
+                this.router.navigate(['pages', 'reports', 'purchase-register'], { 
+                queryParams: { groupBy: this.reportForm.get('groupBy').value } });
             }
             // URL groupBy takes priority over store value
             if (queryParam?.groupBy && [GroupBy.SalesPerson, GroupBy.State, GroupBy.Country].includes(queryParam.groupBy)) {
-                currentGroupBy = queryParam.groupBy;
+                this.reportForm.get('groupBy').patchValue(queryParam.groupBy);
+            } else {
+                this.reportForm.get('groupBy').patchValue(GroupBy.Duration);
             }
-            this.reportForm.get('groupBy').patchValue(currentGroupBy, { emitEvent: false });
             if (activeCompany) {
                 this.selectedCompany = activeCompany;
                 this.financialOptions = activeCompany.financialYears?.map(response => {

--- a/apps/web-giddh/src/app/reports/components/report-details-components/report.details.component.ts
+++ b/apps/web-giddh/src/app/reports/components/report-details-components/report.details.component.ts
@@ -474,7 +474,6 @@ constructor(
         let financialYearChosenInReportUniqueName = '';
         let currentBranchUniqueName = '';
         let currentTimeFilter: DurationEnum = this.selectedType;
-        let currentGroupBy = '';
 
 
         // set financial years based on company financial year
@@ -483,7 +482,6 @@ constructor(
                 financialYearChosenInReportUniqueName = registerReportFilters ? registerReportFilters.financialYearChosenInReport : '';
                 currentBranchUniqueName = registerReportFilters ? registerReportFilters.branchChosenInReport : '';
                 currentTimeFilter = registerReportFilters?.timeFilter?.toLowerCase() ?? '';
-                currentGroupBy = registerReportFilters?.groupBy || GroupBy.Duration;
                 this.reportForm.get('salesPersonUniqueNames').patchValue(registerReportFilters?.salesPersonUniqueNames ?? []);
                 this.reportForm.get('accountUniqueNames').patchValue(registerReportFilters?.accountUniqueNames ?? []);
                 this.reportForm.get('countryCodes').patchValue(registerReportFilters?.countryCodes ?? []);
@@ -495,16 +493,18 @@ constructor(
         ]).pipe(takeUntil(this.destroyed$)).subscribe(([activeCompany, queryParam]) => {
             // URL groupBy takes priority over store value
             if (queryParam?.groupBy && [GroupBy.SalesPerson, GroupBy.State, GroupBy.Country].includes(queryParam.groupBy)) {
-                currentGroupBy = queryParam.groupBy;
+                this.reportForm.get('groupBy').patchValue(queryParam.groupBy);
+            } else {
+                this.reportForm.get('groupBy').patchValue(GroupBy.Duration);
             }
-            this.reportForm.get('groupBy').patchValue(currentGroupBy);
+            
             if (queryParam?.interval || queryParam?.selectedMonth) {
                 this.selectedType = queryParam.interval;
                 this.interval = queryParam.interval;
                 this.reportForm.get('interval').patchValue(queryParam.interval);
                 this.selectedMonth = queryParam.selectedMonth;
                 this.router.navigate(['pages', 'reports', 'sales-register'], { 
-                queryParams: { groupBy: queryParam.groupBy } });
+                queryParams: { groupBy: this.reportForm.get('groupBy').value } });
             }
 
             if (activeCompany) {


### PR DESCRIPTION
## **User description**
https://app.clickup.com/t/86d2397qk


___

## **CodeAnt-AI Description**
Persist report grouping in URL so returning from detail view keeps filters

### What Changed
- When navigating back to purchase or sales reports the current grouping (groupBy) is included in the URL so the report restores the same grouped view
- On report load, URL groupBy now takes priority and is applied to the report form; if no valid groupBy is present the view defaults to "Duration"
- This prevents loss of related filters (state, country, salesperson) when returning from a detailed report view

### Impact
`✅ Fewer lost state/country/salesperson filters when navigating back`
`✅ Consistent report grouping after returning from detail views`
`✅ Stable URL-based report restoration`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reports now drive the grouping selection from the report form control rather than a transient variable, simplifying state management.
  * URL query parameters and navigation consistently include the grouping setting and default to a duration-based grouping when none is provided, improving persistence across report views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->