### PR TITLE
Ankit | Test | Prod - Discount and tax are getting remove when closing the create entry model

### DIFF
--- a/apps/web-giddh/src/app/ledger/components/new-ledger-entry-panel/new-ledger-entry-panel.component.ts
+++ b/apps/web-giddh/src/app/ledger/components/new-ledger-entry-panel/new-ledger-entry-panel.component.ts
@@ -279,8 +279,8 @@ export class NewLedgerEntryPanelComponent implements OnInit, OnDestroy, OnChange
     public salesTaxInclusive: boolean;
     /** True, if stock category is 'assets' and inclusive tax is applied */
     public fixedAssetTaxInclusive: boolean;
-    /** Stores the value of selected stock variant */
-    public selectedStockVariant: IOption = { label: '', value: '' };
+    /** Stores the value of selected stock variant, provided by the parent */
+    @Input() public selectedStockVariant: IOption;
     /** Holds Aside Menu State For Other Taxes DialogRef */
     public asideMenuStateForOtherTaxesDialogRef: MatDialogRef<any>;
     /** Holds Tooltip is opend/close status */
@@ -456,9 +456,13 @@ export class NewLedgerEntryPanelComponent implements OnInit, OnDestroy, OnChange
                     opens the new ledger.
                 */
                 const currentSelectedVariant = res.find(variant => variant.value === this.currentTxn?.inventory?.variant?.uniqueName);
-                this.selectedStockVariant = Object.assign({}, currentSelectedVariant ?? res[0]);
+                const newVariant = Object.assign({}, currentSelectedVariant ?? res[0]);
+                const variantChanged = newVariant.value !== this.selectedStockVariant?.value;
+                this.selectedStockVariant = newVariant;
                 this.cdRef.detectChanges();
-                this.stockVariantSelected.emit(currentSelectedVariant?.value ?? res[0].value);
+                if (variantChanged) {
+                    this.stockVariantSelected.emit(newVariant.value);
+                }
             }
         });
 
@@ -1945,6 +1949,7 @@ export class NewLedgerEntryPanelComponent implements OnInit, OnDestroy, OnChange
      */
     public variantChanged(event: IOption): void {
         if (event.value) {
+            this.selectedStockVariant = event;
             // Must not call the variant API when stock is changed
             this.stockVariantSelected.emit(event.value);
         }

--- a/apps/web-giddh/src/app/ledger/ledger.component.html
+++ b/apps/web-giddh/src/app/ledger/ledger.component.html
@@ -974,6 +974,7 @@
                                                                         loadDetails(selectedAccountDetails, txn, $event)
                                                                     "
                                                                     [selectedAccountDetails]="selectedAccountDetails"
+                                                                    [(selectedStockVariant)]="selectedStockVariant"
                                                                     [(isTotalChanged)]="isTotalChanged"
                                                                     [autoGenerateVoucherFromEntry]="autoGenerateVoucherFromEntryStatus"
                                                                 ></new-ledger-entry-panel>
@@ -1218,6 +1219,7 @@
                                                                         loadDetails(selectedAccountDetails, txn, $event)
                                                                     "
                                                                     [selectedAccountDetails]="selectedAccountDetails"
+                                                                    [(selectedStockVariant)]="selectedStockVariant"
                                                                     [(isTotalChanged)]="isTotalChanged"
                                                                     [autoGenerateVoucherFromEntry]="autoGenerateVoucherFromEntryStatus"
                                                                 ></new-ledger-entry-panel>
@@ -1861,6 +1863,7 @@
                                                     [entrySide]="'dr'"
                                                     (stockVariantSelected)="loadDetails(selectedAccountDetails, txn, $event)"
                                                     [selectedAccountDetails]="selectedAccountDetails"
+                                                    [(selectedStockVariant)]="selectedStockVariant"
                                                     [(isTotalChanged)]="isTotalChanged"
                                                     [autoGenerateVoucherFromEntry]="autoGenerateVoucherFromEntryStatus"
                                                 ></new-ledger-entry-panel>
@@ -2256,6 +2259,7 @@
                                                     [entrySide]="'cr'"
                                                     (stockVariantSelected)="loadDetails(selectedAccountDetails, txn, $event)"
                                                     [selectedAccountDetails]="selectedAccountDetails"
+                                                    [(selectedStockVariant)]="selectedStockVariant"
                                                     [(isTotalChanged)]="isTotalChanged"
                                                     [autoGenerateVoucherFromEntry]="autoGenerateVoucherFromEntryStatus"
                                                 ></new-ledger-entry-panel>
@@ -3424,6 +3428,7 @@
                                 [entrySide]="txn.type === transactionType.Debit ? 'dr' : 'cr'"
                                 (stockVariantSelected)="loadDetails(selectedAccountDetails, txn, $event)"
                                 [selectedAccountDetails]="selectedAccountDetails"
+                                [(selectedStockVariant)]="selectedStockVariant"
                                 [(isTotalChanged)]="isTotalChanged"
                                 [autoGenerateVoucherFromEntry]="autoGenerateVoucherFromEntryStatus"
                             ></new-ledger-entry-panel>

--- a/apps/web-giddh/src/app/ledger/ledger.component.html
+++ b/apps/web-giddh/src/app/ledger/ledger.component.html
@@ -974,7 +974,7 @@
                                                                         loadDetails(selectedAccountDetails, txn, $event)
                                                                     "
                                                                     [selectedAccountDetails]="selectedAccountDetails"
-                                                                    [(selectedStockVariant)]="selectedStockVariant"
+                                                                    [selectedStockVariant]="selectedStockVariant"
                                                                     [(isTotalChanged)]="isTotalChanged"
                                                                     [autoGenerateVoucherFromEntry]="autoGenerateVoucherFromEntryStatus"
                                                                 ></new-ledger-entry-panel>
@@ -1219,7 +1219,7 @@
                                                                         loadDetails(selectedAccountDetails, txn, $event)
                                                                     "
                                                                     [selectedAccountDetails]="selectedAccountDetails"
-                                                                    [(selectedStockVariant)]="selectedStockVariant"
+                                                                    [selectedStockVariant]="selectedStockVariant"
                                                                     [(isTotalChanged)]="isTotalChanged"
                                                                     [autoGenerateVoucherFromEntry]="autoGenerateVoucherFromEntryStatus"
                                                                 ></new-ledger-entry-panel>
@@ -1863,7 +1863,7 @@
                                                     [entrySide]="'dr'"
                                                     (stockVariantSelected)="loadDetails(selectedAccountDetails, txn, $event)"
                                                     [selectedAccountDetails]="selectedAccountDetails"
-                                                    [(selectedStockVariant)]="selectedStockVariant"
+                                                    [selectedStockVariant]="selectedStockVariant"
                                                     [(isTotalChanged)]="isTotalChanged"
                                                     [autoGenerateVoucherFromEntry]="autoGenerateVoucherFromEntryStatus"
                                                 ></new-ledger-entry-panel>
@@ -2259,7 +2259,7 @@
                                                     [entrySide]="'cr'"
                                                     (stockVariantSelected)="loadDetails(selectedAccountDetails, txn, $event)"
                                                     [selectedAccountDetails]="selectedAccountDetails"
-                                                    [(selectedStockVariant)]="selectedStockVariant"
+                                                    [selectedStockVariant]="selectedStockVariant"
                                                     [(isTotalChanged)]="isTotalChanged"
                                                     [autoGenerateVoucherFromEntry]="autoGenerateVoucherFromEntryStatus"
                                                 ></new-ledger-entry-panel>
@@ -3428,7 +3428,7 @@
                                 [entrySide]="txn.type === transactionType.Debit ? 'dr' : 'cr'"
                                 (stockVariantSelected)="loadDetails(selectedAccountDetails, txn, $event)"
                                 [selectedAccountDetails]="selectedAccountDetails"
-                                [(selectedStockVariant)]="selectedStockVariant"
+                                [selectedStockVariant]="selectedStockVariant"
                                 [(isTotalChanged)]="isTotalChanged"
                                 [autoGenerateVoucherFromEntry]="autoGenerateVoucherFromEntryStatus"
                             ></new-ledger-entry-panel>

--- a/apps/web-giddh/src/app/ledger/ledger.component.ts
+++ b/apps/web-giddh/src/app/ledger/ledger.component.ts
@@ -289,6 +289,8 @@ export class LedgerComponent implements OnInit, OnDestroy {
     public enableAutopaid: boolean = false;
     /** Selected account details to load the details after variant is selected */
     public selectedAccountDetails: IOption;
+    /** Selected stock variant passed down to new-ledger-entry-panel, reset on account change */
+    public selectedStockVariant: IOption = { label: '', value: '' };
     /** True, if the total was changed explicitly by the user in case of inclusive tax */
     public isTotalChanged: boolean;
     /* Observable to check if account prediction api call has completed */
@@ -546,6 +548,7 @@ export class LedgerComponent implements OnInit, OnDestroy {
         this.keydownClassAdded = false;
         this.selectedTxnAccUniqueName = '';
         this.selectedAccountDetails = e;
+        this.selectedStockVariant = { label: '', value: '' };
         if (!e?.value || clearAccount) {
             if (clearAccount) {
                 this.getTransactionCountConvertToEntries(txn);
@@ -3507,6 +3510,7 @@ export class LedgerComponent implements OnInit, OnDestroy {
     private loadDetails(event: IOption, txn: TransactionVM, variantUniqueName?: string, allowChangeDetection?: boolean, isBankTransaction?: boolean, transactionType?: string): void {
         let requestObject;
         if (event.additional?.stock) {
+            this.selectedStockVariant.value = variantUniqueName;
             requestObject = {
                 stockUniqueName: event.additional.stock?.uniqueName,
                 oppositeAccountUniqueName: event.additional.uniqueName,

--- a/apps/web-giddh/src/app/vouchers/create/create.component.ts
+++ b/apps/web-giddh/src/app/vouchers/create/create.component.ts
@@ -3110,6 +3110,9 @@ export class VoucherCreateComponent implements OnInit, OnDestroy, AfterViewInit 
                 if (defaultAddress) {
                     this.fillBillingShippingAddress("company", "billingDetails", defaultAddress, index);
                     this.fillBillingShippingAddress("company", "shippingDetails", defaultAddress, index);
+                    if (!this.isUpdateMode) {
+                        this.setDefaultSupplyFields();
+                    }
                 }
             }
 


### PR DESCRIPTION
## **User description**
https://app.clickup.com/t/86d25aytm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Auto-populate Place of Supply and Source of Supply during voucher creation from company address when creating new vouchers.

* **Improvements**
  * Improved stock variant selection in ledger workflows: parent/child components now stay synchronized, selection persists across ledger panels, and change events fire only when the variant actually changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Keep selected stock variant when reopening entry panel and avoid duplicate variant handling

### What Changed
- The create-entry panel now receives the currently selected stock variant from the parent so the variant selection is retained when closing and reopening the panel.
- Variant change events are emitted only when the selected variant actually changes, preventing duplicate handling and extra reloads of variant info.
- The ledger view resets the selected variant when switching accounts and updates it when loading account/variant details, keeping parent and panel in sync.
- For new purchase orders and purchase invoices (not updates), default supply fields are populated automatically when billing/shipping address is set.

### Impact
`✅ Fewer duplicate variant reloads when reopening or switching entries`
`✅ Selected stock variant is retained when closing and reopening the create-entry panel`
`✅ Default supply fields populated for new purchase entries`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
