### PR TITLE
Ankit | Test | revert

### DIFF
--- a/apps/web-giddh/src/app/reports/components/report-details-components/report.details.component.ts
+++ b/apps/web-giddh/src/app/reports/components/report-details-components/report.details.component.ts
@@ -686,13 +686,13 @@ constructor(
         this.store.dispatch(this.companyActions.setUserChosenFinancialYear({
             financialYear: this.currentActiveFinacialYear?.value, 
             branchUniqueName: (this.currentBranch ? this.currentBranch.uniqueName : ""), 
-            timeFilter: null, 
-            salesPersonUniqueNames: [], 
-            accountUniqueNames: [], 
-            groupBy: null, 
-            countryCodes: [],
-            countryCode: null,
-            stateCodes: []
+            timeFilter: this.selectedType, 
+            salesPersonUniqueNames: this.reportForm?.get('salesPersonUniqueNames')?.value, 
+            accountUniqueNames: this.reportForm?.get('accountUniqueNames')?.value, 
+            groupBy: this.reportForm?.get('groupBy')?.value, 
+            countryCodes: this.reportForm?.get('countryCodes')?.value,
+            countryCode: this.reportForm?.get('countryCode')?.value,
+            stateCodes: this.reportForm?.get('stateCodes')?.value
         }));
     }
 

--- a/apps/web-giddh/src/app/shared/header/header.component.ts
+++ b/apps/web-giddh/src/app/shared/header/header.component.ts
@@ -12,7 +12,7 @@ import { CommonActions } from '../../actions/common.actions';
 import { CompanyCountry, CompanyCreateRequest, CompanyResponse, StatesRequest, Organization, StateDetailsRequest, OrganizationDetails } from '../../models/api-models/Company';
 import { UserDetails } from '../../models/api-models/loginModels';
 import { GroupWithAccountsAction } from '../../actions/groupwithaccounts.actions';
-import { NavigationEnd, NavigationError, NavigationStart, RouteConfigLoadEnd, Router } from '@angular/router';
+import { ActivatedRoute, NavigationEnd, NavigationError, NavigationStart, RouteConfigLoadEnd, Router } from '@angular/router';
 import { ElementViewContainerRef } from '../helpers/directives/elementViewChild/element.viewchild.directive';
 import { GeneralActions } from '../../actions/general/general.actions';
 import { createSelector } from 'reselect';
@@ -298,7 +298,8 @@ export class HeaderComponent implements OnInit, AfterViewInit, OnDestroy, AfterV
         @Inject(ServiceConfig) private serviceConfig,
         private elementRef: ElementRef,
         private renderer: Renderer2,
-        private giddhDatePipe: GiddhDatePipe
+        private giddhDatePipe: GiddhDatePipe,
+        private activeRoute: ActivatedRoute
     ) {
         const whiteLabel = this.generalService.getDecodedWhiteLabel();
         this.imgPath = Configuration.isElectron ? 'assets/images/' : (this.serviceConfig.AppUrl || environment.AppUrl) + environment.APP_FOLDER + 'assets/images/';
@@ -545,7 +546,11 @@ export class HeaderComponent implements OnInit, AfterViewInit, OnDestroy, AfterV
     }
 
     public ngOnInit() {
-        this.generalService.restoreRouteQueryFilters();
+        this.activeRoute.queryParams.pipe(distinctUntilChanged(), takeUntil(this.destroyed$)).subscribe(response => {
+            if (response.tab || response.required) {
+                this.generalService.restoreRouteQueryFilters();
+            }
+        });
         /** If this is true, it means we are in branch consolidated mode.  */
         this.store.pipe(select(select => select.branchConsolidated), takeUntil(this.destroyed$)).subscribe(response => {
             if (response) {

--- a/apps/web-giddh/src/app/shared/header/header.component.ts
+++ b/apps/web-giddh/src/app/shared/header/header.component.ts
@@ -545,6 +545,7 @@ export class HeaderComponent implements OnInit, AfterViewInit, OnDestroy, AfterV
     }
 
     public ngOnInit() {
+        this.generalService.restoreRouteQueryFilters();
         /** If this is true, it means we are in branch consolidated mode.  */
         this.store.pipe(select(select => select.branchConsolidated), takeUntil(this.destroyed$)).subscribe(response => {
             if (response) {
@@ -617,8 +618,6 @@ export class HeaderComponent implements OnInit, AfterViewInit, OnDestroy, AfterV
         this.store.pipe(select(s => s.session.lastState), takeUntil(this.destroyed$)).subscribe(s => {
             this.isLedgerAccSelected = false;
             const lastState = s?.toLowerCase();
-
-            this.generalService.restoreRouteQueryFilters();
 
             let lastStateHaveParams: boolean = lastState.includes('?');
             if (lastStateHaveParams) {


### PR DESCRIPTION
## **User description**
https://app.clickup.com/t/86d253fbu


___

## **CodeAnt-AI Description**
**Preserve report filters when changing financial year**

### What Changed
- Report filter selections are now saved when the user switches the financial year instead of being cleared
- The saved filters include time filter, selected sales persons, selected accounts, group-by setting, country codes, country selection, and state codes
- Users returning to a report after changing the financial year will see their previous filter choices applied

### Impact
`✅ Preserves report filter selections when switching financial year`
`✅ Fewer repeated filter setups for reports`
`✅ More consistent report results across year changes`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Report preferences (time filter, grouping, salesperson, account, country/state) are now correctly saved and restored across sessions.

* **New Features**
  * Report filter state is auto-restored when visiting pages with relevant URL query parameters (e.g., tab or required), keeping your view consistent when navigating via links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->