### PR TITLE
Ankit | Test | Prod - Create new dialog box is not getting reopen from applicable tax (other tax) dialog box on create voucher page

### DIFF
--- a/apps/web-giddh/src/app/shared/aside-menu-create-tax/aside-menu-create-tax.component.ts
+++ b/apps/web-giddh/src/app/shared/aside-menu-create-tax/aside-menu-create-tax.component.ts
@@ -81,6 +81,7 @@ export class AsideMenuCreateTaxComponent implements OnInit, OnChanges, AfterView
         private formBuilder: FormBuilder
     ) {
         this.initForm();
+        this.store.dispatch(this.settingsTaxesActions.CreateTaxResponse(null));
     }
 
     /**

--- a/apps/web-giddh/src/app/shared/header/components/new-manage-groups-accounts/manage-groups-accounts.component.html
+++ b/apps/web-giddh/src/app/shared/header/components/new-manage-groups-accounts/manage-groups-accounts.component.html
@@ -76,19 +76,14 @@
 
     <div class="modal-body p-0">
         <div class="clear-both">
-            <div
-                class="grp-col p-0"
-                [ngStyle]="{
-                    'height': (myModelRect() ? myModelRect().height : 0) - (headerRect() ? headerRect().height : 0) + 'px',
-                }"
-            >
+            <div class="grp-col p-0" [style.height.px]="bodyHeight">
                 <div class="search-loading" *ngIf="searchLoad | async">
                     <div class="vertical-center">
                         <span class="spinner small"></span>
                         {{ commonLocaleData?.app_loading }}
                     </div>
                 </div>
-                <div class="search-loading no-result" *ngIf="!(searchLoad | async) && !topSharedGroups()?.length">
+                <div class="search-loading no-result" *ngIf="!(searchLoad | async) && !topSharedGroups?.length">
                     <div class="vertical-center">
                         <p>{{ localeData?.no_result_found }}</p>
                     </div>
@@ -102,12 +97,10 @@
                         >
                             <master
                                 #master
-                                [topSharedGroups]="topSharedGroups()"
+                                [topSharedGroups]="topSharedGroups"
                                 [searchedMasterData]="searchedMasterData"
-                                [ngStyle]="{
-                                    'height': (myModelRect() ? myModelRect().height : 0) - (headerRect() ? headerRect().height : 0) + 'px',
-                                }"
-                                [height]="(myModelRect() ? myModelRect().height : 0) - (headerRect() ? headerRect().height : 0)"
+                                [style.height.px]="bodyHeight"
+                                [height]="bodyHeight"
                                 [isSearchingGroups]="!(grpSrch?.value === '')"
                                 [localeData]="localeData"
                                 [commonLocaleData]="commonLocaleData"
@@ -123,8 +116,8 @@
             <!-- middle body -->
             <div class="form-box height-in-vh">
                 <account-operations
-                    [topSharedGroups]="topSharedGroups()"
-                    [height]="(myModelRect() ? myModelRect().height : 0) - (headerRect() ? headerRect().height : 0)"
+                    [topSharedGroups]="topSharedGroups"
+                    [height]="bodyHeight"
                     [breadcrumbPath]="breadcrumbPath"
                     [breadcrumbUniquePath]="breadcrumbUniquePath"
                     [localeData]="localeData"

--- a/apps/web-giddh/src/app/shared/header/components/new-manage-groups-accounts/manage-groups-accounts.component.ts
+++ b/apps/web-giddh/src/app/shared/header/components/new-manage-groups-accounts/manage-groups-accounts.component.ts
@@ -1,5 +1,5 @@
 import { debounceTime, takeUntil } from 'rxjs/operators';
-import { ChangeDetectorRef, Component, ElementRef, EventEmitter, HostListener, OnDestroy, OnInit, Output, Renderer2, ViewChild, NgZone, ChangeDetectionStrategy } from '@angular/core';
+import { ChangeDetectorRef, Component, ElementRef, EventEmitter, HostListener, OnDestroy, OnInit, Output, Renderer2, ViewChild, NgZone, ChangeDetectionStrategy, AfterViewChecked } from '@angular/core';
 import { Angular21ChangeDetectionService } from '../../../../services/angular21-change-detection.service';
 import { AppState } from '../../../../store/roots';
 import { Store, select } from '@ngrx/store';
@@ -20,7 +20,7 @@ import { IOption } from 'apps/web-giddh/src/app/app.constant';
     standalone: false,
     changeDetection: ChangeDetectionStrategy.Default
 })
-export class ManageGroupsAccountsComponent implements OnInit, OnDestroy {
+export class ManageGroupsAccountsComponent implements OnInit, OnDestroy, AfterViewChecked {
     @Output() public closeEvent: EventEmitter<boolean> = new EventEmitter(true);
     /** Instance of master component */
     @ViewChild('master', { static: false }) public master: MasterComponent;

--- a/apps/web-giddh/src/app/shared/header/components/new-manage-groups-accounts/manage-groups-accounts.component.ts
+++ b/apps/web-giddh/src/app/shared/header/components/new-manage-groups-accounts/manage-groups-accounts.component.ts
@@ -1,5 +1,5 @@
 import { debounceTime, takeUntil } from 'rxjs/operators';
-import { AfterViewChecked, ChangeDetectorRef, Component, ElementRef, EventEmitter, HostListener, OnDestroy, OnInit, Output, Renderer2, ViewChild, NgZone, ChangeDetectionStrategy, signal } from '@angular/core';
+import { ChangeDetectorRef, Component, ElementRef, EventEmitter, HostListener, OnDestroy, OnInit, Output, Renderer2, ViewChild, NgZone, ChangeDetectionStrategy } from '@angular/core';
 import { Angular21ChangeDetectionService } from '../../../../services/angular21-change-detection.service';
 import { AppState } from '../../../../store/roots';
 import { Store, select } from '@ngrx/store';
@@ -20,20 +20,19 @@ import { IOption } from 'apps/web-giddh/src/app/app.constant';
     standalone: false,
     changeDetection: ChangeDetectionStrategy.Default
 })
-export class ManageGroupsAccountsComponent implements OnInit, OnDestroy, AfterViewChecked {
+export class ManageGroupsAccountsComponent implements OnInit, OnDestroy {
     @Output() public closeEvent: EventEmitter<boolean> = new EventEmitter(true);
     /** Instance of master component */
     @ViewChild('master', { static: false }) public master: MasterComponent;
     @ViewChild('header', { static: true }) public header: ElementRef;
     @ViewChild('grpSrch', { static: true }) public groupSrch: ElementRef;
     /** Bounding rect of the header element, used to calculate scrollable body height */
-    public headerRect = signal<any>(null);
     public showForm: boolean = false;
     @ViewChild('myModel', { static: true }) public myModel: ElementRef;
     public breadcrumbPath: string[] = [];
     public breadcrumbUniquePath: string[] = [];
-    /** Bounding rect of the modal container element, used to calculate scrollable body height */
-    public myModelRect = signal<any>(null);
+    /** Computed body height = modal height - header height */
+    public bodyHeight: number = 0;
     public searchLoad: Observable<boolean>;
     public groupAndAccountSearchString$: Observable<string>;
     private groupSearchTerms = new Subject<string>();
@@ -48,7 +47,7 @@ export class ManageGroupsAccountsComponent implements OnInit, OnDestroy, AfterVi
     /** True if initial component load */
     public initialLoad: boolean = true;
     /** List of top shared groups */
-    public topSharedGroups = signal<any[]>([]);
+    public topSharedGroups: any[] = [];
     /** List of data searched */
     public searchedMasterData: any[] = [];
     /** True if account has unsaved changes */
@@ -86,9 +85,7 @@ export class ManageGroupsAccountsComponent implements OnInit, OnDestroy, AfterVi
 
     @HostListener('window:resize', ['$event'])
     public resizeEvent(e) {
-        this.headerRect.set(this.header.nativeElement?.getBoundingClientRect());
-        this.myModelRect.set(this.myModel.nativeElement?.getBoundingClientRect());
-        this.cdRef.detectChanges();
+        this.updateBodyHeight();
     }
 
     /**
@@ -169,14 +166,34 @@ export class ManageGroupsAccountsComponent implements OnInit, OnDestroy, AfterVi
         });
 
         document.querySelector('body')?.classList?.add('master-page');
-        setTimeout(() => {
-            this.headerRect.set(this.header.nativeElement?.getBoundingClientRect());
-            this.myModelRect.set(this.myModel.nativeElement?.getBoundingClientRect());
-        }, 100);
+        this.updateBodyHeight();
     }
 
     public ngAfterViewChecked() {
         this.changeDetectionService.safeChangeDetection(this.cdRef, this.ngZone);
+    }
+
+    /**
+     * Lifecycle hook called after view initialization
+     *
+     * @returns {void}
+     * @memberof ManageGroupsAccountsComponent
+     */
+    public ngAfterViewInit(): void {
+        this.updateBodyHeight();
+    }
+
+    /**
+     * Updates bodyHeight based on current modal and header bounding rects 
+     * 
+     * @memberof ManageGroupsAccountsComponent
+     * @returns {void}
+     */
+    private updateBodyHeight(): void {
+        const modelRect = this.myModel?.nativeElement?.getBoundingClientRect();
+        const headerRect = this.header?.nativeElement?.getBoundingClientRect();
+        this.bodyHeight = (modelRect?.height ?? 0) - (headerRect?.height ?? 0);
+        this.cdRef.detectChanges();
     }
 
     public searchGroups(term: string): void {
@@ -292,10 +309,10 @@ export class ManageGroupsAccountsComponent implements OnInit, OnDestroy, AfterVi
      * @memberof ManageGroupsAccountsComponent
      */
     private getTopSharedGroups(): void {
-        this.topSharedGroups.set([]);
+        this.topSharedGroups = [];
         this.groupService.getTopSharedGroups().pipe(takeUntil(this.destroyed$)).subscribe((response: any) => {
             if (response?.status === "success") {
-                this.topSharedGroups.set(response?.body?.results);
+                this.topSharedGroups = response?.body?.results;
                 this.changeDetectionService.triggerChangeDetection(this.cdRef, this.ngZone);
             } else {
                 this.changeDetectionService.safeChangeDetection(this.cdRef, this.ngZone);


### PR DESCRIPTION
## **User description**
https://app.clickup.com/t/86d257md3. -[Prod - Create new dialog box is not getting reopen from applicable tax (other tax) dialog box on create voucher page]


___

## **CodeAnt-AI Description**
Fix modal layout and ensure tax-create dialog can reopen from applicable-tax flow

### What Changed
- The Groups & Accounts modal now calculates and exposes a stable content height so the list and form areas keep correct height on open and when the window is resized; this prevents list clipping and layout jumps.
- Top shared groups and searches render from plain arrays (no reactive signal), so the group list and "no results" state display reliably.
- The tax creation component clears the previous create-tax response on initialization so the "Create new" dialog can open again when launched from the applicable-tax (other tax) dialog on the voucher page.

### Impact
`✅ Fixed tax-create dialog not reopening from applicable-tax flow`
`✅ Fewer layout glitches when resizing the Groups & Accounts modal`
`✅ More reliable display of top shared groups and search "no results"`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized height calculations in the groups & accounts modal.
  * Simplified property bindings across modal components for improved performance and maintainability.

* **Bug Fixes**
  * Ensure tax form initializes with a cleared/empty tax response when opened to prevent stale state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->