### PR TITLE
Ankit | Test | QA - All filter data is stored in query parameters

### DIFF
--- a/apps/web-giddh/src/app/contact/aging-report/aging-report.component.ts
+++ b/apps/web-giddh/src/app/contact/aging-report/aging-report.component.ts
@@ -269,7 +269,7 @@ export class AgingReportComponent implements OnInit, OnDestroy {
             }
         });
 
-        this.route.queryParams.pipe(takeUntil(this.destroyed$)).subscribe(queryParams => {
+        this.route.queryParams.pipe(debounceTime(700), takeUntil(this.destroyed$)).subscribe(queryParams => {
             if (queryParams.tab === 'aging-report') {
                 const restoredQ = queryParams.searchText || '';
                 this.searchStr = restoredQ;

--- a/apps/web-giddh/src/app/contact/contact.component.html
+++ b/apps/web-giddh/src/app/contact/contact.component.html
@@ -305,11 +305,11 @@
                     <div class="contact-main customer-page on-mobile-view overflow-visible">
                         <div class="pb-4 mb-2 overflow-visible">
                             <div class="overflow-visible">
-                                <div *ngIf="!isGetAccountsInProcess">
+                                <div *ngIf="!isGetAccountsInProcess()">
                                     <ng-container *ngTemplateOutlet="mainTable"></ng-container>
                                 </div>
 
-                                <giddh-page-loader *ngIf="isGetAccountsInProcess"></giddh-page-loader>
+                                <giddh-page-loader *ngIf="isGetAccountsInProcess()"></giddh-page-loader>
                             </div>
                         </div>
                     </div>

--- a/apps/web-giddh/src/app/contact/contact.component.ts
+++ b/apps/web-giddh/src/app/contact/contact.component.ts
@@ -1015,13 +1015,9 @@ export class ContactComponent implements OnInit, OnDestroy {
         this.toggleGiddhDatepicker(false);
         if (value && value.startDate && value.endDate) {
             this.showClearFilter.set(true);
-            // this.selectedDateRange = { startDate: dayjs(value.startDate), endDate: dayjs(value.endDate) };
-            // this.selectedDateRangeUi = dayjs(value.startDate).format(GIDDH_NEW_DATE_FORMAT_UI) + " - " + dayjs(value.endDate).format(GIDDH_NEW_DATE_FORMAT_UI);
             this.fromDate = dayjs(value.startDate).format(GIDDH_DATE_FORMAT);
             this.toDate = dayjs(value.endDate).format(GIDDH_DATE_FORMAT);
             this.generalService.saveRouteQueryFilters({ fromDate: this.fromDate, toDate: this.toDate });
-            // this.getAccounts(this.fromDate, this.toDate, null, "true", PAGINATION_LIMIT, this.searchStr, this.key, this.order, (this.currentBranch ? this.currentBranch.uniqueName : ""));
-            this.detectChanges();
         }
     }
 

--- a/apps/web-giddh/src/app/contact/contact.component.ts
+++ b/apps/web-giddh/src/app/contact/contact.component.ts
@@ -187,7 +187,7 @@ export class ContactComponent implements OnInit, OnDestroy {
     public universalDate: any;
     public selectedRangeLabel: any = "";
     /**True, if get accounts request in process */
-    public isGetAccountsInProcess: boolean = false;
+    public isGetAccountsInProcess = signal(false);
     /** This will hold the current page number */
     public currentPage: number = 1;
     /** Observable to store the branches of current company */
@@ -342,6 +342,7 @@ export class ContactComponent implements OnInit, OnDestroy {
             const previousTab = this.activeTab;
 
             if (newTab !== previousTab) {
+                this.selectedRangeLabel = "";
                 this.displayedColumns = [];
                 this.dynamicCustomColumns = [];
                 this.setActiveTab(newTab);
@@ -353,13 +354,41 @@ export class ContactComponent implements OnInit, OnDestroy {
             }
         });
 
-        this.route.queryParams.pipe(takeUntil(this.destroyed$)).subscribe(queryParams => {
+        this.route.queryParams.pipe(debounceTime(700), takeUntil(this.destroyed$)).subscribe(queryParams => {
             if (queryParams.tab === 'customer' || queryParams.tab === 'vendor') {
-                const restoredQ = queryParams.searchText || '';
-                this.searchStr = restoredQ;
-                this.searchedName.setValue(restoredQ, { emitEvent: false });
-                this.showNameSearch = restoredQ ? true : false;
-                this.searchStr$.next(restoredQ);
+                if (queryParams.fromDate && queryParams.toDate) {
+                    this.fromDate = queryParams.fromDate;
+                    this.toDate = queryParams.toDate;
+                    this.selectedDateRange = {
+                        startDate: dayjs(this.fromDate, GIDDH_DATE_FORMAT),
+                        endDate: dayjs(this.toDate, GIDDH_DATE_FORMAT),
+                    };
+                    this.selectedDateRangeUi = dayjs(this.fromDate, GIDDH_DATE_FORMAT).format(GIDDH_NEW_DATE_FORMAT_UI) + ' - ' + dayjs(this.toDate, GIDDH_DATE_FORMAT).format(GIDDH_NEW_DATE_FORMAT_UI);
+                    const restoredQ = queryParams.searchText || '';
+                    this.searchStr = restoredQ;
+                    this.searchedName.setValue(restoredQ, { emitEvent: false });
+                    this.showNameSearch = restoredQ ? true : false;
+                    this.showClearFilter.set(true);
+                    this.searchStr$.next(restoredQ);
+                } else {
+                    this.universalDate$.pipe(filter(Boolean),take(1)).subscribe(response => {
+                        if (response) {
+                            this.fromDate = dayjs(response[0]).format(GIDDH_DATE_FORMAT);
+                            this.toDate = dayjs(response[1]).format(GIDDH_DATE_FORMAT);
+                            this.selectedDateRange = {
+                                startDate: dayjs(response[0]),
+                                endDate: dayjs(response[1]),
+                            };
+                            this.selectedDateRangeUi = dayjs(response[0]).format(GIDDH_NEW_DATE_FORMAT_UI) + " - " + dayjs(response[1]).format(GIDDH_NEW_DATE_FORMAT_UI);
+                            const restoredQ = queryParams.searchText || '';
+                            this.searchStr = restoredQ;
+                            this.searchedName.setValue(restoredQ, { emitEvent: false });
+                            this.showNameSearch = restoredQ ? true : false;
+                            this.showClearFilter.set(restoredQ ? true : false);
+                            this.searchStr$.next(restoredQ);
+                        }
+                    });
+                }
             }
         });
 
@@ -409,35 +438,6 @@ export class ContactComponent implements OnInit, OnDestroy {
             this.cdRef.detectChanges();
         });
 
-        this.universalDate$.pipe(takeUntil(this.destroyed$)).subscribe(dateObj => {
-            if (dateObj) {
-                this.universalDate = cloneDeep(dateObj);
-
-                setTimeout(() => {
-
-                    this.store.pipe(select(state => state.session.todaySelected), take(1)).subscribe(response => {
-                        this.todaySelected = response;
-
-                        if (this.universalDate && !this.todaySelected) {
-                            this.fromDate = dayjs(this.universalDate[0]).format(GIDDH_DATE_FORMAT);
-                            this.toDate = dayjs(this.universalDate[1]).format(GIDDH_DATE_FORMAT);
-                            this.selectedDateRange = {
-                                startDate: dayjs(this.universalDate[0]),
-                                endDate: dayjs(this.universalDate[1]),
-                            };
-                            this.advanceFilters.from = this.fromDate;
-                            this.advanceFilters.to = this.toDate;
-                            this.selectedDateRangeUi = dayjs(this.universalDate[0]).format(GIDDH_NEW_DATE_FORMAT_UI) + " - " + dayjs(this.universalDate[1]).format(GIDDH_NEW_DATE_FORMAT_UI);
-                        } else {
-                            this.universalDate = [];
-                            this.fromDate = "";
-                            this.toDate = "";
-                        }
-                        this.getAccounts(this.fromDate, this.toDate, null, "true", PAGINATION_LIMIT, this.searchStr, this.key, this.order, (this.currentBranch ? this.currentBranch.uniqueName : ""));
-                    });
-                }, 100);
-            }
-        });
 
         this.createAccountIsSuccess$.pipe(takeUntil(this.destroyed$)).subscribe(response => {
             if (response) {
@@ -453,13 +453,11 @@ export class ContactComponent implements OnInit, OnDestroy {
         });
 
         this.searchStr$.pipe(
-            debounceTime(1000),
-            distinctUntilChanged(), takeUntil(this.destroyed$))
+            takeUntil(this.destroyed$))
             .subscribe((term: any) => {
                 if (term != null && term != undefined) {
                     this.searchStr = term;
                     this.advanceFilters.q = term;
-                    this.showClearFilter.set(term ? true : false);
                     this.getAccounts(this.fromDate, this.toDate, null, "true", PAGINATION_LIMIT, term, this.key, this.order, (this.currentBranch ? this.currentBranch.uniqueName : ""));
                 }
             });
@@ -1016,12 +1014,13 @@ export class ContactComponent implements OnInit, OnDestroy {
 
         this.toggleGiddhDatepicker(false);
         if (value && value.startDate && value.endDate) {
-            this.todaySelected = false;
-            this.selectedDateRange = { startDate: dayjs(value.startDate), endDate: dayjs(value.endDate) };
-            this.selectedDateRangeUi = dayjs(value.startDate).format(GIDDH_NEW_DATE_FORMAT_UI) + " - " + dayjs(value.endDate).format(GIDDH_NEW_DATE_FORMAT_UI);
+            this.showClearFilter.set(true);
+            // this.selectedDateRange = { startDate: dayjs(value.startDate), endDate: dayjs(value.endDate) };
+            // this.selectedDateRangeUi = dayjs(value.startDate).format(GIDDH_NEW_DATE_FORMAT_UI) + " - " + dayjs(value.endDate).format(GIDDH_NEW_DATE_FORMAT_UI);
             this.fromDate = dayjs(value.startDate).format(GIDDH_DATE_FORMAT);
             this.toDate = dayjs(value.endDate).format(GIDDH_DATE_FORMAT);
-            this.getAccounts(this.fromDate, this.toDate, null, "true", PAGINATION_LIMIT, this.searchStr, this.key, this.order, (this.currentBranch ? this.currentBranch.uniqueName : ""));
+            this.generalService.saveRouteQueryFilters({ fromDate: this.fromDate, toDate: this.toDate });
+            // this.getAccounts(this.fromDate, this.toDate, null, "true", PAGINATION_LIMIT, this.searchStr, this.key, this.order, (this.currentBranch ? this.currentBranch.uniqueName : ""));
             this.detectChanges();
         }
     }
@@ -1203,7 +1202,7 @@ export class ContactComponent implements OnInit, OnDestroy {
      */
     private getAccounts(fromDate: string, toDate: string, pageNumber?: number, refresh?: string, count: number = PAGINATION_LIMIT, query?: string,
         sortBy: string = "", order: string = "asc", branchUniqueName?: string): void {
-        this.isGetAccountsInProcess = true;
+        this.isGetAccountsInProcess.set(true);
         pageNumber = pageNumber ? pageNumber : 1;
         refresh = refresh ? refresh : "false";
         fromDate = (fromDate) ? fromDate : "";
@@ -1300,7 +1299,7 @@ export class ContactComponent implements OnInit, OnDestroy {
                 this.allSelectionModel = this.checkboxInfo[this.checkboxInfo.selectedPage] ? true : false;
             }
             if (headerColumns && res) {
-                this.isGetAccountsInProcess = false;
+                this.isGetAccountsInProcess.set(false);
                 this.detectChanges();
             }
         });

--- a/apps/web-giddh/src/app/contact/preview/preview.component.ts
+++ b/apps/web-giddh/src/app/contact/preview/preview.component.ts
@@ -585,7 +585,12 @@ export class ContactPreviewComponent implements OnInit, OnDestroy {
      * @memberof ContactPreviewComponent
      */
     public redirectToGetAllPage(): void {
-        this.router.navigate([`/pages/contact/${this.contactActiveTab}`]);
+        this.router.navigate([`/pages/contact/${this.contactActiveTab}`, {
+            queryParams: {
+                tab: this.contactActiveTab,
+                tabIndex: 1
+            }
+        }]);
     }
 
     /**

--- a/apps/web-giddh/src/app/contact/preview/preview.component.ts
+++ b/apps/web-giddh/src/app/contact/preview/preview.component.ts
@@ -585,12 +585,12 @@ export class ContactPreviewComponent implements OnInit, OnDestroy {
      * @memberof ContactPreviewComponent
      */
     public redirectToGetAllPage(): void {
-        this.router.navigate([`/pages/contact/${this.contactActiveTab}`, {
+        this.router.navigate([`/pages/contact/${this.contactActiveTab}`], {
             queryParams: {
                 tab: this.contactActiveTab,
                 tabIndex: 1
             }
-        }]);
+        });
     }
 
     /**

--- a/apps/web-giddh/src/app/reports/components/report-details-components/report.details.component.ts
+++ b/apps/web-giddh/src/app/reports/components/report-details-components/report.details.component.ts
@@ -301,13 +301,6 @@ constructor(
                 }
             });
 
-        /** Universal date */
-        this.componentStore.universalDate$.pipe(takeUntil(this.destroyed$)).subscribe(response => {
-            if (response) {
-                this.selectedDateRange = { startDate: dayjs(response[0]), endDate: dayjs(response[1]) };
-                this.selectedDateRangeUi = dayjs(response[0]).format(GIDDH_NEW_DATE_FORMAT_UI) + " - " + dayjs(response[1]).format(GIDDH_NEW_DATE_FORMAT_UI);
-            }
-        });
         this.store.pipe(select(state => state.general.states), filter(Boolean), takeUntil(this.destroyed$)).subscribe(states => {
             if (states && (states.stateList ?? states.countyList)) {
                 this.stateList.set((states.stateList ?? states.countyList).map(state => ({
@@ -319,7 +312,7 @@ constructor(
         });
 
         // Subscribe to countryCode changes to automatically load states
-        this.reportForm.get('countryCode')?.valueChanges.pipe(filter(Boolean), takeUntil(this.destroyed$)).subscribe(countryCode => {
+        this.reportForm.get('countryCode')?.valueChanges.pipe(filter(Boolean), distinctUntilChanged(), takeUntil(this.destroyed$)).subscribe(countryCode => {
             if (countryCode) {
                 this.loadStates(countryCode);
             } else {
@@ -444,68 +437,89 @@ constructor(
                 currentBranchUniqueName = registerReportFilters ? registerReportFilters.branchChosenInReport : '';
                 return activeCompany;
             }))),
-            this.activeRoute.queryParams.pipe(distinctUntilChanged()),
+            this.activeRoute.queryParams.pipe(debounceTime(700), distinctUntilChanged()),
         ]).pipe(takeUntil(this.destroyed$)).subscribe(([activeCompany, queryParam]) => {
 
+            this.reportForm.get('accountUniqueNames').patchValue(this.generalService.parseQueryParamArray(queryParam?.accountUniqueNames));
+            this.currentBranch.uniqueName = currentBranchUniqueName ?? this.currentBranch?.uniqueName ?? "";
+            const foundBranch = this.currentCompanyBranches?.find(branch => branch?.value === this.currentBranch?.uniqueName);
+            this.currentBranch.name = foundBranch ? foundBranch.name : this.currentBranch?.name;
             // URL groupBy takes priority over store value
             if (queryParam?.groupBy && [GroupBy.SalesPerson, GroupBy.State, GroupBy.Country].includes(queryParam.groupBy)) {
                 this.reportForm.get('groupBy').patchValue(queryParam.groupBy);
+
+                if (this.reportForm.get('groupBy').value === GroupBy.SalesPerson) {
+                    this.reportForm.get('salesPersonUniqueNames').patchValue(this.generalService.parseQueryParamArray(queryParam?.salesPersonUniqueNames));
+                }
+
+                if (this.reportForm.get('groupBy').value === GroupBy.State) {
+                    this.reportForm.get('countryCode').patchValue(queryParam.countryCode ?? this.activeCompany.countryV2?.alpha2CountryCode);
+                    this.reportForm.get('stateCodes').patchValue(this.generalService.parseQueryParamArray(queryParam?.stateCodes));
+                }
+
+                if (this.reportForm.get('groupBy').value === GroupBy.Country) {
+                    this.reportForm.get('countryCodes').patchValue(this.generalService.parseQueryParamArray(queryParam?.countryCodes));
+                }
+
+                if (queryParam?.fromDate && queryParam?.toDate) {
+                    this.dateRange.from = queryParam.fromDate;
+                    this.dateRange.to = queryParam.toDate;
+                    this.selectedDateRange = {
+                        startDate: dayjs(queryParam.fromDate, GIDDH_DATE_FORMAT),
+                        endDate: dayjs(queryParam.toDate, GIDDH_DATE_FORMAT),
+                    };
+                    this.selectedDateRangeUi = dayjs(queryParam.fromDate, GIDDH_DATE_FORMAT).format(GIDDH_NEW_DATE_FORMAT_UI) + ' - ' + dayjs(queryParam.toDate, GIDDH_DATE_FORMAT).format(GIDDH_NEW_DATE_FORMAT_UI);
+                    this.getSalesRegister(this.dateRange.from, this.dateRange.to);
+                } else {
+                    this.componentStore.universalDate$.pipe(filter(Boolean),take(1)).subscribe(response => {
+                        if (response) {
+                            this.dateRange.from = dayjs(response[0]).format(GIDDH_DATE_FORMAT);
+                            this.dateRange.to = dayjs(response[1]).format(GIDDH_DATE_FORMAT);
+                            this.selectedDateRange = {
+                                startDate: dayjs(response[0]),
+                                endDate: dayjs(response[1]),
+                            };
+                            this.selectedDateRangeUi = dayjs(response[0]).format(GIDDH_NEW_DATE_FORMAT_UI) + " - " + dayjs(response[1]).format(GIDDH_NEW_DATE_FORMAT_UI);
+                            this.getSalesRegister(this.dateRange.from, this.dateRange.to);
+                        }
+                    });
+                }
+
             } else {
                 this.reportForm.get('groupBy').patchValue(GroupBy.Duration);
-            }
-            
-            if (this.reportForm.get('groupBy').value === GroupBy.SalesPerson) {
-                this.reportForm.get('salesPersonUniqueNames').patchValue(this.generalService.parseQueryParamArray(queryParam?.salesPersonUniqueNames));
-            }
-
-            if (this.reportForm.get('groupBy').value === GroupBy.State) {
-                this.reportForm.get('countryCode').patchValue(queryParam.countryCode ?? this.activeCompany.countryV2?.alpha2CountryCode);
-                this.reportForm.get('stateCodes').patchValue(this.generalService.parseQueryParamArray(queryParam?.stateCodes));
-            }
-
-            if (this.reportForm.get('groupBy').value === GroupBy.Country) {
-                this.reportForm.get('countryCodes').patchValue(this.generalService.parseQueryParamArray(queryParam?.countryCodes));
-            }
-
-            if (this.reportForm.get('groupBy').value === GroupBy.Duration) {
+                this.generalService.saveRouteQueryFilters({groupBy: GroupBy.Duration, required: "groupBy"});
                 this.selectedType = queryParam.interval ?? this.durationEnum.Monthly;
                 this.interval = this.selectedType;
                 this.reportForm.get('interval').patchValue(this.selectedType);
                 this.selectedMonth = queryParam.selectedMonth ?? '';
-            }
 
-            this.reportForm.get('accountUniqueNames').patchValue(this.generalService.parseQueryParamArray(queryParam?.accountUniqueNames));
-
-            if (activeCompany) {
-                this.selectedCompany = activeCompany;
-                this.financialOptions = activeCompany.financialYears?.map(response => {
-                    if (response) {
-                        return { label: response.uniqueName, value: response.uniqueName };
+                if (activeCompany) {
+                    this.selectedCompany = activeCompany;
+                    this.financialOptions = activeCompany.financialYears?.map(response => {
+                        if (response) {
+                            return { label: response.uniqueName, value: response.uniqueName };
+                        }
+                    });
+                    let selectedFinancialYear, activeFinancialYear, uniqueNameToSearch;
+                    if (financialYearChosenInReportUniqueName) {
+                        // User is navigating back from details page hence show the selected filter as pre-filled
+                        uniqueNameToSearch = financialYearChosenInReportUniqueName;
+                    } else {
+                        uniqueNameToSearch = (activeCompany.activeFinancialYear) ? activeCompany.activeFinancialYear.uniqueName : "";
                     }
-                });
-                let selectedFinancialYear, activeFinancialYear, uniqueNameToSearch;
-                if (financialYearChosenInReportUniqueName) {
-                    // User is navigating back from details page hence show the selected filter as pre-filled
-                    uniqueNameToSearch = financialYearChosenInReportUniqueName;
-                } else {
-                    uniqueNameToSearch = (activeCompany.activeFinancialYear) ? activeCompany.activeFinancialYear.uniqueName : "";
+                    selectedFinancialYear = this.financialOptions?.find(option => option?.value === uniqueNameToSearch);
+                    activeFinancialYear = this.selectedCompany.financialYears?.find(p => p?.uniqueName === uniqueNameToSearch);
+                    this.activeFinacialYr = activeFinancialYear;
+                    if (!this.activeFinacialYr && this.selectedCompany.financialYears?.length) {
+                        this.activeFinacialYr = this.selectedCompany.financialYears[0];
+                        selectedFinancialYear = this.selectedCompany.financialYears[0];
+                    }
+                    if (selectedFinancialYear) {
+                        this.currentActiveFinacialYear = cloneDeep(selectedFinancialYear);
+                    }
+                    this.populateRecords(this.selectedType, this.selectedMonth);
+                    this.changeDetectorRef.detectChanges();
                 }
-                selectedFinancialYear = this.financialOptions?.find(option => option?.value === uniqueNameToSearch);
-                activeFinancialYear = this.selectedCompany.financialYears?.find(p => p?.uniqueName === uniqueNameToSearch);
-                this.activeFinacialYr = activeFinancialYear;
-                if (!this.activeFinacialYr && this.selectedCompany.financialYears?.length) {
-                    this.activeFinacialYr = this.selectedCompany.financialYears[0];
-                    selectedFinancialYear = this.selectedCompany.financialYears[0];
-                }
-                if (selectedFinancialYear) {
-                    this.currentActiveFinacialYear = cloneDeep(selectedFinancialYear);
-                }
-                this.currentBranch.uniqueName = currentBranchUniqueName ?? this.currentBranch?.uniqueName ?? "";
-                const foundBranch = this.currentCompanyBranches?.find(branch => branch?.value === this.currentBranch?.uniqueName);
-                this.currentBranch.name = foundBranch ? foundBranch.name : this.currentBranch?.name;
-                this.populateRecords(this.selectedType, this.selectedMonth);
-                this.salesRegisterTotal.particular = this.getCustomParticular();
-                this.changeDetectorRef.detectChanges();
             }
         });
     }
@@ -564,27 +578,6 @@ constructor(
 
     public formatParticular(mdyTo, mdyFrom, index, monthNames) {
         return this.commonLocaleData?.app_quarter + ' ' + index + " (" + monthNames[parseInt(mdyFrom[1]) - 1] + " " + mdyFrom[2] + "-" + monthNames[parseInt(mdyTo[1]) - 1] + " " + mdyTo[2] + ")";
-    }
-
-    public bsValueChange(event: any) {
-        if (event) {
-            let request: ReportsRequestModel = {
-                to: dayjs(event[1]).format(GIDDH_DATE_FORMAT),
-                from: dayjs(event[0]).format(GIDDH_DATE_FORMAT),
-                interval: this.durationEnum.Monthly,
-                branchUniqueName: (this.currentBranch ? this.currentBranch.uniqueName : "")
-            }
-            this.companyService.getSalesRegister(request).pipe(takeUntil(this.destroyed$)).subscribe((res) => {
-                if (res?.status === 'error') {
-                    this._toaster.errorToast(res?.message);
-                } else {
-                    this.salesRegisterTotal = new ReportsModel();
-                    this.salesRegisterTotal.particular = this.getCustomParticular();
-                    this.reportRespone = this.filterReportResp(res?.body);
-                }
-            });
-
-        }
     }
 
     public getDateFromMonth(selectedMonth) {
@@ -910,11 +903,9 @@ constructor(
         }
         this.toggleGiddhDatepicker(false);
         if (value && value.startDate && value.endDate) {
-            this.selectedDateRange = { startDate: dayjs(value.startDate), endDate: dayjs(value.endDate) };
-            this.selectedDateRangeUi = dayjs(value.startDate).format(GIDDH_NEW_DATE_FORMAT_UI) + " - " + dayjs(value.endDate).format(GIDDH_NEW_DATE_FORMAT_UI);
             this.dateRange.from = dayjs(value.startDate).format(GIDDH_DATE_FORMAT);
             this.dateRange.to = dayjs(value.endDate).format(GIDDH_DATE_FORMAT);
-            this.getSalesRegister(this.dateRange.from, this.dateRange.to);
+            this.generalService.saveRouteQueryFilters({ fromDate: this.dateRange.from, toDate: this.dateRange.to });
         }
     }
 
@@ -933,6 +924,7 @@ constructor(
             return;
         }
         this.savePreferences();
+        this.salesRegisterTotal.particular = this.getCustomParticular();
         const requestObject = cloneDeep(this.reportForm.value);
         const groupByValue = this.reportForm?.get('groupBy')?.value;
 

--- a/apps/web-giddh/src/app/reports/components/report-details-components/report.details.component.ts
+++ b/apps/web-giddh/src/app/reports/components/report-details-components/report.details.component.ts
@@ -441,7 +441,7 @@ constructor(
         ]).pipe(takeUntil(this.destroyed$)).subscribe(([activeCompany, queryParam]) => {
 
             this.reportForm.get('accountUniqueNames').patchValue(this.generalService.parseQueryParamArray(queryParam?.accountUniqueNames));
-            this.currentBranch.uniqueName = currentBranchUniqueName ?? this.currentBranch?.uniqueName ?? "";
+            this.currentBranch.uniqueName = currentBranchUniqueName || this.currentBranch?.uniqueName || "";
             const foundBranch = this.currentCompanyBranches?.find(branch => branch?.value === this.currentBranch?.uniqueName);
             this.currentBranch.name = foundBranch ? foundBranch.name : this.currentBranch?.name;
             // URL groupBy takes priority over store value
@@ -453,7 +453,7 @@ constructor(
                 }
 
                 if (this.reportForm.get('groupBy').value === GroupBy.State) {
-                    this.reportForm.get('countryCode').patchValue(queryParam.countryCode ?? this.activeCompany.countryV2?.alpha2CountryCode);
+                    this.reportForm.get('countryCode').patchValue(queryParam.countryCode ?? (this.activeCompany || activeCompany)?.countryV2?.alpha2CountryCode);
                     this.reportForm.get('stateCodes').patchValue(this.generalService.parseQueryParamArray(queryParam?.stateCodes));
                 }
 

--- a/apps/web-giddh/src/app/reports/components/sales-register-expand-component/sales.register.expand.component.ts
+++ b/apps/web-giddh/src/app/reports/components/sales-register-expand-component/sales.register.expand.component.ts
@@ -332,7 +332,7 @@ public voucherNumberInput: UntypedFormControl = new UntypedFormControl();
      */
     public gotoSalesRegister(): void {
         this.activeRoute.queryParams.pipe(take(1)).subscribe(params => {
-            this.router.navigate(['pages', 'reports', 'sales-register'], { queryParams: { from: params.from, to: params.to, branchUniqueName: params.branchUniqueName, interval: params.interval, selectedMonth: params.selectedMonth, groupBy: this.currentGroupBy() } });
+            this.router.navigate(['pages', 'reports', 'sales-register'], { queryParams: { groupBy: this.currentGroupBy(), required: "groupBy" } });
         });
     }
 

--- a/apps/web-giddh/src/app/services/general.service.ts
+++ b/apps/web-giddh/src/app/services/general.service.ts
@@ -2352,6 +2352,15 @@ export class GeneralService {
         return { path: scopedPath, queryParams: replaceOnly ? forcedParams : currentUrlParams };
     }
 
+    /** List of scoped route paths that support fromDate/toDate query param persistence */
+    public readonly currentSupportedQueryParam: string[] = [
+        '/pages/contact/customer?tab=customer&tabIndex=1',
+        '/pages/contact/vendor?tab=vendor&tabIndex=1',
+        '/pages/reports/sales-register?groupBy=salesPerson',
+        '/pages/reports/sales-register?groupBy=state',
+        '/pages/reports/sales-register?groupBy=country'
+    ];
+
     /**
      * Update current page query params
      *

--- a/apps/web-giddh/src/app/shared/header/header.component.ts
+++ b/apps/web-giddh/src/app/shared/header/header.component.ts
@@ -1596,6 +1596,9 @@ export class HeaderComponent implements OnInit, AfterViewInit, OnDestroy, AfterV
                 toDate: this.toDate,
             };
             this.isTodaysDateSelected = false;
+            if (this.generalService.currentSupportedQueryParam.includes(this.generalService.getCurrentPath(true).path)) {
+                this.generalService.saveRouteQueryFilters({ fromDate: this.fromDate, toDate: this.toDate });
+            }
             this.store.dispatch(this.companyActions.SetApplicationDate(dates));
         } else {
             this.isTodaysDateSelected = true;
@@ -1611,6 +1614,9 @@ export class HeaderComponent implements OnInit, AfterViewInit, OnDestroy, AfterV
                 period: null,
                 noOfTransactions: null
             };
+            if (this.generalService.currentSupportedQueryParam.includes(this.generalService.getCurrentPath(true).path)) {
+                this.generalService.saveRouteQueryFilters({ fromDate: dayjs().subtract(30, 'day').format(GIDDH_DATE_FORMAT), toDate: dayjs().format(GIDDH_DATE_FORMAT) });
+            }
             this.store.dispatch(this.companyActions.SetApplicationDate(dates));
         }
     }

--- a/apps/web-giddh/src/assets/locale/sidebar-menu/en.json
+++ b/apps/web-giddh/src/assets/locale/sidebar-menu/en.json
@@ -24,7 +24,8 @@
                     "description": "Manage customers, send reminders via SMS/Email",
                     "additional": {
                         "queryParams": {
-                            "tab": "customer"
+                            "tab": "customer",
+                            "tabIndex": 1
                         },
                         "createNew": {
                             "label": "+",
@@ -446,7 +447,8 @@
                     "additional": {
                         "queryParams": {
                             "voucherVersion": 2,
-                            "tab": "vendor"
+                            "tab": "vendor",
+                            "tabIndex": 1
                         },
                         "createNew": {
                             "label": "+",

--- a/apps/web-giddh/src/assets/locale/sidebar-menu/hi.json
+++ b/apps/web-giddh/src/assets/locale/sidebar-menu/hi.json
@@ -24,7 +24,8 @@
                     "description": "ग्राहकों को प्रबंधित करें, एसएमएस/ईमेल के माध्यम से अनुस्मारक भेजें",
                     "additional": {
                         "queryParams": {
-                            "tab": "customer"
+                            "tab": "customer",
+                            "tabIndex": 1
                         },
                         "createNew": {
                             "label": "+",
@@ -446,7 +447,8 @@
                     "additional": {
                         "queryParams": {
                             "voucherVersion": 2,
-                            "tab": "vendor"
+                            "tab": "vendor",
+                            "tabIndex": 1
                         },
                         "createNew": {
                             "label": "+",

--- a/apps/web-giddh/src/assets/locale/sidebar-menu/mr.json
+++ b/apps/web-giddh/src/assets/locale/sidebar-menu/mr.json
@@ -24,7 +24,8 @@
                     "description": "ग्राहक व्यवस्थापित करा, एसएमएस / ईमेलद्वारे स्मरणपत्रे पाठवा",
                     "additional": {
                         "queryParams": {
-                            "tab": "customer"
+                            "tab": "customer",
+                            "tabIndex": 1
                         },
                         "createNew": {
                             "label": "+",
@@ -446,7 +447,8 @@
                     "additional": {
                         "queryParams": {
                             "voucherVersion": 2,
-                            "tab": "vendor"
+                            "tab": "vendor",
+                            "tabIndex": 1
                         },
                         "createNew": {
                             "label": "+",


### PR DESCRIPTION
## **User description**
https://app.clickup.com/t/86d27x9e5


___

## **CodeAnt-AI Description**
Persist date and filter selections in URLs for contacts and reports and make contact loading state reactive

### What Changed
- Contact and report pages now store and restore selected date ranges and search text in the page URL so returned or bookmarked pages show the same filters and date selections.
- Report details and sales-register pages read group-by, account, sales-person, state/country and date query parameters to prefill report filters and show the corresponding grouped view without needing manual re-selection.
- Date pickers on header, contact list and reports save chosen from/to dates to the URL instead of immediately triggering data fetches; returning pages use the URL values to fetch matching data.
- Contact list loading indicator and template use a reactive signal for the "loading accounts" state so the loader visibility is updated reliably.
- Sidebar links and contact preview back-navigation include tabIndex in query parameters so the correct contact tab and state are restored when navigating back.

### Impact
`✅ Restored search and date filters when returning to contacts`
`✅ Persistent report group and date filters via URL`
`✅ Stable contact list loader visibility`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Query-parameter updates are now coalesced to avoid rapid repeated processing, reducing UI thrash during fast navigation.

* **Contact Management**
  * Date filters and search state are more reliably restored when switching tabs or returning from previews.
  * Loading indicators and tab behavior improved for clearer account loading status.

* **Reports**
  * Report filters (including date and grouping) persist to the URL and restore consistently.

* **Navigation**
  * Menu links now include tab indexing for consistent landing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->