### PR TITLE
Ankit | test | Place of supply while creating voucher

### DIFF
--- a/apps/web-giddh/src/app/vouchers/create/create.component.html
+++ b/apps/web-giddh/src/app/vouchers/create/create.component.html
@@ -753,7 +753,7 @@
                                                         formControlName="code"
                                                         [options]="companyStateList$ | async"
                                                         [forceClear]="forceClear"
-                                                        [required]="branchCurrentAddressInfo.taxNumber"
+                                                        [required]="!!branchCurrentAddressInfo.taxNumber"
                                                         [showError]="
                                                             invoiceForm.controls['account'].get('placeOfSupply.code')?.touched &&
                                                             invoiceForm.controls['account'].get('placeOfSupply.code')?.invalid
@@ -774,7 +774,7 @@
                                                         formControlName="code"
                                                         [options]="companyStateList$ | async"
                                                         [forceClear]="forceClear"
-                                                        [required]="branchCurrentAddressInfo.taxNumber"
+                                                        [required]="!!branchCurrentAddressInfo.taxNumber"
                                                         [showError]="
                                                             invoiceForm.controls['account'].get('sourceOfSupply.code')?.touched &&
                                                             invoiceForm.controls['account'].get('sourceOfSupply.code')?.invalid
@@ -1193,7 +1193,7 @@
                                                 formControlName="code"
                                                 [options]="companyStateList$ | async"
                                                 [forceClear]="forceClear"
-                                                [required]="branchCurrentAddressInfo.taxNumber"
+                                                [required]="!!branchCurrentAddressInfo.taxNumber"
                                                 [showError]="
                                                     invoiceForm.controls['account'].get('destinationOfSupply.code')?.touched &&
                                                     invoiceForm.controls['account'].get('destinationOfSupply.code')?.invalid

--- a/apps/web-giddh/src/app/vouchers/create/create.component.html
+++ b/apps/web-giddh/src/app/vouchers/create/create.component.html
@@ -741,7 +741,7 @@
                                         </div>
 
                                         <!-- Supply Fields Row - India only -->
-                                        @if (isIndianCompany) {
+                                        @if (isIndianCompanyAndAccount) {
                                             <!-- Place of Supply (Invoice / Credit Note / Estimate / Proforma) -->
                                             @if (showPlaceOfSupply) {
                                                 <div class="col-6 mt-3" formGroupName="placeOfSupply">
@@ -753,7 +753,7 @@
                                                         formControlName="code"
                                                         [options]="companyStateList$ | async"
                                                         [forceClear]="forceClear"
-                                                        [required]="true"
+                                                        [required]="branchCurrentAddressInfo.taxNumber"
                                                         [showError]="
                                                             invoiceForm.controls['account'].get('placeOfSupply.code')?.touched &&
                                                             invoiceForm.controls['account'].get('placeOfSupply.code')?.invalid
@@ -774,7 +774,7 @@
                                                         formControlName="code"
                                                         [options]="companyStateList$ | async"
                                                         [forceClear]="forceClear"
-                                                        [required]="true"
+                                                        [required]="branchCurrentAddressInfo.taxNumber"
                                                         [showError]="
                                                             invoiceForm.controls['account'].get('sourceOfSupply.code')?.touched &&
                                                             invoiceForm.controls['account'].get('sourceOfSupply.code')?.invalid
@@ -1181,7 +1181,7 @@
                                         </div>
                                     </div>
                                 </div>
-                                @if (isIndianCompany && showSourceDestinationOfSupply) {
+                                @if (isIndianCompanyAndAccount && showSourceDestinationOfSupply) {
                                     <ng-container formGroupName="account">
                                         <!-- Destination of Supply -->
                                         <div class="col-6 mt-3 pl-0" formGroupName="destinationOfSupply">
@@ -1193,7 +1193,7 @@
                                                 formControlName="code"
                                                 [options]="companyStateList$ | async"
                                                 [forceClear]="forceClear"
-                                                [required]="true"
+                                                [required]="branchCurrentAddressInfo.taxNumber"
                                                 [showError]="
                                                     invoiceForm.controls['account'].get('destinationOfSupply.code')?.touched &&
                                                     invoiceForm.controls['account'].get('destinationOfSupply.code')?.invalid

--- a/apps/web-giddh/src/app/vouchers/create/create.component.ts
+++ b/apps/web-giddh/src/app/vouchers/create/create.component.ts
@@ -671,6 +671,19 @@ export class VoucherCreateComponent implements OnInit, OnDestroy, AfterViewInit 
         return this.company.countryCode === 'IN' && this.account.countryCode === 'IN';
     }
 
+    
+
+    /**
+     * True if voucher is a cash sales invoice (not purchase, debit note, or credit note)
+     *
+     * @readonly
+     * @type {boolean}
+     * @memberof VoucherCreateComponent
+     */
+    public get isCashSalesInvoice(): boolean {
+        return this.invoiceType.isCashInvoice && !this.invoiceType.isPurchaseInvoice && !this.invoiceType.isDebitNote && !this.invoiceType.isCreditNote;
+    }
+
     /**
      * True if Place of Supply field should be shown (invoice / credit note / estimate / proforma)
      *
@@ -681,7 +694,7 @@ export class VoucherCreateComponent implements OnInit, OnDestroy, AfterViewInit 
     public get showPlaceOfSupply(): boolean {
         return (
             this.invoiceType.isSalesInvoice ||
-            (this.invoiceType.isCashInvoice && !this.invoiceType.isPurchaseInvoice && !this.invoiceType.isDebitNote && !this.invoiceType.isCreditNote) ||
+            this.isCashSalesInvoice ||
             this.invoiceType.isCreditNote ||
             this.invoiceType.isEstimateInvoice ||
             this.invoiceType.isProformaInvoice

--- a/apps/web-giddh/src/app/vouchers/create/create.component.ts
+++ b/apps/web-giddh/src/app/vouchers/create/create.component.ts
@@ -570,6 +570,8 @@ export class VoucherCreateComponent implements OnInit, OnDestroy, AfterViewInit 
     public isAccountChanged: boolean = false;
     /** True if recurring voucher */
     public isRecurringVoucher: any;
+    /** store branch current address information */
+    public branchCurrentAddressInfo: any = {};
 
     /**
      * Returns true, if invoice type is sales, proforma or estimate, for these vouchers we
@@ -665,8 +667,8 @@ export class VoucherCreateComponent implements OnInit, OnDestroy, AfterViewInit 
      * @type {boolean}
      * @memberof VoucherCreateComponent
      */
-    public get isIndianCompany(): boolean {
-        return this.company.countryCode === 'IN';
+    public get isIndianCompanyAndAccount(): boolean {
+        return this.company.countryCode === 'IN' && this.account.countryCode === 'IN';
     }
 
     /**
@@ -679,7 +681,7 @@ export class VoucherCreateComponent implements OnInit, OnDestroy, AfterViewInit 
     public get showPlaceOfSupply(): boolean {
         return (
             this.invoiceType.isSalesInvoice ||
-            this.invoiceType.isCashInvoice ||
+            (this.invoiceType.isCashInvoice && !this.invoiceType.isPurchaseInvoice && !this.invoiceType.isDebitNote && !this.invoiceType.isCreditNote) ||
             this.invoiceType.isCreditNote ||
             this.invoiceType.isEstimateInvoice ||
             this.invoiceType.isProformaInvoice
@@ -2359,6 +2361,7 @@ export class VoucherCreateComponent implements OnInit, OnDestroy, AfterViewInit 
                     // Find the HO branch
                     this.company.branch = response.find((branch) => !branch.parentBranch);
                 }
+                this.branchCurrentAddressInfo = this.company.branch.addresses.find((address)=>address.isDefault);
             }
         });
     }
@@ -2944,6 +2947,9 @@ export class VoucherCreateComponent implements OnInit, OnDestroy, AfterViewInit 
         if (defaultAddress) {
             this.fillBillingShippingAddress("account", "billingDetails", defaultAddress, index);
             this.fillBillingShippingAddress("account", "shippingDetails", defaultAddress, index);
+            if (!this.isUpdateMode) {
+                this.setDefaultSupplyFields();
+            }
         }
     }
 
@@ -2960,7 +2966,7 @@ export class VoucherCreateComponent implements OnInit, OnDestroy, AfterViewInit 
             return '';
         }
         const defaultAddr = addresses.find((a) => a.isDefault);
-        return defaultAddr?.gstNumber || '';
+        return defaultAddr?.gstNumber;
     }
 
     /**
@@ -2972,11 +2978,11 @@ export class VoucherCreateComponent implements OnInit, OnDestroy, AfterViewInit 
      * @memberof VoucherCreateComponent
      */
     private setDefaultSupplyFields(): void {
-        if (!this.isIndianCompany || !this.invoiceForm) {
+        if (!this.isIndianCompanyAndAccount || !this.invoiceForm) {
             return;
         }
 
-        const isB2C = this.getDefaultAddressGstNumber(this.account?.addresses) ? false : true;
+        const isB2C = !!this.getDefaultAddressGstNumber(this.account?.addresses);
 
         if (this.showPlaceOfSupply) {
             const stateSource = isB2C
@@ -3100,7 +3106,6 @@ export class VoucherCreateComponent implements OnInit, OnDestroy, AfterViewInit 
             this.invoiceForm.controls["account"]?.get("mobileNumber").setValue(accountData?.mobileNo ?? "");
             this.account.mobileNumber = accountData?.mobileNo ?? "";
             this.updateDueDate();
-            this.setDefaultSupplyFields();
         } else {
             if (
                 !this.invoiceSettings?.invoiceSettings?.voucherAddressManualEnabled &&
@@ -3191,9 +3196,6 @@ export class VoucherCreateComponent implements OnInit, OnDestroy, AfterViewInit 
         }
         this.invoiceForm.controls[entityType]?.get(addressType).get("state").get("name").patchValue(state.name);
         this.invoiceForm.controls[entityType]?.get(addressType).get("state").get("code").patchValue(state.code);
-        if (!this.isUpdateMode && (entityType === 'company' || entityType === 'account')) {
-            this.setDefaultSupplyFields();
-        }
     }
 
     /**
@@ -5344,7 +5346,7 @@ export class VoucherCreateComponent implements OnInit, OnDestroy, AfterViewInit 
             }
         }
 
-        if (this.isIndianCompany) {
+        if (this.isIndianCompanyAndAccount && !!this.branchCurrentAddressInfo.taxNumber) {
             if (this.showPlaceOfSupply && !this.invoiceForm.get('account.placeOfSupply.code')?.value) {
                 this.invoiceForm.get('account.placeOfSupply.code')?.markAsTouched();
                 return false;
@@ -5528,7 +5530,7 @@ export class VoucherCreateComponent implements OnInit, OnDestroy, AfterViewInit 
 
         invoiceForm = this.vouchersUtilityService.formatVoucherObject(invoiceForm);
 
-        if (!this.isIndianCompany) {
+        if (!this.isIndianCompanyAndAccount) {
             delete invoiceForm.account?.placeOfSupply;
             delete invoiceForm.account?.sourceOfSupply;
             delete invoiceForm.account?.destinationOfSupply;

--- a/apps/web-giddh/src/app/vouchers/template/template-edit-filter/template-edit-filter.component.html
+++ b/apps/web-giddh/src/app/vouchers/template/template-edit-filter/template-edit-filter.component.html
@@ -374,7 +374,8 @@
                                             <div
                                                 *ngIf="
                                                     sectionSettings?.header.displayPlaceOfSupply &&
-                                                    customTemplate?.templateType !== templateTypeEnum.ThermalTemplate
+                                                    customTemplate?.templateType !== templateTypeEnum.ThermalTemplate &&
+                                                    (templateType === voucherTypeEnum.invoice || templateType === voucherTypeEnum.voucher)
                                                 "
                                             >
                                                 <mat-checkbox
@@ -384,6 +385,42 @@
                                                     (ngModelChange)="onChangeFieldVisibility()"
                                                 >
                                                     <span class="ml-2">{{ localeData?.place_of_supply }}</span>
+                                                </mat-checkbox>
+                                            </div>
+                                            <div
+                                                *ngIf="
+                                                    sectionSettings?.header.sourceOfSupply &&
+                                                    customTemplate?.templateType !== templateTypeEnum.ThermalTemplate &&
+                                                    (templateType === voucherTypeEnum.purchase_order ||
+                                                        templateType === voucherTypeEnum.purchase_bill ||
+                                                        templateType === voucherTypeEnum.voucher)
+                                                "
+                                            >
+                                                <mat-checkbox
+                                                    color="primary"
+                                                    name="sourceOfSupplyCheckbox"
+                                                    [(ngModel)]="customTemplate.sections['header'].data['sourceOfSupply'].display"
+                                                    (ngModelChange)="onChangeFieldVisibility()"
+                                                >
+                                                    <span class="ml-2">{{ localeData?.source_of_supply }}</span>
+                                                </mat-checkbox>
+                                            </div>
+                                            <div
+                                                *ngIf="
+                                                    sectionSettings?.header.destinationOfSupply &&
+                                                    customTemplate?.templateType !== templateTypeEnum.ThermalTemplate &&
+                                                    (templateType === voucherTypeEnum.purchase_order ||
+                                                        templateType === voucherTypeEnum.purchase_bill ||
+                                                        templateType === voucherTypeEnum.voucher)
+                                                "
+                                            >
+                                                <mat-checkbox
+                                                    color="primary"
+                                                    name="destinationOfSupplyCheckbox"
+                                                    [(ngModel)]="customTemplate.sections['header'].data['destinationOfSupply'].display"
+                                                    (ngModelChange)="onChangeFieldVisibility()"
+                                                >
+                                                    <span class="ml-2">{{ localeData?.destination_of_supply }}</span>
                                                 </mat-checkbox>
                                             </div>
                                             <!-- place of country -->

--- a/apps/web-giddh/src/assets/locale/vouchers/preview/en.json
+++ b/apps/web-giddh/src/assets/locale/vouchers/preview/en.json
@@ -473,6 +473,8 @@
     "exchange_conversion_rate": "Exchange/Conversion Rate",
     "place_of_supply": "Place Of Supply",
     "country_of_supply": "Country of Supply",
+    "source_of_supply": "Source of Supply",
+    "destination_of_supply": "Destination of Supply",
     "failed_to_get_template_preview": "Failed to get template preview",
     "please_enter_template_name": "Please enter template name.",
     "template_saved_successfully": "Template Saved Successfully.",

--- a/apps/web-giddh/src/assets/locale/vouchers/preview/hi.json
+++ b/apps/web-giddh/src/assets/locale/vouchers/preview/hi.json
@@ -473,6 +473,8 @@
     "exchange_conversion_rate": "एक्सचेंज/कन्वर्ज़न रेट",
     "place_of_supply": "आपूर्ति का स्थान",
     "country_of_supply": "आपूर्ति का स्थान",
+    "source_of_supply": "आपूर्ति का स्रोत",
+    "destination_of_supply": "आपूर्ति का गंतव्य",
     "failed_to_get_template_preview": "टेम्पलेट पूर्वावलोकन उपलब्ध नहीं है",
     "please_enter_template_name": "कृपया टेम्पलेट नाम दर्ज करें।",
     "template_saved_successfully": "टेम्पलेट सफलतापूर्वक सहायक बनाया गया।",

--- a/apps/web-giddh/src/assets/locale/vouchers/preview/mr.json
+++ b/apps/web-giddh/src/assets/locale/vouchers/preview/mr.json
@@ -473,6 +473,8 @@
     "exchange_conversion_rate": "विनिमय/रूपांतरण दर",
     "place_of_supply": "पुरवठ्याचे ठिकाण",
     "country_of_supply": "पुरवठ्याचे ठिकाण",
+    "source_of_supply": "पुरवठ्याचा स्रोत",
+    "destination_of_supply": "पुरवठ्याचे गंतव्य",
     "failed_to_get_template_preview": "टेम्पलेट पूर्वावलोकन उपलब्ध नहीं है",
     "please_enter_template_name": "कृपया टेम्पलेट नाव प्रविष्ट करा",
     "template_saved_successfully": "टेम्पलेट सफलतापूर्वक सहायक बनाया गया।",


### PR DESCRIPTION
## **User description**
https://app.clickup.com/t/86d29e3xa


___

## **CodeAnt-AI Description**
**Require Indian company + account and branch tax number for Place/Source/Destination of Supply fields**

### What Changed
- Supply-related fields (Place of Supply, Source of Supply, Destination of Supply) are shown and used only when both the company and the selected account are in India.
- Those supply fields become required only if the current branch has a tax number; otherwise they are hidden/removed from the voucher payload.
- Template editor now allows toggling Source/Destination of Supply for purchase-related templates; locale text for those labels added.
- Default supply values are set only when creating a new voucher (not when editing) and B2B/B2C detection uses the account's default address GST presence.

### Impact
`✅ Clearer supply field validation for Indian vouchers`
`✅ Fewer invalid voucher submissions when branch lacks GST`
`✅ Template editor exposes source/destination options for purchase templates`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Template editor: added controls to show/hide source and destination of supply fields for relevant templates.

* **Behavior Changes**
  * India-specific supply fields now require both company+account context and the branch tax number to appear and be validated.

* **Documentation & Localization**
  * Added English, Hindi and Marathi translations for source/destination of supply.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->