### PR TITLE
Production to Books

### DIFF
--- a/apps/web-giddh/src/app/contact/aging-report/aging-report.component.html
+++ b/apps/web-giddh/src/app/contact/aging-report/aging-report.component.html
@@ -4,7 +4,7 @@
             *ngIf="
                 (dueAmountReportData$ | async)?.results?.length ||
                 (getAgingReportRequestInProcess$ | async) ||
-                showClearFilter ||
+                showClearFilter() ||
                 isAdvanceSearchApplied
             "
             class="top-bar aging-top-bar d-flex align-items-center justify-content-between"
@@ -33,7 +33,7 @@
             </div>
             <div
                 class="clear-filter align-items-center d-flex justify-content-xl-center justify-content-lg-start"
-                *ngIf="showClearFilter || isAdvanceSearchApplied"
+                *ngIf="showClearFilter() || isAdvanceSearchApplied"
             >
                 <button matButton="outlined" class="mr-0" (click)="resetAdvanceSearch()" aria-label="filter">
                     <span class="icon-cross"></span>
@@ -127,7 +127,7 @@
                 *ngIf="
                     !(dueAmountReportData$ | async)?.results?.length &&
                     !(getAgingReportRequestInProcess$ | async) &&
-                    !showClearFilter &&
+                    !showClearFilter() &&
                     !isAdvanceSearchApplied
                 "
             >
@@ -148,7 +148,7 @@
                 *ngIf="
                     !(dueAmountReportData$ | async)?.results?.length &&
                     !(getAgingReportRequestInProcess$ | async) &&
-                    (showClearFilter || isAdvanceSearchApplied)
+                    (showClearFilter() || isAdvanceSearchApplied)
                 "
             >
                 <no-data [secondaryMessageClass]="'p-0'"></no-data>

--- a/apps/web-giddh/src/app/contact/aging-report/aging-report.component.ts
+++ b/apps/web-giddh/src/app/contact/aging-report/aging-report.component.ts
@@ -216,7 +216,7 @@ export class AgingReportComponent implements OnInit, OnDestroy {
             distinctUntilChanged(),
             takeUntil(this.destroyed$),
         ).subscribe(term => {
-            if (term!=undefined && term!=null) {
+            if (term !== undefined && term !== null) {
                 this.showClearFilter = (term) ? true : false;
                 this.dueAmountReportRequest.q = term;
                 this.getDueReport();

--- a/apps/web-giddh/src/app/contact/aging-report/aging-report.component.ts
+++ b/apps/web-giddh/src/app/contact/aging-report/aging-report.component.ts
@@ -8,7 +8,8 @@ import {
     Input,
     OnDestroy,
     TemplateRef,
-    Inject
+    Inject,
+    signal
 } from "@angular/core";
 import {
     AgingAdvanceSearchModal,
@@ -112,7 +113,7 @@ export class AgingReportComponent implements OnInit, OnDestroy {
     /** Mat menu instance reference */
     @ViewChild(MatMenuTrigger) menu: MatMenuTrigger;
     /** True, if custom date filter is selected or custom searching or sorting is performed */
-    public showClearFilter: boolean = false;
+    public showClearFilter = signal<boolean>(false);
     /** Holds images folder path */
     public imgPath: string = "";
     /** False for on init call */
@@ -202,7 +203,6 @@ export class AgingReportComponent implements OnInit, OnDestroy {
         });
         this.voucherApiVersion = this.generalService.voucherApiVersion;
         this.store.dispatch(this.settingsFinancialYearActions.getFinancialYearLimits());
-        this.getDueReport();
         this.imgPath = Configuration.isElectron ? 'assets/images/' : (this.serviceConfig.AppUrl || environment.AppUrl) + environment.APP_FOLDER + 'assets/images/';
         this.getDueAmountreportData();
         this.currentOrganizationType = this.generalService.currentOrganizationType;
@@ -217,7 +217,6 @@ export class AgingReportComponent implements OnInit, OnDestroy {
             takeUntil(this.destroyed$),
         ).subscribe(term => {
             if (term !== undefined && term !== null) {
-                this.showClearFilter = (term) ? true : false;
                 this.dueAmountReportRequest.q = term;
                 this.getDueReport();
             }
@@ -280,10 +279,14 @@ export class AgingReportComponent implements OnInit, OnDestroy {
                     this.commonRequest.amountType = queryParams.amountType || '';
                     this.commonRequest.amount = queryParams.amount ? Number(queryParams.amount) : null;
                     this.dueAmountReportRequest.q = restoredQ;
+                    this.showClearFilter.set(true);
                     this.applyAdvanceSearch(this.commonRequest, true);
                 } else {
+                    this.showClearFilter.set(restoredQ ? true : false);
                     this.searchStr$.next(restoredQ);
                 }
+            } else {
+                this.generalService.saveRouteQueryFilters({ tab: 'aging-report', tabIndex: 1 });
             }
         });
 
@@ -351,7 +354,7 @@ export class AgingReportComponent implements OnInit, OnDestroy {
         }
         this.isAdvanceSearchApplied = false;
         this.dueAmountReportRequest.q = '';
-        this.showClearFilter = false;
+        this.showClearFilter.set(false);
         this.generalService.saveRouteQueryFilters(null, true);
         this.sort("name", "asc");
     }
@@ -413,12 +416,12 @@ export class AgingReportComponent implements OnInit, OnDestroy {
         }
 
         this.isAdvanceSearchApplied = true;
-        this.showClearFilter = false;
+        this.showClearFilter.set(false);
         this.getDueReport();
     }
 
     public sort(key: string, ord: "asc" | "desc" = "asc") {
-        this.showClearFilter = true;
+        this.showClearFilter.set(true);
         if (key.includes("range")) {
             this.dueAmountReportRequest.rangeCol = parseInt(key?.replace("range", ""));
             this.dueAmountReportRequest.sortBy = "range";

--- a/apps/web-giddh/src/app/contact/aging-report/aging-report.component.ts
+++ b/apps/web-giddh/src/app/contact/aging-report/aging-report.component.ts
@@ -269,7 +269,7 @@ export class AgingReportComponent implements OnInit, OnDestroy {
             }
         });
 
-        this.route.queryParams.pipe(takeUntil(this.destroyed$)).subscribe(queryParams => {
+        this.route.queryParams.pipe(debounceTime(700), takeUntil(this.destroyed$)).subscribe(queryParams => {
             if (queryParams.tab === 'aging-report') {
                 const restoredQ = queryParams.searchText || '';
                 this.searchStr = restoredQ;

--- a/apps/web-giddh/src/app/contact/aging-report/aging-report.component.ts
+++ b/apps/web-giddh/src/app/contact/aging-report/aging-report.component.ts
@@ -36,7 +36,7 @@ import { PageEvent } from "@angular/material/paginator";
 import { BranchHierarchyType, PAGINATION_LIMIT, PAGE_SIZE_OPTIONS, ASIDE_PANE_CONFIG, Configuration } from "../../app.constant";
 import { AgingreportingService } from "../../services/agingreporting.service";
 import { ToasterService } from "../../services/toaster.service";
-import { Router } from "@angular/router";
+import { ActivatedRoute, Router } from "@angular/router";
 import { VoucherTypeEnum } from "../../models/api-models/Sales";
 import { ReceiptService } from "../../services/receipt.service";
 import { InvoiceReceiptFilter } from "../../models/api-models/recipt";
@@ -149,6 +149,7 @@ export class AgingReportComponent implements OnInit, OnDestroy {
         private settingsBranchAction: SettingsBranchActions,
         private generalService: GeneralService,
         private router: Router,
+        private route: ActivatedRoute,
         private agingReportService: AgingreportingService,
         private receiptService: ReceiptService,
         private scrollDispatcher: ScrollDispatcher,
@@ -215,12 +216,11 @@ export class AgingReportComponent implements OnInit, OnDestroy {
             distinctUntilChanged(),
             takeUntil(this.destroyed$),
         ).subscribe(term => {
-            if (!this.defaultLoad) {
+            if (term!=undefined && term!=null) {
                 this.showClearFilter = (term) ? true : false;
                 this.dueAmountReportRequest.q = term;
                 this.getDueReport();
             }
-            this.defaultLoad = false;
         });
 
         this.store.pipe(
@@ -268,12 +268,31 @@ export class AgingReportComponent implements OnInit, OnDestroy {
                 }
             }
         });
+
+        this.route.queryParams.pipe(takeUntil(this.destroyed$)).subscribe(queryParams => {
+            const params = queryParams;
+            if (params.tab === 'aging-report') {
+                const restoredQ = params.searchText || '';
+                this.searchStr = restoredQ;
+                this.searchedName.setValue(restoredQ, { emitEvent: false });
+                this.showNameSearch = restoredQ ? true : false;
+                if (params.category || params.amountType || params.amount) {
+                    this.commonRequest.category = params.category || '';
+                    this.commonRequest.amountType = params.amountType || '';
+                    this.commonRequest.amount = params.amount ? Number(params.amount) : null;
+                    this.applyAdvanceSearch(this.commonRequest, true);
+                } else {
+                    this.searchStr$.next(restoredQ);
+                }
+            }
+        });
+
         this.searchedName?.valueChanges.pipe(
             debounceTime(700),
             distinctUntilChanged(),
             takeUntil(this.destroyed$),
         ).subscribe(searchedText => {
-            this.searchStr$.next(searchedText);
+            this.generalService.saveRouteQueryFilters({ searchText: searchedText || null });
         });
 
         this.store.pipe(select(state => state.agingreport.setDueRangeRequestInFlight), takeUntil(this.destroyed$)).subscribe(response => {
@@ -330,19 +349,29 @@ export class AgingReportComponent implements OnInit, OnDestroy {
         if (this.agingReportAdvanceSearch) {
             this.agingReportAdvanceSearch.reset();
         }
-        this.searchStr$.next('');
-        this.searchedName?.reset();
-        this.searchStr = "";
-        this.showNameSearch = false;
         this.isAdvanceSearchApplied = false;
         this.dueAmountReportRequest.q = '';
-        this.sort("name", "asc");
         this.showClearFilter = false;
-        this.defaultLoad = true;
+        this.generalService.saveRouteQueryFilters(null, true);
+        this.sort("name", "asc");
     }
 
-    public applyAdvanceSearch(request: ContactAdvanceSearchCommonModal) {
+    /**
+     * Saves the current advance search filters and search text to localStorage and URL query params
+     *
+     * @private
+     * @memberof AgingReportComponent
+     */
+    private saveAgingReportFilters(): void {
+        const { category, amountType, amount } = this.commonRequest;
+        this.generalService.saveRouteQueryFilters({ category, amountType, amount });
+    }
+
+    public applyAdvanceSearch(request: ContactAdvanceSearchCommonModal, skipSave: boolean = false) {
         this.commonRequest = request;
+        if (!skipSave) {
+            this.saveAgingReportFilters();
+        }
         this.agingAdvanceSearchModal.totalDueAmount = request.amount;
         if (request.category === "totalDue") {
             this.agingAdvanceSearchModal.includeTotalDueAmount = true;

--- a/apps/web-giddh/src/app/contact/aging-report/aging-report.component.ts
+++ b/apps/web-giddh/src/app/contact/aging-report/aging-report.component.ts
@@ -270,16 +270,16 @@ export class AgingReportComponent implements OnInit, OnDestroy {
         });
 
         this.route.queryParams.pipe(takeUntil(this.destroyed$)).subscribe(queryParams => {
-            const params = queryParams;
-            if (params.tab === 'aging-report') {
-                const restoredQ = params.searchText || '';
+            if (queryParams.tab === 'aging-report') {
+                const restoredQ = queryParams.searchText || '';
                 this.searchStr = restoredQ;
                 this.searchedName.setValue(restoredQ, { emitEvent: false });
                 this.showNameSearch = restoredQ ? true : false;
-                if (params.category || params.amountType || params.amount) {
-                    this.commonRequest.category = params.category || '';
-                    this.commonRequest.amountType = params.amountType || '';
-                    this.commonRequest.amount = params.amount ? Number(params.amount) : null;
+                if (queryParams.category || queryParams.amountType || queryParams.amount) {
+                    this.commonRequest.category = queryParams.category || '';
+                    this.commonRequest.amountType = queryParams.amountType || '';
+                    this.commonRequest.amount = queryParams.amount ? Number(queryParams.amount) : null;
+                    this.dueAmountReportRequest.q = restoredQ;
                     this.applyAdvanceSearch(this.commonRequest, true);
                 } else {
                     this.searchStr$.next(restoredQ);

--- a/apps/web-giddh/src/app/contact/contact.component.html
+++ b/apps/web-giddh/src/app/contact/contact.component.html
@@ -84,7 +84,7 @@
                                 </div>
                                 <div
                                     class="clear-filter align-items-center d-flex justify-content-xl-center justify-content-lg-start w-50"
-                                    *ngIf="showClearFilter"
+                                    *ngIf="showClearFilter()"
                                 >
                                     <button matButton="outlined" class="mr-0" (click)="resetAdvanceSearch()" aria-label="filter">
                                         <span class="icon-cross"></span>

--- a/apps/web-giddh/src/app/contact/contact.component.html
+++ b/apps/web-giddh/src/app/contact/contact.component.html
@@ -305,11 +305,11 @@
                     <div class="contact-main customer-page on-mobile-view overflow-visible">
                         <div class="pb-4 mb-2 overflow-visible">
                             <div class="overflow-visible">
-                                <div *ngIf="!isGetAccountsInProcess">
+                                <div *ngIf="!isGetAccountsInProcess()">
                                     <ng-container *ngTemplateOutlet="mainTable"></ng-container>
                                 </div>
 
-                                <giddh-page-loader *ngIf="isGetAccountsInProcess"></giddh-page-loader>
+                                <giddh-page-loader *ngIf="isGetAccountsInProcess()"></giddh-page-loader>
                             </div>
                         </div>
                     </div>

--- a/apps/web-giddh/src/app/contact/contact.component.ts
+++ b/apps/web-giddh/src/app/contact/contact.component.ts
@@ -1015,13 +1015,9 @@ export class ContactComponent implements OnInit, OnDestroy {
         this.toggleGiddhDatepicker(false);
         if (value && value.startDate && value.endDate) {
             this.showClearFilter.set(true);
-            // this.selectedDateRange = { startDate: dayjs(value.startDate), endDate: dayjs(value.endDate) };
-            // this.selectedDateRangeUi = dayjs(value.startDate).format(GIDDH_NEW_DATE_FORMAT_UI) + " - " + dayjs(value.endDate).format(GIDDH_NEW_DATE_FORMAT_UI);
             this.fromDate = dayjs(value.startDate).format(GIDDH_DATE_FORMAT);
             this.toDate = dayjs(value.endDate).format(GIDDH_DATE_FORMAT);
             this.generalService.saveRouteQueryFilters({ fromDate: this.fromDate, toDate: this.toDate });
-            // this.getAccounts(this.fromDate, this.toDate, null, "true", PAGINATION_LIMIT, this.searchStr, this.key, this.order, (this.currentBranch ? this.currentBranch.uniqueName : ""));
-            this.detectChanges();
         }
     }
 

--- a/apps/web-giddh/src/app/contact/contact.component.ts
+++ b/apps/web-giddh/src/app/contact/contact.component.ts
@@ -354,9 +354,8 @@ export class ContactComponent implements OnInit, OnDestroy {
         });
 
         this.route.queryParams.pipe(takeUntil(this.destroyed$)).subscribe(queryParams => {
-            const params = queryParams;
-            if (params.tab === 'customer' || params.tab === 'vendor') {
-                const restoredQ = params.searchText || '';
+            if (queryParams.tab === 'customer' || queryParams.tab === 'vendor') {
+                const restoredQ = queryParams.searchText || '';
                 this.searchStr = restoredQ;
                 this.searchedName.setValue(restoredQ, { emitEvent: false });
                 this.showNameSearch = restoredQ ? true : false;

--- a/apps/web-giddh/src/app/contact/contact.component.ts
+++ b/apps/web-giddh/src/app/contact/contact.component.ts
@@ -17,6 +17,7 @@ import {
     Renderer2,
     TemplateRef,
     ViewChild,
+    signal,
 } from "@angular/core";
 import { PageEvent } from '@angular/material/paginator';
 import { ActivatedRoute, Router } from "@angular/router";
@@ -232,7 +233,7 @@ export class ContactComponent implements OnInit, OnDestroy {
     /** True if we should select all checkbox */
     public showSelectAll: boolean = false;
     /** True, if custom date filter is selected or custom searching or sorting is performed */
-    public showClearFilter: boolean = false;
+    public showClearFilter = signal<boolean>(false);
     /** True if it's default load */
     public defaultLoad: boolean = true;
     /** This will use for displayed table columns */
@@ -326,34 +327,42 @@ export class ContactComponent implements OnInit, OnDestroy {
             }
         });
 
-        combineLatest([this.route.params, this.route.queryParams])
-            .pipe(takeUntil(this.destroyed$))
-            .subscribe(([params, queryParams]) => {
-                const lastTabType = this.moduleType;
-                const typeParam = params?.type?.toLowerCase();
-                const tabQueryParam = queryParams?.tab?.toLowerCase();
-                this.moduleType = params.type?.toUpperCase();
+        this.route.params.pipe(takeUntil(this.destroyed$)).subscribe((params) => {
+            const lastTabType = this.moduleType;
+            const typeParam = params?.type?.toLowerCase();
+            this.moduleType = params?.type?.toUpperCase();
 
-                const isCustomer = typeParam?.includes('customer') || tabQueryParam === 'customer';
-                const isVendor = typeParam?.includes('vendor') || tabQueryParam === 'vendor';
+            const isCustomer = typeParam?.includes('customer');
+            const isVendor = typeParam?.includes('vendor');
 
-                const newTab = isCustomer ? 'customer'
-                    : isVendor ? 'vendor'
-                        : 'aging-report';
+            const newTab = isCustomer ? 'customer'
+                : isVendor ? 'vendor'
+                    : 'aging-report';
 
-                const previousTab = this.activeTab;
+            const previousTab = this.activeTab;
 
-                if (newTab !== previousTab) {
-                    this.displayedColumns = [];
-                    this.dynamicCustomColumns = [];
-                    this.setActiveTab(newTab);
-                    this.resetSearchIfSwitched(previousTab);
-                }
+            if (newTab !== previousTab) {
+                this.displayedColumns = [];
+                this.dynamicCustomColumns = [];
+                this.setActiveTab(newTab);
+                this.resetSearchIfSwitched(previousTab);
+            }
 
-                if (lastTabType) {
-                    this.translationComplete(true);
-                }
-            });
+            if (lastTabType) {
+                this.translationComplete(true);
+            }
+        });
+
+        this.route.queryParams.pipe(takeUntil(this.destroyed$)).subscribe(queryParams => {
+            const params = queryParams;
+            if (params.tab === 'customer' || params.tab === 'vendor') {
+                const restoredQ = params.searchText || '';
+                this.searchStr = restoredQ;
+                this.searchedName.setValue(restoredQ, { emitEvent: false });
+                this.showNameSearch = restoredQ ? true : false;
+                this.searchStr$.next(restoredQ);
+            }
+        });
 
         this.store.pipe(select(session => session.session.currentCompanyCurrency), takeUntil(this.destroyed$)).subscribe(res => {
             if (res) {
@@ -448,13 +457,12 @@ export class ContactComponent implements OnInit, OnDestroy {
             debounceTime(1000),
             distinctUntilChanged(), takeUntil(this.destroyed$))
             .subscribe((term: any) => {
-                if (!this.defaultLoad) {
+                if (term != null && term != undefined) {
                     this.searchStr = term;
                     this.advanceFilters.q = term;
+                    this.showClearFilter.set(term ? true : false);
                     this.getAccounts(this.fromDate, this.toDate, null, "true", PAGINATION_LIMIT, term, this.key, this.order, (this.currentBranch ? this.currentBranch.uniqueName : ""));
                 }
-
-                this.defaultLoad = false;
             });
 
         if (this.activeCompany && this.activeCompany.countryV2) {
@@ -522,12 +530,10 @@ export class ContactComponent implements OnInit, OnDestroy {
 
         this.searchedName?.valueChanges.pipe(
             debounceTime(700),
-            distinctUntilChanged(),
             takeUntil(this.destroyed$),
         ).subscribe(searchedText => {
             if (searchedText !== null && searchedText !== undefined) {
-                this.showClearFilter = true;
-                this.searchStr$.next(searchedText);
+                this.generalService.saveRouteQueryFilters({ searchText: searchedText || null });
             }
         });
     }
@@ -690,11 +696,6 @@ export class ContactComponent implements OnInit, OnDestroy {
                 this.getAccounts(this.fromDate, this.toDate, null, "true", PAGINATION_LIMIT, "", this.key, this.order, (this.currentBranch ? this.currentBranch.uniqueName : ""));
             }
 
-            if (!this.hasNavigated) {
-                this.store.dispatch(this.generalAction.setAppTitle(`/pages/contact/${tabName}`));
-                this.router.navigate(["/pages/contact/", tabName], { replaceUrl: true });
-                this.hasNavigated = true;
-            }
         }
     }
 
@@ -1079,19 +1080,13 @@ export class ContactComponent implements OnInit, OnDestroy {
     }
 
     public resetAdvanceSearch() {
-        this.showClearFilter = false;
+        this.showClearFilter.set(false);
         this.advanceSearchRequestModal = new ContactAdvanceSearchModal();
         this.commonRequest = new ContactAdvanceSearchCommonModal();
         this.isAdvanceSearchApplied = false;
         this.key = (this.activeTab === "vendor") ? "amountDue" : "name";
         this.order = (this.activeTab === "vendor") ? "desc" : "asc";
-        if (!this.searchedName?.value) {
-            this.getAccounts(this.fromDate, this.toDate,
-                null, "true", PAGINATION_LIMIT, "", "", null, (this.currentBranch ? this.currentBranch.uniqueName : ""));
-        }
-        this.searchedName?.reset();
-        this.searchStr = "";
-        this.showNameSearch = false;
+        this.generalService.saveRouteQueryFilters(null, true);
     }
 
     public applyAdvanceSearch(request: ContactAdvanceSearchCommonModal) {
@@ -1547,7 +1542,6 @@ export class ContactComponent implements OnInit, OnDestroy {
      * @memberof ContactComponent
      */
     public handleClickOutside(event: any, element: any, searchedFieldName: string): void {
-        this.showClearFilter = false;
         if (searchedFieldName === "name") {
             if (this.searchedName?.value) {
                 return;
@@ -1624,7 +1618,7 @@ export class ContactComponent implements OnInit, OnDestroy {
     }
 
     public sort(key: string, ord = "asc") {
-        this.showClearFilter = true;
+        this.showClearFilter.set(true);
         this.key = key;
         this.order = ord;
         this.advanceFilters.sort = ord;

--- a/apps/web-giddh/src/app/contact/contact.component.ts
+++ b/apps/web-giddh/src/app/contact/contact.component.ts
@@ -389,6 +389,8 @@ export class ContactComponent implements OnInit, OnDestroy {
                         }
                     });
                 }
+            } else if (queryParams.tab !== this.moduleType.toLowerCase()) {
+                this.generalService.saveRouteQueryFilters({ tab: this.moduleType.toLowerCase(), tabIndex: 1 });
             }
         });
 

--- a/apps/web-giddh/src/app/contact/contact.component.ts
+++ b/apps/web-giddh/src/app/contact/contact.component.ts
@@ -187,7 +187,7 @@ export class ContactComponent implements OnInit, OnDestroy {
     public universalDate: any;
     public selectedRangeLabel: any = "";
     /**True, if get accounts request in process */
-    public isGetAccountsInProcess: boolean = false;
+    public isGetAccountsInProcess = signal(false);
     /** This will hold the current page number */
     public currentPage: number = 1;
     /** Observable to store the branches of current company */
@@ -342,6 +342,7 @@ export class ContactComponent implements OnInit, OnDestroy {
             const previousTab = this.activeTab;
 
             if (newTab !== previousTab) {
+                this.selectedRangeLabel = "";
                 this.displayedColumns = [];
                 this.dynamicCustomColumns = [];
                 this.setActiveTab(newTab);
@@ -353,13 +354,41 @@ export class ContactComponent implements OnInit, OnDestroy {
             }
         });
 
-        this.route.queryParams.pipe(takeUntil(this.destroyed$)).subscribe(queryParams => {
+        this.route.queryParams.pipe(debounceTime(700), takeUntil(this.destroyed$)).subscribe(queryParams => {
             if (queryParams.tab === 'customer' || queryParams.tab === 'vendor') {
-                const restoredQ = queryParams.searchText || '';
-                this.searchStr = restoredQ;
-                this.searchedName.setValue(restoredQ, { emitEvent: false });
-                this.showNameSearch = restoredQ ? true : false;
-                this.searchStr$.next(restoredQ);
+                if (queryParams.fromDate && queryParams.toDate) {
+                    this.fromDate = queryParams.fromDate;
+                    this.toDate = queryParams.toDate;
+                    this.selectedDateRange = {
+                        startDate: dayjs(this.fromDate, GIDDH_DATE_FORMAT),
+                        endDate: dayjs(this.toDate, GIDDH_DATE_FORMAT),
+                    };
+                    this.selectedDateRangeUi = dayjs(this.fromDate, GIDDH_DATE_FORMAT).format(GIDDH_NEW_DATE_FORMAT_UI) + ' - ' + dayjs(this.toDate, GIDDH_DATE_FORMAT).format(GIDDH_NEW_DATE_FORMAT_UI);
+                    const restoredQ = queryParams.searchText || '';
+                    this.searchStr = restoredQ;
+                    this.searchedName.setValue(restoredQ, { emitEvent: false });
+                    this.showNameSearch = restoredQ ? true : false;
+                    this.showClearFilter.set(true);
+                    this.searchStr$.next(restoredQ);
+                } else {
+                    this.universalDate$.pipe(filter(Boolean),take(1)).subscribe(response => {
+                        if (response) {
+                            this.fromDate = dayjs(response[0]).format(GIDDH_DATE_FORMAT);
+                            this.toDate = dayjs(response[1]).format(GIDDH_DATE_FORMAT);
+                            this.selectedDateRange = {
+                                startDate: dayjs(response[0]),
+                                endDate: dayjs(response[1]),
+                            };
+                            this.selectedDateRangeUi = dayjs(response[0]).format(GIDDH_NEW_DATE_FORMAT_UI) + " - " + dayjs(response[1]).format(GIDDH_NEW_DATE_FORMAT_UI);
+                            const restoredQ = queryParams.searchText || '';
+                            this.searchStr = restoredQ;
+                            this.searchedName.setValue(restoredQ, { emitEvent: false });
+                            this.showNameSearch = restoredQ ? true : false;
+                            this.showClearFilter.set(restoredQ ? true : false);
+                            this.searchStr$.next(restoredQ);
+                        }
+                    });
+                }
             }
         });
 
@@ -409,35 +438,6 @@ export class ContactComponent implements OnInit, OnDestroy {
             this.cdRef.detectChanges();
         });
 
-        this.universalDate$.pipe(takeUntil(this.destroyed$)).subscribe(dateObj => {
-            if (dateObj) {
-                this.universalDate = cloneDeep(dateObj);
-
-                setTimeout(() => {
-
-                    this.store.pipe(select(state => state.session.todaySelected), take(1)).subscribe(response => {
-                        this.todaySelected = response;
-
-                        if (this.universalDate && !this.todaySelected) {
-                            this.fromDate = dayjs(this.universalDate[0]).format(GIDDH_DATE_FORMAT);
-                            this.toDate = dayjs(this.universalDate[1]).format(GIDDH_DATE_FORMAT);
-                            this.selectedDateRange = {
-                                startDate: dayjs(this.universalDate[0]),
-                                endDate: dayjs(this.universalDate[1]),
-                            };
-                            this.advanceFilters.from = this.fromDate;
-                            this.advanceFilters.to = this.toDate;
-                            this.selectedDateRangeUi = dayjs(this.universalDate[0]).format(GIDDH_NEW_DATE_FORMAT_UI) + " - " + dayjs(this.universalDate[1]).format(GIDDH_NEW_DATE_FORMAT_UI);
-                        } else {
-                            this.universalDate = [];
-                            this.fromDate = "";
-                            this.toDate = "";
-                        }
-                        this.getAccounts(this.fromDate, this.toDate, null, "true", PAGINATION_LIMIT, this.searchStr, this.key, this.order, (this.currentBranch ? this.currentBranch.uniqueName : ""));
-                    });
-                }, 100);
-            }
-        });
 
         this.createAccountIsSuccess$.pipe(takeUntil(this.destroyed$)).subscribe(response => {
             if (response) {
@@ -453,13 +453,11 @@ export class ContactComponent implements OnInit, OnDestroy {
         });
 
         this.searchStr$.pipe(
-            debounceTime(1000),
-            distinctUntilChanged(), takeUntil(this.destroyed$))
+            takeUntil(this.destroyed$))
             .subscribe((term: any) => {
                 if (term != null && term != undefined) {
                     this.searchStr = term;
                     this.advanceFilters.q = term;
-                    this.showClearFilter.set(term ? true : false);
                     this.getAccounts(this.fromDate, this.toDate, null, "true", PAGINATION_LIMIT, term, this.key, this.order, (this.currentBranch ? this.currentBranch.uniqueName : ""));
                 }
             });
@@ -1016,12 +1014,13 @@ export class ContactComponent implements OnInit, OnDestroy {
 
         this.toggleGiddhDatepicker(false);
         if (value && value.startDate && value.endDate) {
-            this.todaySelected = false;
-            this.selectedDateRange = { startDate: dayjs(value.startDate), endDate: dayjs(value.endDate) };
-            this.selectedDateRangeUi = dayjs(value.startDate).format(GIDDH_NEW_DATE_FORMAT_UI) + " - " + dayjs(value.endDate).format(GIDDH_NEW_DATE_FORMAT_UI);
+            this.showClearFilter.set(true);
+            // this.selectedDateRange = { startDate: dayjs(value.startDate), endDate: dayjs(value.endDate) };
+            // this.selectedDateRangeUi = dayjs(value.startDate).format(GIDDH_NEW_DATE_FORMAT_UI) + " - " + dayjs(value.endDate).format(GIDDH_NEW_DATE_FORMAT_UI);
             this.fromDate = dayjs(value.startDate).format(GIDDH_DATE_FORMAT);
             this.toDate = dayjs(value.endDate).format(GIDDH_DATE_FORMAT);
-            this.getAccounts(this.fromDate, this.toDate, null, "true", PAGINATION_LIMIT, this.searchStr, this.key, this.order, (this.currentBranch ? this.currentBranch.uniqueName : ""));
+            this.generalService.saveRouteQueryFilters({ fromDate: this.fromDate, toDate: this.toDate });
+            // this.getAccounts(this.fromDate, this.toDate, null, "true", PAGINATION_LIMIT, this.searchStr, this.key, this.order, (this.currentBranch ? this.currentBranch.uniqueName : ""));
             this.detectChanges();
         }
     }
@@ -1203,7 +1202,7 @@ export class ContactComponent implements OnInit, OnDestroy {
      */
     private getAccounts(fromDate: string, toDate: string, pageNumber?: number, refresh?: string, count: number = PAGINATION_LIMIT, query?: string,
         sortBy: string = "", order: string = "asc", branchUniqueName?: string): void {
-        this.isGetAccountsInProcess = true;
+        this.isGetAccountsInProcess.set(true);
         pageNumber = pageNumber ? pageNumber : 1;
         refresh = refresh ? refresh : "false";
         fromDate = (fromDate) ? fromDate : "";
@@ -1300,7 +1299,7 @@ export class ContactComponent implements OnInit, OnDestroy {
                 this.allSelectionModel = this.checkboxInfo[this.checkboxInfo.selectedPage] ? true : false;
             }
             if (headerColumns && res) {
-                this.isGetAccountsInProcess = false;
+                this.isGetAccountsInProcess.set(false);
                 this.detectChanges();
             }
         });

--- a/apps/web-giddh/src/app/contact/preview/preview.component.ts
+++ b/apps/web-giddh/src/app/contact/preview/preview.component.ts
@@ -585,7 +585,12 @@ export class ContactPreviewComponent implements OnInit, OnDestroy {
      * @memberof ContactPreviewComponent
      */
     public redirectToGetAllPage(): void {
-        this.router.navigate([`/pages/contact/${this.contactActiveTab}`]);
+        this.router.navigate([`/pages/contact/${this.contactActiveTab}`, {
+            queryParams: {
+                tab: this.contactActiveTab,
+                tabIndex: 1
+            }
+        }]);
     }
 
     /**

--- a/apps/web-giddh/src/app/contact/preview/preview.component.ts
+++ b/apps/web-giddh/src/app/contact/preview/preview.component.ts
@@ -585,12 +585,12 @@ export class ContactPreviewComponent implements OnInit, OnDestroy {
      * @memberof ContactPreviewComponent
      */
     public redirectToGetAllPage(): void {
-        this.router.navigate([`/pages/contact/${this.contactActiveTab}`, {
+        this.router.navigate([`/pages/contact/${this.contactActiveTab}`], {
             queryParams: {
                 tab: this.contactActiveTab,
                 tabIndex: 1
             }
-        }]);
+        });
     }
 
     /**

--- a/apps/web-giddh/src/app/ledger/components/new-ledger-entry-panel/new-ledger-entry-panel.component.html
+++ b/apps/web-giddh/src/app/ledger/components/new-ledger-entry-panel/new-ledger-entry-panel.component.html
@@ -717,7 +717,7 @@
         </div>
 
         <div class="row">
-            <div class="col-12 pt-2 pb-2">
+            <div class="col-12 pt-3 pb-2">
                 <div class="row align-items-end">
                     <div class="col-5 pr-0">
                         <div class="clear-both">

--- a/apps/web-giddh/src/app/ledger/components/new-ledger-entry-panel/new-ledger-entry-panel.component.ts
+++ b/apps/web-giddh/src/app/ledger/components/new-ledger-entry-panel/new-ledger-entry-panel.component.ts
@@ -497,8 +497,6 @@ export class NewLedgerEntryPanelComponent implements OnInit, OnDestroy, OnChange
             }
             if (callback) {
                 callback();
-            } else {
-                this.preparePreAppliedDiscounts();
             }
         });
     }
@@ -551,7 +549,6 @@ export class NewLedgerEntryPanelComponent implements OnInit, OnDestroy, OnChange
                 this.selectedWarehouse = this.currentTxn.inventory?.warehouse?.uniqueName ?? this.blankLedger.transactions[0].inventory?.warehouse?.uniqueName;
             }
             this.calculatePreAppliedTax();
-            this.preparePreAppliedDiscounts();
             if (this.blankLedger?.otherTaxModal?.appliedOtherTax?.uniqueName) {
                 this.blankLedger.isOtherTaxesApplicable = true;
             }
@@ -607,7 +604,6 @@ export class NewLedgerEntryPanelComponent implements OnInit, OnDestroy, OnChange
         this.needToReCalculate.pipe(takeUntil(this.destroyed$)).subscribe(a => {
             if (a) {
                 this.setTaxCalculationMethodForStock();
-                this.preparePreAppliedDiscounts();
                 this.calculatePreAppliedTax();
                 this.detectChanges();
                 setTimeout(() => {
@@ -1216,6 +1212,7 @@ export class NewLedgerEntryPanelComponent implements OnInit, OnDestroy, OnChange
         }
 
         if (!event.relatedTarget || !this.entryContent?.nativeElement.contains(event.relatedTarget)) {
+            this.currentTxn.selectedAccount.applicableTaxes = this.currentTxn.taxesVm;
             this.clickedOutsideEvent.emit(event);
         }
     }
@@ -1808,62 +1805,8 @@ export class NewLedgerEntryPanelComponent implements OnInit, OnDestroy, OnChange
         if (accountDetails.country && accountDetails.country.countryName) {
             this.activeAccountCountryName = accountDetails.country.countryName;
         }
-        if (accountDetails.applicableDiscounts && accountDetails.applicableDiscounts.length) {
-            this.accountOtherApplicableDiscount = accountDetails.applicableDiscounts;
-        } else if (accountDetails.inheritedDiscounts && accountDetails.inheritedDiscounts.length && (!this.accountOtherApplicableDiscount || !this.accountOtherApplicableDiscount?.length)) {
-            this.accountOtherApplicableDiscount.push(...accountDetails.inheritedDiscounts[0].applicableDiscounts);
-        }
-        if (!accountDetails.applicableTaxes?.length && accountDetails.otherApplicableTaxes?.length) {
-            accountDetails.applicableTaxes = [...accountDetails.otherApplicableTaxes];
-        }
-        this.preparePreAppliedDiscounts();
         this.calculatePreAppliedTax();
 
-    }
-
-    /**
-     * To prepare pre applied discount for current transactions
-     *
-     * @memberof NewLedgerEntryPanelComponent
-     */
-    public preparePreAppliedDiscounts(): void {
-        if (!this.currentTxn?.duplicateEntry) {
-            this.currentTxn.discounts = [];
-        }
-        const stockDiscounts = this.currentTxn.selectedAccount?.stock?.variant?.variantDiscount?.discounts
-        if (stockDiscounts?.length && !this.currentTxn.isMrpDiscountApplied) {
-            stockDiscounts?.forEach(variantDiscount => {
-                this.discountsList()?.forEach(item => {
-                    if (variantDiscount?.discount?.uniqueName === item?.uniqueName) {
-                        this.currentTxn.discounts.push(item);
-                    }
-                    return item;
-                });
-            });
-        } else {
-            if (this.currentTxn?.selectedAccount?.accountApplicableDiscounts?.length) {
-                this.currentTxn?.selectedAccount?.accountApplicableDiscounts?.map(item => item.isActive = true);
-                (Array.isArray(this.currentTxn?.selectedAccount.accountApplicableDiscounts) ? this.currentTxn?.selectedAccount.accountApplicableDiscounts : []).forEach(element => {
-                    this.discountsList()?.forEach(item => {
-                        if (element?.uniqueName === item?.uniqueName) {
-                            this.currentTxn.discounts.push(item);
-                        }
-                    });
-                });
-            } else if (this.accountOtherApplicableDiscount && this.accountOtherApplicableDiscount.length) {
-                (Array.isArray(this.accountOtherApplicableDiscount) ? this.accountOtherApplicableDiscount : []).forEach(element => {
-                    this.discountsList()?.forEach(item => {
-                        if (element?.uniqueName === item?.uniqueName) {
-                            this.currentTxn.discounts.push(item);
-                        }
-                    });
-                });
-            } else if (!this.currentTxn?.duplicateEntry) {
-                if (this.currentTxn) {
-                    this.currentTxn.discount = 0;
-                }
-            }
-        }
     }
 
     /**

--- a/apps/web-giddh/src/app/ledger/components/new-ledger-entry-panel/new-ledger-entry-panel.component.ts
+++ b/apps/web-giddh/src/app/ledger/components/new-ledger-entry-panel/new-ledger-entry-panel.component.ts
@@ -279,8 +279,8 @@ export class NewLedgerEntryPanelComponent implements OnInit, OnDestroy, OnChange
     public salesTaxInclusive: boolean;
     /** True, if stock category is 'assets' and inclusive tax is applied */
     public fixedAssetTaxInclusive: boolean;
-    /** Stores the value of selected stock variant */
-    public selectedStockVariant: IOption = { label: '', value: '' };
+    /** Stores the value of selected stock variant, provided by the parent */
+    @Input() public selectedStockVariant: IOption;
     /** Holds Aside Menu State For Other Taxes DialogRef */
     public asideMenuStateForOtherTaxesDialogRef: MatDialogRef<any>;
     /** Holds Tooltip is opend/close status */
@@ -456,9 +456,13 @@ export class NewLedgerEntryPanelComponent implements OnInit, OnDestroy, OnChange
                     opens the new ledger.
                 */
                 const currentSelectedVariant = res.find(variant => variant.value === this.currentTxn?.inventory?.variant?.uniqueName);
-                this.selectedStockVariant = Object.assign({}, currentSelectedVariant ?? res[0]);
+                const newVariant = Object.assign({}, currentSelectedVariant ?? res[0]);
+                const variantChanged = newVariant.value !== this.selectedStockVariant?.value;
+                this.selectedStockVariant = newVariant;
                 this.cdRef.detectChanges();
-                this.stockVariantSelected.emit(currentSelectedVariant?.value ?? res[0].value);
+                if (variantChanged) {
+                    this.stockVariantSelected.emit(newVariant.value);
+                }
             }
         });
 
@@ -1945,6 +1949,7 @@ export class NewLedgerEntryPanelComponent implements OnInit, OnDestroy, OnChange
      */
     public variantChanged(event: IOption): void {
         if (event.value) {
+            this.selectedStockVariant = event;
             // Must not call the variant API when stock is changed
             this.stockVariantSelected.emit(event.value);
         }

--- a/apps/web-giddh/src/app/ledger/components/update-ledger-entry-panel/update-ledger-entry-panel.component.html
+++ b/apps/web-giddh/src/app/ledger/components/update-ledger-entry-panel/update-ledger-entry-panel.component.html
@@ -1069,6 +1069,7 @@
                                                         [readonly]="true"
                                                         [(ngModel)]="txn.particular.name"
                                                         [cssClass]="'transaction-particular-name border-none bg-transparent'"
+                                                        class="w-100"
                                                     />
                                                 </ng-template>
 
@@ -1798,32 +1799,19 @@
                                         >
                                             <div class="mr-2">
                                                 <div class="form-group">
-                                                    <label>
-                                                        {{ localeData?.adjustment_vouchers }}
-                                                        <span class="text-danger">*</span>
-                                                    </label>
                                                     <input-field
                                                         [id]="'update-ledger-adjust-voucher'"
                                                         [type]="'text'"
                                                         class="mb-2"
                                                         [(ngModel)]="item.voucherNumber"
                                                         [readonly]="true"
+                                                        [label]="localeData?.adjustment_vouchers"
+                                                        [required]="true"
                                                     ></input-field>
                                                 </div>
                                             </div>
                                             <div class="mr-2">
                                                 <div class="form-group amount-width">
-                                                    <label>
-                                                        {{ commonLocaleData?.app_amount }}
-                                                        <span class="text-danger">*</span>
-                                                        <span
-                                                            *ngIf="item.voucherType === 'receipt' && isAdvanceReceipt"
-                                                            class="text-light font-size-12 ml-1"
-                                                            class="text-light font-size-12 ml-1"
-                                                        >
-                                                            ({{ commonLocaleData?.app_inclusive_tax }})
-                                                        </span>
-                                                    </label>
                                                     <input-field
                                                         [id]="'update-ledger-inclusive-tax-edit-mode'"
                                                         [type]="'text'"
@@ -1834,6 +1822,9 @@
                                                         decimalDigitsDirective
                                                         [(ngModel)]="item.adjustmentAmount.amountForAccount"
                                                         [readonly]="true"
+                                                        [label]="
+                                                            `${commonLocaleData?.app_amount} ${item.voucherType === 'sales' ? `(${commonLocaleData?.app_inclusive_tax})` : ''}`
+                                                        "
                                                     ></input-field>
                                                     <input-field
                                                         [readonly]="isEinvoiceGenerated"
@@ -1848,6 +1839,9 @@
                                                         (blur)="adjustedInvoiceAmountChange()"
                                                         *ngIf="selectedAdvanceReceiptAdjustInvoiceEditMode"
                                                         [(ngModel)]="item.adjustmentAmount.amountForAccount"
+                                                        [label]="
+                                                            `${commonLocaleData?.app_amount} ${item.voucherType === 'sales' ? `(${commonLocaleData?.app_inclusive_tax})` : ''}`
+                                                        "
                                                     ></input-field>
                                                 </div>
                                             </div>

--- a/apps/web-giddh/src/app/ledger/components/update-ledger-entry-panel/update-ledger-entry-panel.component.scss
+++ b/apps/web-giddh/src/app/ledger/components/update-ledger-entry-panel/update-ledger-entry-panel.component.scss
@@ -197,7 +197,7 @@ ng-select > div {
 }
 
 .amount-width {
-    width: 125px;
+    width: 160px;
 }
 
 .delete-attachment {

--- a/apps/web-giddh/src/app/ledger/components/update-ledger-entry-panel/update-ledger-entry-panel.component.ts
+++ b/apps/web-giddh/src/app/ledger/components/update-ledger-entry-panel/update-ledger-entry-panel.component.ts
@@ -31,6 +31,7 @@ import { AdjustAdvancePaymentModal, VoucherAdjustments } from '../../../models/a
 import { ICurrencyResponse, TaxResponse } from '../../../models/api-models/Company';
 import { DownloadLedgerRequest, IVariant, LedgerResponse } from '../../../models/api-models/Ledger';
 import { IForceClear, SalesOtherTaxesCalculationMethodEnum, SalesOtherTaxesModal, VoucherTypeEnum } from '../../../models/api-models/Sales';
+import { OtherTaxTypeEnum } from '../../../vouchers/utility/vouchers.const';
 import { TagRequest } from '../../../models/api-models/settingsTags';
 import { ILedgerTransactionItem, ITransactionItem } from '../../../models/interfaces/ledger.interface';
 import { AccountService } from '../../../services/account.service';
@@ -227,6 +228,8 @@ export class UpdateLedgerEntryPanelComponent implements OnInit, AfterViewInit, O
     public totalAdjustedAmount: number = 0;
     /** True, if company country supports other tax (TCS/TDS) */
     public isTcsTdsApplicable: boolean;
+    /** Enum for Other tax types */
+    public otherTaxTypeEnum: typeof OtherTaxTypeEnum = OtherTaxTypeEnum;
     /** Rate should have precision up to 4 digits for better calculation */
     public ratePrecision = RATE_FIELD_PRECISION;
     /** Clear selected invoice */
@@ -961,7 +964,7 @@ export class UpdateLedgerEntryPanelComponent implements OnInit, AfterViewInit, O
         }
         if (this.isAdvanceReceipt) {
             requestObj.voucherType = 'rcpt';
-            requestObj.transactions[0].amount = this.vm.advanceReceiptAmount;
+            requestObj.transactions[0].amount = this.vm.grandTotal;
         }
 
         if (this.voucherApiVersion === 2) {

--- a/apps/web-giddh/src/app/ledger/components/update-ledger-entry-panel/update-ledger-entry-panel.module.ts
+++ b/apps/web-giddh/src/app/ledger/components/update-ledger-entry-panel/update-ledger-entry-panel.module.ts
@@ -31,6 +31,7 @@ import { NumberToWordsModule } from '../../../shared/helpers/pipes/numberToWords
 import { ReplacePipeModule } from '../../../shared/helpers/pipes/replace/replace.module';
 import { CommonTaxComponent } from '../../../shared/common-tax/common-tax.component';
 import { CommonDiscountComponent } from '../../../shared/common-discount/common-discount.component';
+import { GiddhDatePipe } from '../../../shared/pipes/giddh-date.pipe';
 
 @NgModule({
     declarations: [
@@ -71,7 +72,8 @@ import { CommonDiscountComponent } from '../../../shared/common-discount/common-
         }),
         OverlayModule,
         CommonTaxComponent,
-        CommonDiscountComponent
+        CommonDiscountComponent,
+        GiddhDatePipe
     ],
     exports: [UpdateLedgerEntryPanelComponent, UpdateLedgerTaxControlComponent, UpdateLedgerDiscountComponent]
 })

--- a/apps/web-giddh/src/app/ledger/ledger.component.html
+++ b/apps/web-giddh/src/app/ledger/ledger.component.html
@@ -974,6 +974,7 @@
                                                                         loadDetails(selectedAccountDetails, txn, $event)
                                                                     "
                                                                     [selectedAccountDetails]="selectedAccountDetails"
+                                                                    [(selectedStockVariant)]="selectedStockVariant"
                                                                     [(isTotalChanged)]="isTotalChanged"
                                                                     [autoGenerateVoucherFromEntry]="autoGenerateVoucherFromEntryStatus"
                                                                 ></new-ledger-entry-panel>
@@ -1218,6 +1219,7 @@
                                                                         loadDetails(selectedAccountDetails, txn, $event)
                                                                     "
                                                                     [selectedAccountDetails]="selectedAccountDetails"
+                                                                    [(selectedStockVariant)]="selectedStockVariant"
                                                                     [(isTotalChanged)]="isTotalChanged"
                                                                     [autoGenerateVoucherFromEntry]="autoGenerateVoucherFromEntryStatus"
                                                                 ></new-ledger-entry-panel>
@@ -1861,6 +1863,7 @@
                                                     [entrySide]="'dr'"
                                                     (stockVariantSelected)="loadDetails(selectedAccountDetails, txn, $event)"
                                                     [selectedAccountDetails]="selectedAccountDetails"
+                                                    [(selectedStockVariant)]="selectedStockVariant"
                                                     [(isTotalChanged)]="isTotalChanged"
                                                     [autoGenerateVoucherFromEntry]="autoGenerateVoucherFromEntryStatus"
                                                 ></new-ledger-entry-panel>
@@ -2256,6 +2259,7 @@
                                                     [entrySide]="'cr'"
                                                     (stockVariantSelected)="loadDetails(selectedAccountDetails, txn, $event)"
                                                     [selectedAccountDetails]="selectedAccountDetails"
+                                                    [(selectedStockVariant)]="selectedStockVariant"
                                                     [(isTotalChanged)]="isTotalChanged"
                                                     [autoGenerateVoucherFromEntry]="autoGenerateVoucherFromEntryStatus"
                                                 ></new-ledger-entry-panel>
@@ -3424,6 +3428,7 @@
                                 [entrySide]="txn.type === transactionType.Debit ? 'dr' : 'cr'"
                                 (stockVariantSelected)="loadDetails(selectedAccountDetails, txn, $event)"
                                 [selectedAccountDetails]="selectedAccountDetails"
+                                [(selectedStockVariant)]="selectedStockVariant"
                                 [(isTotalChanged)]="isTotalChanged"
                                 [autoGenerateVoucherFromEntry]="autoGenerateVoucherFromEntryStatus"
                             ></new-ledger-entry-panel>

--- a/apps/web-giddh/src/app/ledger/ledger.component.html
+++ b/apps/web-giddh/src/app/ledger/ledger.component.html
@@ -974,7 +974,7 @@
                                                                         loadDetails(selectedAccountDetails, txn, $event)
                                                                     "
                                                                     [selectedAccountDetails]="selectedAccountDetails"
-                                                                    [(selectedStockVariant)]="selectedStockVariant"
+                                                                    [selectedStockVariant]="selectedStockVariant"
                                                                     [(isTotalChanged)]="isTotalChanged"
                                                                     [autoGenerateVoucherFromEntry]="autoGenerateVoucherFromEntryStatus"
                                                                 ></new-ledger-entry-panel>
@@ -1219,7 +1219,7 @@
                                                                         loadDetails(selectedAccountDetails, txn, $event)
                                                                     "
                                                                     [selectedAccountDetails]="selectedAccountDetails"
-                                                                    [(selectedStockVariant)]="selectedStockVariant"
+                                                                    [selectedStockVariant]="selectedStockVariant"
                                                                     [(isTotalChanged)]="isTotalChanged"
                                                                     [autoGenerateVoucherFromEntry]="autoGenerateVoucherFromEntryStatus"
                                                                 ></new-ledger-entry-panel>
@@ -1863,7 +1863,7 @@
                                                     [entrySide]="'dr'"
                                                     (stockVariantSelected)="loadDetails(selectedAccountDetails, txn, $event)"
                                                     [selectedAccountDetails]="selectedAccountDetails"
-                                                    [(selectedStockVariant)]="selectedStockVariant"
+                                                    [selectedStockVariant]="selectedStockVariant"
                                                     [(isTotalChanged)]="isTotalChanged"
                                                     [autoGenerateVoucherFromEntry]="autoGenerateVoucherFromEntryStatus"
                                                 ></new-ledger-entry-panel>
@@ -2259,7 +2259,7 @@
                                                     [entrySide]="'cr'"
                                                     (stockVariantSelected)="loadDetails(selectedAccountDetails, txn, $event)"
                                                     [selectedAccountDetails]="selectedAccountDetails"
-                                                    [(selectedStockVariant)]="selectedStockVariant"
+                                                    [selectedStockVariant]="selectedStockVariant"
                                                     [(isTotalChanged)]="isTotalChanged"
                                                     [autoGenerateVoucherFromEntry]="autoGenerateVoucherFromEntryStatus"
                                                 ></new-ledger-entry-panel>
@@ -3428,7 +3428,7 @@
                                 [entrySide]="txn.type === transactionType.Debit ? 'dr' : 'cr'"
                                 (stockVariantSelected)="loadDetails(selectedAccountDetails, txn, $event)"
                                 [selectedAccountDetails]="selectedAccountDetails"
-                                [(selectedStockVariant)]="selectedStockVariant"
+                                [selectedStockVariant]="selectedStockVariant"
                                 [(isTotalChanged)]="isTotalChanged"
                                 [autoGenerateVoucherFromEntry]="autoGenerateVoucherFromEntryStatus"
                             ></new-ledger-entry-panel>

--- a/apps/web-giddh/src/app/ledger/ledger.component.ts
+++ b/apps/web-giddh/src/app/ledger/ledger.component.ts
@@ -289,6 +289,8 @@ export class LedgerComponent implements OnInit, OnDestroy {
     public enableAutopaid: boolean = false;
     /** Selected account details to load the details after variant is selected */
     public selectedAccountDetails: IOption;
+    /** Selected stock variant passed down to new-ledger-entry-panel, reset on account change */
+    public selectedStockVariant: IOption = { label: '', value: '' };
     /** True, if the total was changed explicitly by the user in case of inclusive tax */
     public isTotalChanged: boolean;
     /* Observable to check if account prediction api call has completed */
@@ -546,6 +548,7 @@ export class LedgerComponent implements OnInit, OnDestroy {
         this.keydownClassAdded = false;
         this.selectedTxnAccUniqueName = '';
         this.selectedAccountDetails = e;
+        this.selectedStockVariant = { label: '', value: '' };
         if (!e?.value || clearAccount) {
             if (clearAccount) {
                 this.getTransactionCountConvertToEntries(txn);
@@ -3507,6 +3510,7 @@ export class LedgerComponent implements OnInit, OnDestroy {
     private loadDetails(event: IOption, txn: TransactionVM, variantUniqueName?: string, allowChangeDetection?: boolean, isBankTransaction?: boolean, transactionType?: string): void {
         let requestObject;
         if (event.additional?.stock) {
+            this.selectedStockVariant.value = variantUniqueName;
             requestObject = {
                 stockUniqueName: event.additional.stock?.uniqueName,
                 oppositeAccountUniqueName: event.additional.uniqueName,

--- a/apps/web-giddh/src/app/ledger/ledger.component.ts
+++ b/apps/web-giddh/src/app/ledger/ledger.component.ts
@@ -1,5 +1,5 @@
 import { BankIntegrationDialogComponent } from './../shared/bank-integration/bank-integration-popup/bank-integration-popup.component';
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Inject, NgZone, OnDestroy, OnInit, QueryList, TemplateRef, ViewChild, ViewChildren } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Inject, NgZone, OnDestroy, OnInit, QueryList, signal, TemplateRef, ViewChild, ViewChildren } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { select, Store } from '@ngrx/store';
 import { LoginActions } from 'apps/web-giddh/src/app/actions/login.action';
@@ -66,6 +66,7 @@ import { OtherTaxTypeEnum } from '../vouchers/utility/vouchers.const';
 import { LedgerDropdownTypeEnum } from '../models/api-models/Ledger';
 import { IOption } from '../app.constant';
 import { environment } from '../../environments/environment.generated';
+import { SettingsDiscountService } from '../services/settings.discount.service';
 
 @Component({
     selector: 'ledger',
@@ -412,6 +413,8 @@ export class LedgerComponent implements OnInit, OnDestroy {
     public forceClear$: BehaviorSubject<boolean | null> = new BehaviorSubject(null);
     /** Tracks if account unique name should be shown in dropdowns */
     public showAccountUniqueName: boolean = false;
+    /** List of discounts */
+    public discountsList = signal<any[]>([]);
 
     constructor(
         private store: Store<AppState>,
@@ -441,7 +444,8 @@ export class LedgerComponent implements OnInit, OnDestroy {
         private componentStore: BankIntegrationComponentStore,
         private homeComponentStore: HomeComponentStore,
         private ledgerComponentStore: LedgerComponentStore,
-        private breakpointObserver: BreakpointObserver
+        private breakpointObserver: BreakpointObserver,
+        private settingsDiscountService: SettingsDiscountService
     ) {
         if (window.localStorage) {
             localStorage.setItem('refNo', null);
@@ -1224,6 +1228,7 @@ export class LedgerComponent implements OnInit, OnDestroy {
                 this.cdRf.detectChanges();
             }
         });
+        this.getAllDiscounts();
     }
 
     private assignPrefixAndSuffixForCurrency() {
@@ -3714,6 +3719,7 @@ export class LedgerComponent implements OnInit, OnDestroy {
                         this.lc.blankLedger.salesPersonName = this.ledgerAccountResponse.salesPerson?.name || this.lc.blankLedger.salesPersonName || '';
                     }
                 }
+                this.preparePreAppliedDiscounts(txn);
                 // check if selected account category allows to show taxationDiscountBox in newEntry popup
                 txn.showTaxationDiscountBox = this.getCategoryNameFromAccountUniqueName(txn);
                 txn.showOtherTax = this.showOtherTax(txn);
@@ -3726,6 +3732,70 @@ export class LedgerComponent implements OnInit, OnDestroy {
                     this.cdRf.detectChanges();
                 }
                 this.getTransactionCountConvertToEntries();
+            }
+        });
+    }
+
+    /**
+     * To prepare pre applied discount for current transactions
+     *
+     * @memberof LedgerComponent
+     */
+    public preparePreAppliedDiscounts(txn: any): void {
+        if (!txn?.duplicateEntry) {
+            txn.discounts = [];
+        }
+        const stockDiscounts = txn.selectedAccount?.stock?.variant?.variantDiscount?.discounts
+        if (stockDiscounts?.length && !txn.isMrpDiscountApplied) {
+            stockDiscounts?.forEach(variantDiscount => {
+                this.discountsList()?.forEach(item => {
+                    if (variantDiscount?.discount?.uniqueName === item?.uniqueName) {
+                        txn.discounts.push(item);
+                    }
+                    return item;
+                });
+            });
+        } else {
+            if (txn?.selectedAccount?.accountApplicableDiscounts?.length) {
+                txn?.selectedAccount?.accountApplicableDiscounts?.map(item => item.isActive = true);
+                (Array.isArray(txn?.selectedAccount.accountApplicableDiscounts) ? txn?.selectedAccount.accountApplicableDiscounts : []).forEach(element => {
+                    this.discountsList()?.forEach(item => {
+                        if (element?.uniqueName === item?.uniqueName) {
+                            txn.discounts.push(item);
+                        }
+                    });
+                });
+            } else if (this.lc.activeAccount.applicableDiscounts.length) {
+                this.lc.activeAccount.applicableDiscounts.forEach(element => {
+                    this.discountsList()?.forEach(item => {
+                        if (element?.uniqueName === item?.uniqueName) {
+                            txn.discounts.push(item);
+                        }
+                    });
+                });
+            } else if (!txn?.duplicateEntry) {
+                if (txn) {
+                    txn.discount = 0;
+                }
+            }
+        }
+    }
+
+    /**
+     * Get all discounts API call
+     *
+     * @private
+     * @memberof LedgerComponent
+     */
+    private getAllDiscounts(): void {
+        this.settingsDiscountService.GetDiscounts().pipe(take(1)).subscribe(response => {
+            if (response?.status === "success" && response?.body?.length > 0) {
+                let discounts = response?.body;
+                discounts.map((discount: any) => {
+                    discount.amount = discount.discountValue;
+                    discount.discountUniqueName = discount.uniqueName;
+                })
+                this.discountsList.set(discounts);
             }
         });
     }

--- a/apps/web-giddh/src/app/ledger/ledger.component.ts
+++ b/apps/web-giddh/src/app/ledger/ledger.component.ts
@@ -1978,10 +1978,6 @@ export class LedgerComponent implements OnInit, OnDestroy {
                 blankTransactionObj = this.adjustmentUtilityService.getAdjustmentObject(blankTransactionObj);
             }
             const model = cloneDeep(blankTransactionObj);
-            if (model.transactions[0]?.subVoucher === "ADVANCE_RECEIPT") {
-                /** Here key 'taxInclusiveAmount' represents the amount of the advance receipt, exclusive of tax (if tax is applied) */
-                model.transactions[0].amount = model.transactions[0].taxInclusiveAmount;
-            }
             if (eWayBillResponse && Object.keys(eWayBillResponse).length > 0) {
                 model.ewayBillDetails = eWayBillResponse;
             }

--- a/apps/web-giddh/src/app/reports/components/purchase-register-component/purchase.register.component.ts
+++ b/apps/web-giddh/src/app/reports/components/purchase-register-component/purchase.register.component.ts
@@ -935,6 +935,9 @@ constructor(
             this.removeKeysFromObject(requestObject, keysToRemove);
         }
         this.currentGroupBy.set(requestObject.groupBy);
+        if (requestObject.groupBy === GroupBy.State && !this.reportForm.get('countryCode')?.value) {
+            this.reportForm.get('countryCode')?.setValue(this.activeCompany.countryV2?.alpha2CountryCode);
+        }
         this.componentStore.getSalesPurchaseList({
             payload: requestObject,
             params: { branchUniqueName: (this.currentBranch ? this.currentBranch.uniqueName : ""), from, to },

--- a/apps/web-giddh/src/app/reports/components/report-details-components/report.details.component.html
+++ b/apps/web-giddh/src/app/reports/components/report-details-components/report.details.component.html
@@ -41,6 +41,7 @@
                         [options]="groupByOptions"
                         formControlName="groupBy"
                         [required]="true"
+                        (selectedOption)="handleGroupByChange($event.value)"
                     ></reactive-dropdown-field>
                 </div>
                 @if (reportForm?.get('groupBy')?.value === groupByEnum.Duration) {

--- a/apps/web-giddh/src/app/reports/components/report-details-components/report.details.component.html
+++ b/apps/web-giddh/src/app/reports/components/report-details-components/report.details.component.html
@@ -58,15 +58,15 @@
                     <div class="mr-3">
                         <mat-form-field appearance="outline" class="duration-dropdown w-100">
                             <mat-label>{{ commonLocaleData?.app_duration?.duration }}</mat-label>
-                            <mat-select #durationMatSelect [value]="getSelectedDuration()">
+                            <mat-select #durationMatSelect [value]="selectedType">
                                 <mat-option
-                                    (click)="populateRecords(durationEnum.Monthly)"
+                                    (click)="saveDurationFilter(durationEnum.Monthly)"
                                     [value]="commonLocaleData?.app_duration?.monthly"
                                 >
                                     {{ commonLocaleData?.app_duration?.monthly }}
                                 </mat-option>
                                 <mat-option
-                                    (click)="populateRecords(durationEnum.Quarterly)"
+                                    (click)="saveDurationFilter(durationEnum.Quarterly)"
                                     [value]="commonLocaleData?.app_duration?.quarterly"
                                 >
                                     {{ commonLocaleData?.app_duration?.quarterly }}
@@ -95,7 +95,7 @@
                                 @for (month of monthNames; track month) {
                                     <button
                                         mat-menu-item
-                                        (click)="durationMatSelect.close(); populateRecords(durationEnum.Weekly, month)"
+                                        (click)="durationMatSelect.close(); saveDurationFilter(durationEnum.Weekly, month)"
                                         aria-label="Select month"
                                     >
                                         {{ month | slice: 0 : 3 }}
@@ -114,7 +114,7 @@
                                     panelClass="py-0"
                                     name="salesPerson"
                                     [multiple]="true"
-                                    (selectionChange)="getSalesRegister(dateRange.from, dateRange.to)"
+                                    (selectionChange)="saveSalesPersonFilter()"
                                     (closed)="!filteredSalesPersonList()?.length ? salesPerson.reset() : null"
                                     formControlName="salesPersonUniqueNames"
                                 >
@@ -157,7 +157,7 @@
                                     name="state"
                                     [multiple]="true"
                                     formControlName="stateCodes"
-                                    (selectionChange)="getSalesRegister(dateRange.from, dateRange.to)"
+                                    (selectionChange)="saveStateCodesFilter()"
                                     (closed)="!filteredStateList().length ? stateSearch.reset() : null"
                                 >
                                     <ngx-mat-select-search
@@ -187,7 +187,7 @@
                                 name="country"
                                 [multiple]="true"
                                 formControlName="countryCodes"
-                                (selectionChange)="getSalesRegister(dateRange.from, dateRange.to)"
+                                (selectionChange)="saveCountryCodesFilter()"
                                 (closed)="!filteredCountryList()?.length ? countrySearch.reset() : null"
                             >
                                 <ngx-mat-select-search
@@ -237,7 +237,7 @@
                             name="account"
                             [multiple]="true"
                             formControlName="accountUniqueNames"
-                            (selectionChange)="getSalesRegister(dateRange.from, dateRange.to)"
+                            (selectionChange)="saveAccountFilter()"
                             (closed)="accountReset()"
                         >
                             <ngx-mat-select-search

--- a/apps/web-giddh/src/app/reports/components/report-details-components/report.details.component.ts
+++ b/apps/web-giddh/src/app/reports/components/report-details-components/report.details.component.ts
@@ -327,13 +327,6 @@ constructor(
                 this.filteredStateList.set([]);
             }
         });
-
-        this.reportForm.get('groupBy')?.valueChanges.pipe(filter(Boolean), distinctUntilChanged(), takeUntil(this.destroyed$)).subscribe(groupBy => {
-            if (groupBy) {
-                this.generalService.updateActivatedRouteQueryParams({ groupBy, required: "groupBy" }, "replace");
-            }
-        });
-
     }
 
     public goToDashboard() {
@@ -456,9 +449,9 @@ constructor(
 
             // URL groupBy takes priority over store value
             if (queryParam?.groupBy && [GroupBy.SalesPerson, GroupBy.State, GroupBy.Country].includes(queryParam.groupBy)) {
-                this.reportForm.get('groupBy').patchValue(queryParam.groupBy, {emitevent: false});
+                this.reportForm.get('groupBy').patchValue(queryParam.groupBy);
             } else {
-                this.reportForm.get('groupBy').patchValue(GroupBy.Duration, {emitevent: false});
+                this.reportForm.get('groupBy').patchValue(GroupBy.Duration);
             }
             
             if (this.reportForm.get('groupBy').value === GroupBy.SalesPerson) {
@@ -515,6 +508,15 @@ constructor(
                 this.changeDetectorRef.detectChanges();
             }
         });
+    }
+
+    /**
+     * Handle group by change
+     *
+     * @param groupBy
+     */
+    public handleGroupByChange(groupBy: string) {
+        this.generalService.updateActivatedRouteQueryParams({ groupBy, required: "groupBy" }, "replace");
     }
 
     public selectFinancialYearOption(event: IOption) {

--- a/apps/web-giddh/src/app/reports/components/report-details-components/report.details.component.ts
+++ b/apps/web-giddh/src/app/reports/components/report-details-components/report.details.component.ts
@@ -301,13 +301,6 @@ constructor(
                 }
             });
 
-        /** Universal date */
-        this.componentStore.universalDate$.pipe(takeUntil(this.destroyed$)).subscribe(response => {
-            if (response) {
-                this.selectedDateRange = { startDate: dayjs(response[0]), endDate: dayjs(response[1]) };
-                this.selectedDateRangeUi = dayjs(response[0]).format(GIDDH_NEW_DATE_FORMAT_UI) + " - " + dayjs(response[1]).format(GIDDH_NEW_DATE_FORMAT_UI);
-            }
-        });
         this.store.pipe(select(state => state.general.states), filter(Boolean), takeUntil(this.destroyed$)).subscribe(states => {
             if (states && (states.stateList ?? states.countyList)) {
                 this.stateList.set((states.stateList ?? states.countyList).map(state => ({
@@ -319,7 +312,7 @@ constructor(
         });
 
         // Subscribe to countryCode changes to automatically load states
-        this.reportForm.get('countryCode')?.valueChanges.pipe(filter(Boolean), takeUntil(this.destroyed$)).subscribe(countryCode => {
+        this.reportForm.get('countryCode')?.valueChanges.pipe(filter(Boolean), distinctUntilChanged(), takeUntil(this.destroyed$)).subscribe(countryCode => {
             if (countryCode) {
                 this.loadStates(countryCode);
             } else {
@@ -444,68 +437,89 @@ constructor(
                 currentBranchUniqueName = registerReportFilters ? registerReportFilters.branchChosenInReport : '';
                 return activeCompany;
             }))),
-            this.activeRoute.queryParams.pipe(distinctUntilChanged()),
+            this.activeRoute.queryParams.pipe(debounceTime(700), distinctUntilChanged()),
         ]).pipe(takeUntil(this.destroyed$)).subscribe(([activeCompany, queryParam]) => {
 
+            this.reportForm.get('accountUniqueNames').patchValue(this.generalService.parseQueryParamArray(queryParam?.accountUniqueNames));
+            this.currentBranch.uniqueName = currentBranchUniqueName ?? this.currentBranch?.uniqueName ?? "";
+            const foundBranch = this.currentCompanyBranches?.find(branch => branch?.value === this.currentBranch?.uniqueName);
+            this.currentBranch.name = foundBranch ? foundBranch.name : this.currentBranch?.name;
             // URL groupBy takes priority over store value
             if (queryParam?.groupBy && [GroupBy.SalesPerson, GroupBy.State, GroupBy.Country].includes(queryParam.groupBy)) {
                 this.reportForm.get('groupBy').patchValue(queryParam.groupBy);
+
+                if (this.reportForm.get('groupBy').value === GroupBy.SalesPerson) {
+                    this.reportForm.get('salesPersonUniqueNames').patchValue(this.generalService.parseQueryParamArray(queryParam?.salesPersonUniqueNames));
+                }
+
+                if (this.reportForm.get('groupBy').value === GroupBy.State) {
+                    this.reportForm.get('countryCode').patchValue(queryParam.countryCode ?? this.activeCompany.countryV2?.alpha2CountryCode);
+                    this.reportForm.get('stateCodes').patchValue(this.generalService.parseQueryParamArray(queryParam?.stateCodes));
+                }
+
+                if (this.reportForm.get('groupBy').value === GroupBy.Country) {
+                    this.reportForm.get('countryCodes').patchValue(this.generalService.parseQueryParamArray(queryParam?.countryCodes));
+                }
+
+                if (queryParam?.fromDate && queryParam?.toDate) {
+                    this.dateRange.from = queryParam.fromDate;
+                    this.dateRange.to = queryParam.toDate;
+                    this.selectedDateRange = {
+                        startDate: dayjs(queryParam.fromDate, GIDDH_DATE_FORMAT),
+                        endDate: dayjs(queryParam.toDate, GIDDH_DATE_FORMAT),
+                    };
+                    this.selectedDateRangeUi = dayjs(queryParam.fromDate, GIDDH_DATE_FORMAT).format(GIDDH_NEW_DATE_FORMAT_UI) + ' - ' + dayjs(queryParam.toDate, GIDDH_DATE_FORMAT).format(GIDDH_NEW_DATE_FORMAT_UI);
+                    this.getSalesRegister(this.dateRange.from, this.dateRange.to);
+                } else {
+                    this.componentStore.universalDate$.pipe(filter(Boolean),take(1)).subscribe(response => {
+                        if (response) {
+                            this.dateRange.from = dayjs(response[0]).format(GIDDH_DATE_FORMAT);
+                            this.dateRange.to = dayjs(response[1]).format(GIDDH_DATE_FORMAT);
+                            this.selectedDateRange = {
+                                startDate: dayjs(response[0]),
+                                endDate: dayjs(response[1]),
+                            };
+                            this.selectedDateRangeUi = dayjs(response[0]).format(GIDDH_NEW_DATE_FORMAT_UI) + " - " + dayjs(response[1]).format(GIDDH_NEW_DATE_FORMAT_UI);
+                            this.getSalesRegister(this.dateRange.from, this.dateRange.to);
+                        }
+                    });
+                }
+
             } else {
                 this.reportForm.get('groupBy').patchValue(GroupBy.Duration);
-            }
-            
-            if (this.reportForm.get('groupBy').value === GroupBy.SalesPerson) {
-                this.reportForm.get('salesPersonUniqueNames').patchValue(this.generalService.parseQueryParamArray(queryParam?.salesPersonUniqueNames));
-            }
-
-            if (this.reportForm.get('groupBy').value === GroupBy.State) {
-                this.reportForm.get('countryCode').patchValue(queryParam.countryCode ?? this.activeCompany.countryV2?.alpha2CountryCode);
-                this.reportForm.get('stateCodes').patchValue(this.generalService.parseQueryParamArray(queryParam?.stateCodes));
-            }
-
-            if (this.reportForm.get('groupBy').value === GroupBy.Country) {
-                this.reportForm.get('countryCodes').patchValue(this.generalService.parseQueryParamArray(queryParam?.countryCodes));
-            }
-
-            if (this.reportForm.get('groupBy').value === GroupBy.Duration) {
+                this.generalService.saveRouteQueryFilters({groupBy: GroupBy.Duration, required: "groupBy"});
                 this.selectedType = queryParam.interval ?? this.durationEnum.Monthly;
                 this.interval = this.selectedType;
                 this.reportForm.get('interval').patchValue(this.selectedType);
                 this.selectedMonth = queryParam.selectedMonth ?? '';
-            }
 
-            this.reportForm.get('accountUniqueNames').patchValue(this.generalService.parseQueryParamArray(queryParam?.accountUniqueNames));
-
-            if (activeCompany) {
-                this.selectedCompany = activeCompany;
-                this.financialOptions = activeCompany.financialYears?.map(response => {
-                    if (response) {
-                        return { label: response.uniqueName, value: response.uniqueName };
+                if (activeCompany) {
+                    this.selectedCompany = activeCompany;
+                    this.financialOptions = activeCompany.financialYears?.map(response => {
+                        if (response) {
+                            return { label: response.uniqueName, value: response.uniqueName };
+                        }
+                    });
+                    let selectedFinancialYear, activeFinancialYear, uniqueNameToSearch;
+                    if (financialYearChosenInReportUniqueName) {
+                        // User is navigating back from details page hence show the selected filter as pre-filled
+                        uniqueNameToSearch = financialYearChosenInReportUniqueName;
+                    } else {
+                        uniqueNameToSearch = (activeCompany.activeFinancialYear) ? activeCompany.activeFinancialYear.uniqueName : "";
                     }
-                });
-                let selectedFinancialYear, activeFinancialYear, uniqueNameToSearch;
-                if (financialYearChosenInReportUniqueName) {
-                    // User is navigating back from details page hence show the selected filter as pre-filled
-                    uniqueNameToSearch = financialYearChosenInReportUniqueName;
-                } else {
-                    uniqueNameToSearch = (activeCompany.activeFinancialYear) ? activeCompany.activeFinancialYear.uniqueName : "";
+                    selectedFinancialYear = this.financialOptions?.find(option => option?.value === uniqueNameToSearch);
+                    activeFinancialYear = this.selectedCompany.financialYears?.find(p => p?.uniqueName === uniqueNameToSearch);
+                    this.activeFinacialYr = activeFinancialYear;
+                    if (!this.activeFinacialYr && this.selectedCompany.financialYears?.length) {
+                        this.activeFinacialYr = this.selectedCompany.financialYears[0];
+                        selectedFinancialYear = this.selectedCompany.financialYears[0];
+                    }
+                    if (selectedFinancialYear) {
+                        this.currentActiveFinacialYear = cloneDeep(selectedFinancialYear);
+                    }
+                    this.populateRecords(this.selectedType, this.selectedMonth);
+                    this.changeDetectorRef.detectChanges();
                 }
-                selectedFinancialYear = this.financialOptions?.find(option => option?.value === uniqueNameToSearch);
-                activeFinancialYear = this.selectedCompany.financialYears?.find(p => p?.uniqueName === uniqueNameToSearch);
-                this.activeFinacialYr = activeFinancialYear;
-                if (!this.activeFinacialYr && this.selectedCompany.financialYears?.length) {
-                    this.activeFinacialYr = this.selectedCompany.financialYears[0];
-                    selectedFinancialYear = this.selectedCompany.financialYears[0];
-                }
-                if (selectedFinancialYear) {
-                    this.currentActiveFinacialYear = cloneDeep(selectedFinancialYear);
-                }
-                this.currentBranch.uniqueName = currentBranchUniqueName ?? this.currentBranch?.uniqueName ?? "";
-                const foundBranch = this.currentCompanyBranches?.find(branch => branch?.value === this.currentBranch?.uniqueName);
-                this.currentBranch.name = foundBranch ? foundBranch.name : this.currentBranch?.name;
-                this.populateRecords(this.selectedType, this.selectedMonth);
-                this.salesRegisterTotal.particular = this.getCustomParticular();
-                this.changeDetectorRef.detectChanges();
             }
         });
     }
@@ -564,27 +578,6 @@ constructor(
 
     public formatParticular(mdyTo, mdyFrom, index, monthNames) {
         return this.commonLocaleData?.app_quarter + ' ' + index + " (" + monthNames[parseInt(mdyFrom[1]) - 1] + " " + mdyFrom[2] + "-" + monthNames[parseInt(mdyTo[1]) - 1] + " " + mdyTo[2] + ")";
-    }
-
-    public bsValueChange(event: any) {
-        if (event) {
-            let request: ReportsRequestModel = {
-                to: dayjs(event[1]).format(GIDDH_DATE_FORMAT),
-                from: dayjs(event[0]).format(GIDDH_DATE_FORMAT),
-                interval: this.durationEnum.Monthly,
-                branchUniqueName: (this.currentBranch ? this.currentBranch.uniqueName : "")
-            }
-            this.companyService.getSalesRegister(request).pipe(takeUntil(this.destroyed$)).subscribe((res) => {
-                if (res?.status === 'error') {
-                    this._toaster.errorToast(res?.message);
-                } else {
-                    this.salesRegisterTotal = new ReportsModel();
-                    this.salesRegisterTotal.particular = this.getCustomParticular();
-                    this.reportRespone = this.filterReportResp(res?.body);
-                }
-            });
-
-        }
     }
 
     public getDateFromMonth(selectedMonth) {
@@ -910,11 +903,9 @@ constructor(
         }
         this.toggleGiddhDatepicker(false);
         if (value && value.startDate && value.endDate) {
-            this.selectedDateRange = { startDate: dayjs(value.startDate), endDate: dayjs(value.endDate) };
-            this.selectedDateRangeUi = dayjs(value.startDate).format(GIDDH_NEW_DATE_FORMAT_UI) + " - " + dayjs(value.endDate).format(GIDDH_NEW_DATE_FORMAT_UI);
             this.dateRange.from = dayjs(value.startDate).format(GIDDH_DATE_FORMAT);
             this.dateRange.to = dayjs(value.endDate).format(GIDDH_DATE_FORMAT);
-            this.getSalesRegister(this.dateRange.from, this.dateRange.to);
+            this.generalService.saveRouteQueryFilters({ fromDate: this.dateRange.from, toDate: this.dateRange.to });
         }
     }
 
@@ -933,6 +924,7 @@ constructor(
             return;
         }
         this.savePreferences();
+        this.salesRegisterTotal.particular = this.getCustomParticular();
         const requestObject = cloneDeep(this.reportForm.value);
         const groupByValue = this.reportForm?.get('groupBy')?.value;
 

--- a/apps/web-giddh/src/app/reports/components/report-details-components/report.details.component.ts
+++ b/apps/web-giddh/src/app/reports/components/report-details-components/report.details.component.ts
@@ -441,7 +441,7 @@ constructor(
         ]).pipe(takeUntil(this.destroyed$)).subscribe(([activeCompany, queryParam]) => {
 
             this.reportForm.get('accountUniqueNames').patchValue(this.generalService.parseQueryParamArray(queryParam?.accountUniqueNames));
-            this.currentBranch.uniqueName = currentBranchUniqueName ?? this.currentBranch?.uniqueName ?? "";
+            this.currentBranch.uniqueName = currentBranchUniqueName || this.currentBranch?.uniqueName || "";
             const foundBranch = this.currentCompanyBranches?.find(branch => branch?.value === this.currentBranch?.uniqueName);
             this.currentBranch.name = foundBranch ? foundBranch.name : this.currentBranch?.name;
             // URL groupBy takes priority over store value
@@ -453,7 +453,7 @@ constructor(
                 }
 
                 if (this.reportForm.get('groupBy').value === GroupBy.State) {
-                    this.reportForm.get('countryCode').patchValue(queryParam.countryCode ?? this.activeCompany.countryV2?.alpha2CountryCode);
+                    this.reportForm.get('countryCode').patchValue(queryParam.countryCode ?? (this.activeCompany || activeCompany)?.countryV2?.alpha2CountryCode);
                     this.reportForm.get('stateCodes').patchValue(this.generalService.parseQueryParamArray(queryParam?.stateCodes));
                 }
 

--- a/apps/web-giddh/src/app/reports/components/report-details-components/report.details.component.ts
+++ b/apps/web-giddh/src/app/reports/components/report-details-components/report.details.component.ts
@@ -686,13 +686,13 @@ constructor(
         this.store.dispatch(this.companyActions.setUserChosenFinancialYear({
             financialYear: this.currentActiveFinacialYear?.value, 
             branchUniqueName: (this.currentBranch ? this.currentBranch.uniqueName : ""), 
-            timeFilter: null, 
-            salesPersonUniqueNames: [], 
-            accountUniqueNames: [], 
-            groupBy: null, 
-            countryCodes: [],
-            countryCode: null,
-            stateCodes: []
+            timeFilter: this.selectedType, 
+            salesPersonUniqueNames: this.reportForm?.get('salesPersonUniqueNames')?.value, 
+            accountUniqueNames: this.reportForm?.get('accountUniqueNames')?.value, 
+            groupBy: this.reportForm?.get('groupBy')?.value, 
+            countryCodes: this.reportForm?.get('countryCodes')?.value,
+            countryCode: this.reportForm?.get('countryCode')?.value,
+            stateCodes: this.reportForm?.get('stateCodes')?.value
         }));
     }
 

--- a/apps/web-giddh/src/app/reports/components/report-details-components/report.details.component.ts
+++ b/apps/web-giddh/src/app/reports/components/report-details-components/report.details.component.ts
@@ -330,40 +330,10 @@ constructor(
 
         this.reportForm.get('groupBy')?.valueChanges.pipe(filter(Boolean), distinctUntilChanged(), takeUntil(this.destroyed$)).subscribe(groupBy => {
             if (groupBy) {
-                this.handleGroupByChange(groupBy);
-                this.generalService.updateActivatedRouteQueryParams({ groupBy });
+                this.generalService.updateActivatedRouteQueryParams({ groupBy, required: "groupBy" }, "replace");
             }
         });
 
-    }
-
-    /**
-     * Handle group by change
-     *
-     * @param groupBy
-     */
-    public handleGroupByChange(groupBy: GroupBy): void {
-        if (GroupBy.SalesPerson !== groupBy) {
-            this.reportForm.get('salesPersonUniqueNames')?.setValue([]);
-        }
-        if (GroupBy.State !== groupBy) {
-            this.reportForm.get('countryCode')?.setValue(null);
-            this.reportForm.get('stateCodes')?.setValue([]);
-        }
-        if (GroupBy.Country !== groupBy) {
-            this.reportForm.get('countryCodes')?.setValue([]);
-        }
-
-        if ([GroupBy.SalesPerson, GroupBy.State, GroupBy.Country].includes(groupBy)) {
-            this.dateRange.from = dayjs(this.selectedDateRange?.startDate).format(GIDDH_DATE_FORMAT);
-            this.dateRange.to = dayjs(this.selectedDateRange?.endDate).format(GIDDH_DATE_FORMAT);
-            if (groupBy === GroupBy.State && !this.reportForm.get('countryCode')?.value) {
-                this.reportForm.get('countryCode')?.setValue(this.activeCompany.countryV2?.alpha2CountryCode);
-            }
-            this.getSalesRegister(this.dateRange.from, this.dateRange.to);
-        } else {
-            this.populateRecords(this.interval, this.selectedMonth);
-        }
     }
 
     public goToDashboard() {
@@ -473,39 +443,47 @@ constructor(
     public setCurrentFY() {
         let financialYearChosenInReportUniqueName = '';
         let currentBranchUniqueName = '';
-        let currentTimeFilter: DurationEnum = this.selectedType;
-
 
         // set financial years based on company financial year
         combineLatest([
             this.store.pipe(select(createSelector([(state: AppState) => state.session.activeCompany, (state: AppState) => state.session.registerReportFilters], (activeCompany, registerReportFilters) => {
                 financialYearChosenInReportUniqueName = registerReportFilters ? registerReportFilters.financialYearChosenInReport : '';
                 currentBranchUniqueName = registerReportFilters ? registerReportFilters.branchChosenInReport : '';
-                currentTimeFilter = registerReportFilters?.timeFilter?.toLowerCase() ?? '';
-                this.reportForm.get('salesPersonUniqueNames').patchValue(registerReportFilters?.salesPersonUniqueNames ?? []);
-                this.reportForm.get('accountUniqueNames').patchValue(registerReportFilters?.accountUniqueNames ?? []);
-                this.reportForm.get('countryCodes').patchValue(registerReportFilters?.countryCodes ?? []);
-                this.reportForm.get('countryCode').patchValue(registerReportFilters?.countryCode ?? '');
-                this.reportForm.get('stateCodes').patchValue(registerReportFilters?.stateCodes ?? []);
                 return activeCompany;
             }))),
             this.activeRoute.queryParams.pipe(distinctUntilChanged()),
         ]).pipe(takeUntil(this.destroyed$)).subscribe(([activeCompany, queryParam]) => {
+
             // URL groupBy takes priority over store value
             if (queryParam?.groupBy && [GroupBy.SalesPerson, GroupBy.State, GroupBy.Country].includes(queryParam.groupBy)) {
-                this.reportForm.get('groupBy').patchValue(queryParam.groupBy);
+                this.reportForm.get('groupBy').patchValue(queryParam.groupBy, {emitevent: false});
             } else {
-                this.reportForm.get('groupBy').patchValue(GroupBy.Duration);
+                this.reportForm.get('groupBy').patchValue(GroupBy.Duration, {emitevent: false});
             }
             
-            if (queryParam?.interval || queryParam?.selectedMonth) {
-                this.selectedType = queryParam.interval;
-                this.interval = queryParam.interval;
-                this.reportForm.get('interval').patchValue(queryParam.interval);
-                this.selectedMonth = queryParam.selectedMonth;
-                this.router.navigate(['pages', 'reports', 'sales-register'], { 
-                queryParams: { groupBy: this.reportForm.get('groupBy').value } });
+            if (this.reportForm.get('groupBy').value === GroupBy.SalesPerson) {
+                this.reportForm.get('salesPersonUniqueNames').patchValue(this.generalService.parseQueryParamArray(queryParam?.salesPersonUniqueNames));
             }
+
+            if (this.reportForm.get('groupBy').value === GroupBy.State) {
+                this.reportForm.get('countryCode').patchValue(queryParam.countryCode ?? this.activeCompany.countryV2?.alpha2CountryCode);
+                this.reportForm.get('stateCodes').patchValue(this.generalService.parseQueryParamArray(queryParam?.stateCodes));
+            }
+
+            if (this.reportForm.get('groupBy').value === GroupBy.Country) {
+                this.reportForm.get('countryCodes').patchValue(this.generalService.parseQueryParamArray(queryParam?.countryCodes));
+            }
+
+            if (this.reportForm.get('groupBy').value === GroupBy.Duration) {
+                this.selectedType = queryParam.interval ?? this.durationEnum.Monthly;
+                this.interval = this.selectedType;
+                this.reportForm.get('interval').patchValue(this.selectedType);
+                if (queryParam?.selectedMonth) {
+                    this.selectedMonth = queryParam.selectedMonth;
+                }
+            }
+
+            this.reportForm.get('accountUniqueNames').patchValue(this.generalService.parseQueryParamArray(queryParam?.accountUniqueNames));
 
             if (activeCompany) {
                 this.selectedCompany = activeCompany;
@@ -534,7 +512,6 @@ constructor(
                 this.currentBranch.uniqueName = currentBranchUniqueName ?? this.currentBranch?.uniqueName ?? "";
                 const foundBranch = this.currentCompanyBranches?.find(branch => branch?.value === this.currentBranch?.uniqueName);
                 this.currentBranch.name = foundBranch ? foundBranch.name : this.currentBranch?.name;
-                this.selectedType = currentTimeFilter || this.selectedType;
                 this.populateRecords(this.selectedType, this.selectedMonth);
                 this.salesRegisterTotal.particular = this.getCustomParticular();
                 this.changeDetectorRef.detectChanges();
@@ -553,7 +530,7 @@ constructor(
         this.interval = interval;
         this.reportForm.get('interval').patchValue(interval);
         if (interval === this.durationEnum.Weekly && !month) {
-            this.populateRecords(this.durationEnum.Monthly);
+            this.saveDurationFilter(this.durationEnum.Monthly);
             return;
         }
         if (this.activeFinacialYr && this.reportForm.get('groupBy')?.value === GroupBy.Duration) {
@@ -650,6 +627,56 @@ constructor(
     }
 
     /**
+     * Saves the selected duration interval and optional month to URL query params
+     *
+     * @param {string} interval - Duration interval (e.g. Monthly, Quarterly, Weekly)
+     * @param {string} [month] - Optional month name for weekly view
+     * @memberof ReportsDetailsComponent
+     */
+    public saveDurationFilter(interval: string, month?: string): void {
+        this.generalService.saveRouteQueryFilters({
+            interval: interval ?? null,
+            selectedMonth: month ?? null
+        });
+    }
+
+    /**
+     * Saves the selected sales person unique names to URL query params
+     *
+     * @memberof ReportsDetailsComponent
+     */
+    public saveSalesPersonFilter(): void {
+        this.generalService.saveRouteQueryFilters({ salesPersonUniqueNames: this.reportForm.get('salesPersonUniqueNames')?.value ?? [] });
+    }
+
+    /**
+     * Saves the selected account unique names to URL query params
+     *
+     * @memberof ReportsDetailsComponent
+     */
+    public saveAccountFilter(): void {
+        this.generalService.saveRouteQueryFilters({ accountUniqueNames: this.reportForm.get('accountUniqueNames')?.value ?? [] });
+    }
+
+    /**
+     * Saves the selected country codes to URL query params
+     *
+     * @memberof ReportsDetailsComponent
+     */
+    public saveCountryCodesFilter(): void {
+        this.generalService.saveRouteQueryFilters({ countryCodes: this.reportForm.get('countryCodes')?.value ?? [] });
+    }
+
+    /**
+     * Saves the selected state codes to URL query params
+     *
+     * @memberof ReportsDetailsComponent
+     */
+    public saveStateCodesFilter(): void {
+        this.generalService.saveRouteQueryFilters({ stateCodes: this.reportForm.get('stateCodes')?.value ?? [] });
+    }
+
+    /**
      * Saves the user preference for filters
      *
      * @private
@@ -659,13 +686,13 @@ constructor(
         this.store.dispatch(this.companyActions.setUserChosenFinancialYear({
             financialYear: this.currentActiveFinacialYear?.value, 
             branchUniqueName: (this.currentBranch ? this.currentBranch.uniqueName : ""), 
-            timeFilter: this.selectedType, 
-            salesPersonUniqueNames: this.reportForm?.get('salesPersonUniqueNames')?.value, 
-            accountUniqueNames: this.reportForm?.get('accountUniqueNames')?.value, 
-            groupBy: this.reportForm?.get('groupBy')?.value, 
-            countryCodes: this.reportForm?.get('countryCodes')?.value,
-            countryCode: this.reportForm?.get('countryCode')?.value,
-            stateCodes: this.reportForm?.get('stateCodes')?.value
+            timeFilter: null, 
+            salesPersonUniqueNames: [], 
+            accountUniqueNames: [], 
+            groupBy: null, 
+            countryCodes: [],
+            countryCode: null,
+            stateCodes: []
         }));
     }
 
@@ -701,7 +728,6 @@ constructor(
         if (event) {
             this.monthNames = [this.commonLocaleData?.app_months_full.january, this.commonLocaleData?.app_months_full.february, this.commonLocaleData?.app_months_full.march, this.commonLocaleData?.app_months_full.april, this.commonLocaleData?.app_months_full.may, this.commonLocaleData?.app_months_full.june, this.commonLocaleData?.app_months_full.july, this.commonLocaleData?.app_months_full.august, this.commonLocaleData?.app_months_full.september, this.commonLocaleData?.app_months_full.october, this.commonLocaleData?.app_months_full.november, this.commonLocaleData?.app_months_full.december];
             this.setCurrentFY();
-            this.getSelectedDuration();
             this.groupByOptions = [
                 { label: this.localeData?.by_duration, value: GroupBy.Duration },
                 { label: this.localeData?.by_sales_person, value: GroupBy.SalesPerson },
@@ -719,22 +745,6 @@ constructor(
     public ngOnDestroy(): void {
         this.destroyed$.next(true);
         this.destroyed$.complete();
-    }
-
-    /**
-     * This will return duration name
-     *
-     * @returns {string}
-     * @memberof ReportsDetailsComponent
-     */
-    public getSelectedDuration(): string {
-        if (this.selectedType?.toLowerCase() === "monthly") {
-            return this.commonLocaleData?.app_duration?.monthly;
-        } else if (this.selectedType?.toLowerCase() === "quarterly") {
-            return this.commonLocaleData?.app_duration?.quarterly;
-        } else if (this.selectedType?.toLowerCase() === "weekly") {
-            return this.commonLocaleData?.app_duration?.weekly;
-        }
     }
 
     /**
@@ -1025,6 +1035,10 @@ constructor(
             this.dateRange.from = dayjs(this.selectedDateRange?.startDate).format(GIDDH_DATE_FORMAT);
             this.dateRange.to = dayjs(this.selectedDateRange?.endDate).format(GIDDH_DATE_FORMAT);
             this.reportForm.get('stateCodes')?.setValue([]);
+            this.generalService.saveRouteQueryFilters({
+                countryCode: event.value,
+                stateCodes: null,
+            });
             this.getSalesRegister(this.dateRange.from, this.dateRange.to);
         }
     }

--- a/apps/web-giddh/src/app/reports/components/report-details-components/report.details.component.ts
+++ b/apps/web-giddh/src/app/reports/components/report-details-components/report.details.component.ts
@@ -478,9 +478,7 @@ constructor(
                 this.selectedType = queryParam.interval ?? this.durationEnum.Monthly;
                 this.interval = this.selectedType;
                 this.reportForm.get('interval').patchValue(this.selectedType);
-                if (queryParam?.selectedMonth) {
-                    this.selectedMonth = queryParam.selectedMonth;
-                }
+                this.selectedMonth = queryParam.selectedMonth ?? '';
             }
 
             this.reportForm.get('accountUniqueNames').patchValue(this.generalService.parseQueryParamArray(queryParam?.accountUniqueNames));

--- a/apps/web-giddh/src/app/reports/components/sales-register-expand-component/sales.register.expand.component.ts
+++ b/apps/web-giddh/src/app/reports/components/sales-register-expand-component/sales.register.expand.component.ts
@@ -332,7 +332,7 @@ public voucherNumberInput: UntypedFormControl = new UntypedFormControl();
      */
     public gotoSalesRegister(): void {
         this.activeRoute.queryParams.pipe(take(1)).subscribe(params => {
-            this.router.navigate(['pages', 'reports', 'sales-register'], { queryParams: { from: params.from, to: params.to, branchUniqueName: params.branchUniqueName, interval: params.interval, selectedMonth: params.selectedMonth, groupBy: this.currentGroupBy() } });
+            this.router.navigate(['pages', 'reports', 'sales-register'], { queryParams: { groupBy: this.currentGroupBy(), required: "groupBy" } });
         });
     }
 

--- a/apps/web-giddh/src/app/services/general.service.ts
+++ b/apps/web-giddh/src/app/services/general.service.ts
@@ -33,6 +33,7 @@ import { Configuration } from '../app.constant';
 import { cloneDeep, concat, find, findIndex, forEach, includes, indexOf, keys, map, orderBy, remove, set, slice, some } from '../lodash-optimized';
 import { ToasterService } from './toaster.service';
 import { AbstractControl } from '@angular/forms';
+import { UiSettingsService } from './ui-settings.service';
 
 @Injectable({
     providedIn: 'root'
@@ -124,7 +125,8 @@ export class GeneralService {
         private http: HttpClient,
         @Optional() @Inject(ServiceConfig)
         private config: IServiceConfigArgs,
-        private toasterService: ToasterService
+        private toasterService: ToasterService,
+        private uiSettingsService: UiSettingsService
     ) { }
 
     public SetIAmLoaded(iAmLoaded: boolean) {
@@ -2228,6 +2230,125 @@ export class GeneralService {
             footerCssClass,
             buttons
         };
+    }
+
+    /**
+     * Parses a comma-separated query param string into a string array.
+     *
+     * @param {string} [value] - Raw query param value
+     * @returns {string[]} Parsed array, empty if no value
+     * @memberof GeneralService
+     */
+    public parseQueryParamArray(value?: string): string[] {
+        return value ? value.split(',').filter(Boolean) : [];
+    }
+
+    /**
+     * Normalizes query params by converting any array values to comma-separated strings.
+     *
+     * @private
+     * @param {Record<string, any>} queryParams - Raw query params
+     * @returns {Record<string, any>} Normalized params
+     * @memberof GeneralService
+     */
+    private normalizeQueryParams(queryParams: Record<string, any>): Record<string, any> {
+        const normalized: Record<string, any> = {};
+        for (const [key, value] of Object.entries(queryParams)) {
+            normalized[key] = Array.isArray(value) ? (value.length ? value.join(',') : null) : value;
+        }
+        return normalized;
+    }
+
+    /**
+     * Saves query params for a given route path scoped to the active company.
+     * Pass null as queryParams to clear the saved entry.
+     * When replaceOnly is true, saves exactly the provided params without merging with existing ones.
+     * When replaceOnly is false (default), merges the provided params with any existing saved params.
+     * Array values are automatically normalized to comma-separated strings.
+     *
+     * @public
+     * @param {(Record<string, any> | null)} queryParams - Params to save, or null to clear
+     * @param {boolean} [replaceOnly=false] - When true, replaces existing saved params entirely
+     * @memberof GeneralService
+     */
+    public saveRouteQueryFilters(queryParams: Record<string, any> | null, replaceOnly: boolean = false): void {
+        const companyUniqueName = this.companyUniqueName;
+        const { path, queryParams: forcedParams } = this.getCurrentPath(replaceOnly);
+        if (companyUniqueName && path) {
+            const normalized = queryParams ? this.normalizeQueryParams(queryParams) : {};
+            const existing = replaceOnly ? {} : (this.uiSettingsService.getRouteQueryFilters(companyUniqueName, path) ?? {});
+            const merged = { ...existing, ...forcedParams, ...normalized };
+            this.updateActivatedRouteQueryParams(merged ?? {}, replaceOnly ? 'replace' : 'merge');
+            this.uiSettingsService.setRouteQueryFilters(companyUniqueName, path, merged);
+        }
+    }
+
+    /**
+     * Gets the saved query params for a given route path scoped to the active company
+     *
+     * @public
+     * @param {string} routePath - Route path to look up (e.g. /pages/contact/customer)
+     * @returns {(Record<string, any> | null)} Saved query params or null
+     * @memberof GeneralService
+     */
+    public getRouteQueryFiltersForPath(): Record<string, any> | null {
+        const companyUniqueName = this.companyUniqueName;
+        const { path } = this.getCurrentPath();
+        if (!companyUniqueName || !path) {
+            return null;
+        }
+        return this.uiSettingsService.getRouteQueryFilters(companyUniqueName, path);
+    }
+
+    /**
+     * Restores saved query params for a given route path from localStorage only.
+     * Returns the saved params so the component can apply them to its own state and URL.
+     *
+     * @public
+     * @param {string} routePath - Explicit route path (e.g. /pages/contact/customer)
+     * @returns {(Record<string, any> | null)} Saved params or null if nothing found
+     * @memberof GeneralService
+     */
+    public restoreRouteQueryFilters(): void {
+        const { queryParams: forcedParams } = this.getCurrentPath();
+        const saved = this.getRouteQueryFiltersForPath() ?? {};
+        const merged: Record<string, any> = { ...saved, ...forcedParams };
+        this.updateActivatedRouteQueryParams(merged);
+    }
+
+    /**
+     * Returns the current route path scoped by required query params (for localStorage key)
+     * and the full current query params (for merging with saved filters).
+     * When replaceOnly is true, returns only the forced/required params as queryParams.
+     *
+     * @param {boolean} [replaceOnly] - When true, returns only required params in queryParams
+     * @returns {{ path: string; queryParams: Record<string, any> }} Scoped path and query params
+     * @memberof GeneralService
+     */
+    public getCurrentPath(replaceOnly: boolean = false): { path: string; queryParams: Record<string, any> } {
+        const currentUrlParams = this.activatedRoute.snapshot.queryParams;
+        const basePath = this.router.url.split('?')[0];
+        const forcedParams: Record<string, any> = {};
+
+        if (currentUrlParams?.required) {
+            const requiredKeys: string[] = currentUrlParams.required.split(',');
+            requiredKeys.forEach(key => {
+                if (currentUrlParams[key] != null) {
+                    forcedParams[key] = currentUrlParams[key];
+                }
+            });
+        } else if (currentUrlParams?.tab) {
+            forcedParams['tab'] = currentUrlParams['tab'];
+            if (currentUrlParams?.tabIndex) {
+                forcedParams['tabIndex'] = currentUrlParams['tabIndex'];
+            }
+        }
+        
+        const scopedPath = Object.keys(forcedParams).length
+            ? `${basePath}?${Object.entries(forcedParams).map(([k, v]) => `${k}=${v}`).join('&')}`
+            : basePath;
+
+        return { path: scopedPath, queryParams: replaceOnly ? forcedParams : currentUrlParams };
     }
 
     /**

--- a/apps/web-giddh/src/app/services/general.service.ts
+++ b/apps/web-giddh/src/app/services/general.service.ts
@@ -870,12 +870,13 @@ export class GeneralService {
      */
     public fetchTaxesOnPriority(stockTaxes?: Array<string>, stockGroupTaxes?: Array<string>,
         accountTaxes?: Array<string>, accountGroupTaxes?: Array<string>): Array<string> {
+        accountTaxes = accountTaxes?.filter((tax) => !(accountGroupTaxes ?? []).includes(tax)) ?? [];
         if (stockTaxes?.length) {
             return stockTaxes;
         } else if (stockGroupTaxes?.length) {
             return stockGroupTaxes;
         } else if (accountTaxes?.length) {
-            return accountTaxes?.filter((tax) => !(accountGroupTaxes ?? []).includes(tax)) ?? [];
+            return accountTaxes;
         } else if (accountGroupTaxes?.length) {
             return accountGroupTaxes;
         } else {

--- a/apps/web-giddh/src/app/services/general.service.ts
+++ b/apps/web-giddh/src/app/services/general.service.ts
@@ -2358,7 +2358,8 @@ export class GeneralService {
         '/pages/contact/vendor?tab=vendor&tabIndex=1',
         '/pages/reports/sales-register?groupBy=salesPerson',
         '/pages/reports/sales-register?groupBy=state',
-        '/pages/reports/sales-register?groupBy=country'
+        '/pages/reports/sales-register?groupBy=country',
+        '/pages/reports/sales-register?groupBy=duration'
     ];
 
     /**

--- a/apps/web-giddh/src/app/services/general.service.ts
+++ b/apps/web-giddh/src/app/services/general.service.ts
@@ -2352,6 +2352,15 @@ export class GeneralService {
         return { path: scopedPath, queryParams: replaceOnly ? forcedParams : currentUrlParams };
     }
 
+    /** List of scoped route paths that support fromDate/toDate query param persistence */
+    public readonly currentSupportedQueryParam: string[] = [
+        '/pages/contact/customer?tab=customer&tabIndex=1',
+        '/pages/contact/vendor?tab=vendor&tabIndex=1',
+        '/pages/reports/sales-register?groupBy=salesPerson',
+        '/pages/reports/sales-register?groupBy=state',
+        '/pages/reports/sales-register?groupBy=country'
+    ];
+
     /**
      * Update current page query params
      *

--- a/apps/web-giddh/src/app/services/general.service.ts
+++ b/apps/web-giddh/src/app/services/general.service.ts
@@ -2356,6 +2356,7 @@ export class GeneralService {
     public readonly currentSupportedQueryParam: string[] = [
         '/pages/contact/customer?tab=customer&tabIndex=1',
         '/pages/contact/vendor?tab=vendor&tabIndex=1',
+        '/pages/contact/aging-report?tab=aging-report&tabIndex=1',
         '/pages/reports/sales-register?groupBy=salesPerson',
         '/pages/reports/sales-register?groupBy=state',
         '/pages/reports/sales-register?groupBy=country',

--- a/apps/web-giddh/src/app/services/ui-settings.service.ts
+++ b/apps/web-giddh/src/app/services/ui-settings.service.ts
@@ -317,6 +317,58 @@ export class UiSettingsService {
     }
 
     /**
+     * Gets the saved query params for a specific route and company
+     *
+     * @public
+     * @param {string} companyUniqueName - The active company unique name
+     * @param {string} routePath - The route path (e.g. /pages/contact/customer)
+     * @returns {(Record<string, any> | null)} Saved query params or null if not found
+     * @memberof UiSettingsService
+     */
+    public getRouteQueryFilters(companyUniqueName: string, routePath: string): Record<string, any> | null {
+        try {
+            const allSettings = this.getAllSettings();
+            const routeFilters = allSettings['route-query-filters'];
+            return routeFilters?.[companyUniqueName]?.[routePath]?.queryParams ?? null;
+        } catch (error) {
+            console.warn('Error getting route query filters:', error);
+            return null;
+        }
+    }
+
+    /**
+     * Saves query params for a specific route and company. Pass null to clear.
+     *
+     * @public
+     * @param {string} companyUniqueName - The active company unique name
+     * @param {string} routePath - The route path (e.g. /pages/contact/customer)
+     * @param {(Record<string, any> | null)} queryParams - Query params to save, or null to clear
+     * @returns {boolean} Success status
+     * @memberof UiSettingsService
+     */
+    public setRouteQueryFilters(companyUniqueName: string, routePath: string, queryParams: Record<string, any> | null): boolean {
+        try {
+            const allSettings = this.getAllSettings();
+            if (!allSettings['route-query-filters']) {
+                allSettings['route-query-filters'] = {};
+            }
+            if (!allSettings['route-query-filters'][companyUniqueName]) {
+                allSettings['route-query-filters'][companyUniqueName] = {};
+            }
+            if (queryParams === null) {
+                delete allSettings['route-query-filters'][companyUniqueName][routePath];
+            } else {
+                allSettings['route-query-filters'][companyUniqueName][routePath] = { queryParams };
+            }
+            localStorage.setItem(UI_SETTINGS_STORAGE_KEY, JSON.stringify(allSettings));
+            return true;
+        } catch (error) {
+            console.error('Error setting route query filters:', error);
+            return false;
+        }
+    }
+
+    /**
      * Checks if a value is a cached setting with expiry
      * 
      * @private

--- a/apps/web-giddh/src/app/services/ui-settings.service.ts
+++ b/apps/web-giddh/src/app/services/ui-settings.service.ts
@@ -1,6 +1,9 @@
 import { Injectable } from '@angular/core';
 import { UI_SETTINGS_STORAGE_KEY, CACHE_DURATION } from '../app.constant';
 
+/** Storage key for persisted route query filter params */
+const ROUTE_QUERY_FILTERS_KEY = 'route-query-filters';
+
 /**
  * Interface for UI settings data structure
  */
@@ -328,7 +331,7 @@ export class UiSettingsService {
     public getRouteQueryFilters(companyUniqueName: string, routePath: string): Record<string, any> | null {
         try {
             const allSettings = this.getAllSettings();
-            const routeFilters = allSettings['route-query-filters'];
+            const routeFilters = allSettings[ROUTE_QUERY_FILTERS_KEY];
             return routeFilters?.[companyUniqueName]?.[routePath]?.queryParams ?? null;
         } catch (error) {
             console.warn('Error getting route query filters:', error);
@@ -349,16 +352,16 @@ export class UiSettingsService {
     public setRouteQueryFilters(companyUniqueName: string, routePath: string, queryParams: Record<string, any> | null): boolean {
         try {
             const allSettings = this.getAllSettings();
-            if (!allSettings['route-query-filters']) {
-                allSettings['route-query-filters'] = {};
+            if (!allSettings[ROUTE_QUERY_FILTERS_KEY]) {
+                allSettings[ROUTE_QUERY_FILTERS_KEY] = {};
             }
-            if (!allSettings['route-query-filters'][companyUniqueName]) {
-                allSettings['route-query-filters'][companyUniqueName] = {};
+            if (!allSettings[ROUTE_QUERY_FILTERS_KEY][companyUniqueName]) {
+                allSettings[ROUTE_QUERY_FILTERS_KEY][companyUniqueName] = {};
             }
             if (queryParams === null) {
-                delete allSettings['route-query-filters'][companyUniqueName][routePath];
+                delete allSettings[ROUTE_QUERY_FILTERS_KEY][companyUniqueName][routePath];
             } else {
-                allSettings['route-query-filters'][companyUniqueName][routePath] = { queryParams };
+                allSettings[ROUTE_QUERY_FILTERS_KEY][companyUniqueName][routePath] = { queryParams };
             }
             localStorage.setItem(UI_SETTINGS_STORAGE_KEY, JSON.stringify(allSettings));
             return true;

--- a/apps/web-giddh/src/app/shared/aside-menu-create-tax/aside-menu-create-tax.component.ts
+++ b/apps/web-giddh/src/app/shared/aside-menu-create-tax/aside-menu-create-tax.component.ts
@@ -81,6 +81,7 @@ export class AsideMenuCreateTaxComponent implements OnInit, OnChanges, AfterView
         private formBuilder: FormBuilder
     ) {
         this.initForm();
+        this.store.dispatch(this.settingsTaxesActions.CreateTaxResponse(null));
     }
 
     /**

--- a/apps/web-giddh/src/app/shared/header/components/master/master.component.html
+++ b/apps/web-giddh/src/app/shared/header/components/master/master.component.html
@@ -12,7 +12,7 @@
     >
         <div
             class="col-wrapper left-account-operation"
-            [style.height.px]="height"
+            [style.height.px]="height()"
             nav-hr-item
             (ngInit)="onColAdd($event, navigation)"
             *ngFor="let items of masterColumnsData; let i = index"

--- a/apps/web-giddh/src/app/shared/header/components/master/master.component.ts
+++ b/apps/web-giddh/src/app/shared/header/components/master/master.component.ts
@@ -1,5 +1,5 @@
 import { CdkVirtualScrollViewport, ScrollDispatcher } from "@angular/cdk/scrolling";
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, EventEmitter, Input, OnChanges, OnDestroy, OnInit, Output, QueryList, SimpleChanges, ViewChildren, NgZone } from "@angular/core";
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, EventEmitter, Input, OnChanges, OnDestroy, OnInit, Output, QueryList, SimpleChanges, ViewChildren, NgZone, input } from "@angular/core";
 import { Angular21ChangeDetectionService } from "../../../../services/angular21-change-detection.service";
 import { select, Store } from "@ngrx/store";
 import { AccountsAction } from "apps/web-giddh/src/app/actions/accounts.actions";
@@ -30,7 +30,7 @@ export class MasterComponent implements OnInit, OnChanges, OnDestroy {
     /** Data obtained by searching master */
     @Input() public searchedMasterData: any[] = [];
     /** Height of column */
-    @Input() public height: number;
+    public height = input<number>();
     /** true/false if searching */
     @Input() public isSearchingGroups: boolean = false;
     /** This will hold local JSON data */

--- a/apps/web-giddh/src/app/shared/header/components/new-manage-groups-accounts/manage-groups-accounts.component.html
+++ b/apps/web-giddh/src/app/shared/header/components/new-manage-groups-accounts/manage-groups-accounts.component.html
@@ -88,7 +88,7 @@
                         {{ commonLocaleData?.app_loading }}
                     </div>
                 </div>
-                <div class="search-loading no-result" *ngIf="!(searchLoad | async) && !topSharedGroups?.length">
+                <div class="search-loading no-result" *ngIf="!(searchLoad | async) && !topSharedGroups()?.length">
                     <div class="vertical-center">
                         <p>{{ localeData?.no_result_found }}</p>
                     </div>
@@ -102,7 +102,7 @@
                         >
                             <master
                                 #master
-                                [topSharedGroups]="topSharedGroups"
+                                [topSharedGroups]="topSharedGroups()"
                                 [searchedMasterData]="searchedMasterData"
                                 [ngStyle]="{
                                     'height': (myModelRect ? myModelRect.height : 0) - (headerRect ? headerRect.height : 0) + 'px',
@@ -123,7 +123,7 @@
             <!-- middle body -->
             <div class="form-box height-in-vh">
                 <account-operations
-                    [topSharedGroups]="topSharedGroups"
+                    [topSharedGroups]="topSharedGroups()"
                     [height]="(myModelRect ? myModelRect.height : 0) - (headerRect ? headerRect.height : 0)"
                     [breadcrumbPath]="breadcrumbPath"
                     [breadcrumbUniquePath]="breadcrumbUniquePath"

--- a/apps/web-giddh/src/app/shared/header/components/new-manage-groups-accounts/manage-groups-accounts.component.html
+++ b/apps/web-giddh/src/app/shared/header/components/new-manage-groups-accounts/manage-groups-accounts.component.html
@@ -79,7 +79,7 @@
             <div
                 class="grp-col p-0"
                 [ngStyle]="{
-                    'height': (myModelRect ? myModelRect.height : 0) - (headerRect ? headerRect.height : 0) + 'px',
+                    'height': (myModelRect() ? myModelRect().height : 0) - (headerRect() ? headerRect().height : 0) + 'px',
                 }"
             >
                 <div class="search-loading" *ngIf="searchLoad | async">
@@ -105,9 +105,9 @@
                                 [topSharedGroups]="topSharedGroups()"
                                 [searchedMasterData]="searchedMasterData"
                                 [ngStyle]="{
-                                    'height': (myModelRect ? myModelRect.height : 0) - (headerRect ? headerRect.height : 0) + 'px',
+                                    'height': (myModelRect() ? myModelRect().height : 0) - (headerRect() ? headerRect().height : 0) + 'px',
                                 }"
-                                [height]="(myModelRect ? myModelRect.height : 0) - (headerRect ? headerRect.height : 0)"
+                                [height]="(myModelRect() ? myModelRect().height : 0) - (headerRect() ? headerRect().height : 0)"
                                 [isSearchingGroups]="!(grpSrch?.value === '')"
                                 [localeData]="localeData"
                                 [commonLocaleData]="commonLocaleData"
@@ -124,7 +124,7 @@
             <div class="form-box height-in-vh">
                 <account-operations
                     [topSharedGroups]="topSharedGroups()"
-                    [height]="(myModelRect ? myModelRect.height : 0) - (headerRect ? headerRect.height : 0)"
+                    [height]="(myModelRect() ? myModelRect().height : 0) - (headerRect() ? headerRect().height : 0)"
                     [breadcrumbPath]="breadcrumbPath"
                     [breadcrumbUniquePath]="breadcrumbUniquePath"
                     [localeData]="localeData"

--- a/apps/web-giddh/src/app/shared/header/components/new-manage-groups-accounts/manage-groups-accounts.component.html
+++ b/apps/web-giddh/src/app/shared/header/components/new-manage-groups-accounts/manage-groups-accounts.component.html
@@ -76,19 +76,14 @@
 
     <div class="modal-body p-0">
         <div class="clear-both">
-            <div
-                class="grp-col p-0"
-                [ngStyle]="{
-                    'height': (myModelRect() ? myModelRect().height : 0) - (headerRect() ? headerRect().height : 0) + 'px',
-                }"
-            >
+            <div class="grp-col p-0" [style.height.px]="bodyHeight">
                 <div class="search-loading" *ngIf="searchLoad | async">
                     <div class="vertical-center">
                         <span class="spinner small"></span>
                         {{ commonLocaleData?.app_loading }}
                     </div>
                 </div>
-                <div class="search-loading no-result" *ngIf="!(searchLoad | async) && !topSharedGroups()?.length">
+                <div class="search-loading no-result" *ngIf="!(searchLoad | async) && !topSharedGroups?.length">
                     <div class="vertical-center">
                         <p>{{ localeData?.no_result_found }}</p>
                     </div>
@@ -102,12 +97,10 @@
                         >
                             <master
                                 #master
-                                [topSharedGroups]="topSharedGroups()"
+                                [topSharedGroups]="topSharedGroups"
                                 [searchedMasterData]="searchedMasterData"
-                                [ngStyle]="{
-                                    'height': (myModelRect() ? myModelRect().height : 0) - (headerRect() ? headerRect().height : 0) + 'px',
-                                }"
-                                [height]="(myModelRect() ? myModelRect().height : 0) - (headerRect() ? headerRect().height : 0)"
+                                [style.height.px]="bodyHeight"
+                                [height]="bodyHeight"
                                 [isSearchingGroups]="!(grpSrch?.value === '')"
                                 [localeData]="localeData"
                                 [commonLocaleData]="commonLocaleData"
@@ -123,8 +116,8 @@
             <!-- middle body -->
             <div class="form-box height-in-vh">
                 <account-operations
-                    [topSharedGroups]="topSharedGroups()"
-                    [height]="(myModelRect() ? myModelRect().height : 0) - (headerRect() ? headerRect().height : 0)"
+                    [topSharedGroups]="topSharedGroups"
+                    [height]="bodyHeight"
                     [breadcrumbPath]="breadcrumbPath"
                     [breadcrumbUniquePath]="breadcrumbUniquePath"
                     [localeData]="localeData"

--- a/apps/web-giddh/src/app/shared/header/components/new-manage-groups-accounts/manage-groups-accounts.component.ts
+++ b/apps/web-giddh/src/app/shared/header/components/new-manage-groups-accounts/manage-groups-accounts.component.ts
@@ -1,5 +1,5 @@
 import { debounceTime, takeUntil } from 'rxjs/operators';
-import { AfterViewChecked, ChangeDetectorRef, Component, ElementRef, EventEmitter, HostListener, OnDestroy, OnInit, Output, Renderer2, ViewChild, NgZone, ChangeDetectionStrategy } from '@angular/core';
+import { AfterViewChecked, ChangeDetectorRef, Component, ElementRef, EventEmitter, HostListener, OnDestroy, OnInit, Output, Renderer2, ViewChild, NgZone, ChangeDetectionStrategy, signal } from '@angular/core';
 import { Angular21ChangeDetectionService } from '../../../../services/angular21-change-detection.service';
 import { AppState } from '../../../../store/roots';
 import { Store, select } from '@ngrx/store';
@@ -46,7 +46,7 @@ export class ManageGroupsAccountsComponent implements OnInit, OnDestroy, AfterVi
     /** True if initial component load */
     public initialLoad: boolean = true;
     /** List of top shared groups */
-    public topSharedGroups: any[] = [];
+    public topSharedGroups = signal<any[]>([]);
     /** List of data searched */
     public searchedMasterData: any[] = [];
     /** True if account has unsaved changes */
@@ -86,6 +86,7 @@ export class ManageGroupsAccountsComponent implements OnInit, OnDestroy, AfterVi
     public resizeEvent(e) {
         this.headerRect = this.header.nativeElement?.getBoundingClientRect();
         this.myModelRect = this.myModel.nativeElement?.getBoundingClientRect();
+        this.cdRef.detectChanges();
     }
 
     /**
@@ -285,10 +286,10 @@ export class ManageGroupsAccountsComponent implements OnInit, OnDestroy, AfterVi
      * @memberof ManageGroupsAccountsComponent
      */
     private getTopSharedGroups(): void {
-        this.topSharedGroups = [];
+        this.topSharedGroups.set([]);
         this.groupService.getTopSharedGroups().pipe(takeUntil(this.destroyed$)).subscribe((response: any) => {
             if (response?.status === "success") {
-                this.topSharedGroups = response?.body?.results;
+                this.topSharedGroups.set(response?.body?.results);
                 this.changeDetectionService.triggerChangeDetection(this.cdRef, this.ngZone);
             } else {
                 this.changeDetectionService.safeChangeDetection(this.cdRef, this.ngZone);

--- a/apps/web-giddh/src/app/shared/header/components/new-manage-groups-accounts/manage-groups-accounts.component.ts
+++ b/apps/web-giddh/src/app/shared/header/components/new-manage-groups-accounts/manage-groups-accounts.component.ts
@@ -167,6 +167,8 @@ export class ManageGroupsAccountsComponent implements OnInit, OnDestroy, AfterVi
         });
 
         document.querySelector('body')?.classList?.add('master-page');
+        this.headerRect = this.header.nativeElement?.getBoundingClientRect();
+        this.myModelRect = this.myModel.nativeElement?.getBoundingClientRect();
     }
 
     public ngAfterViewChecked() {

--- a/apps/web-giddh/src/app/shared/header/components/new-manage-groups-accounts/manage-groups-accounts.component.ts
+++ b/apps/web-giddh/src/app/shared/header/components/new-manage-groups-accounts/manage-groups-accounts.component.ts
@@ -26,12 +26,14 @@ export class ManageGroupsAccountsComponent implements OnInit, OnDestroy, AfterVi
     @ViewChild('master', { static: false }) public master: MasterComponent;
     @ViewChild('header', { static: true }) public header: ElementRef;
     @ViewChild('grpSrch', { static: true }) public groupSrch: ElementRef;
-    public headerRect: any;
+    /** Bounding rect of the header element, used to calculate scrollable body height */
+    public headerRect = signal<any>(null);
     public showForm: boolean = false;
     @ViewChild('myModel', { static: true }) public myModel: ElementRef;
     public breadcrumbPath: string[] = [];
     public breadcrumbUniquePath: string[] = [];
-    public myModelRect: any;
+    /** Bounding rect of the modal container element, used to calculate scrollable body height */
+    public myModelRect = signal<any>(null);
     public searchLoad: Observable<boolean>;
     public groupAndAccountSearchString$: Observable<string>;
     private groupSearchTerms = new Subject<string>();
@@ -84,8 +86,8 @@ export class ManageGroupsAccountsComponent implements OnInit, OnDestroy, AfterVi
 
     @HostListener('window:resize', ['$event'])
     public resizeEvent(e) {
-        this.headerRect = this.header.nativeElement?.getBoundingClientRect();
-        this.myModelRect = this.myModel.nativeElement?.getBoundingClientRect();
+        this.headerRect.set(this.header.nativeElement?.getBoundingClientRect());
+        this.myModelRect.set(this.myModel.nativeElement?.getBoundingClientRect());
         this.cdRef.detectChanges();
     }
 
@@ -168,8 +170,8 @@ export class ManageGroupsAccountsComponent implements OnInit, OnDestroy, AfterVi
 
         document.querySelector('body')?.classList?.add('master-page');
         setTimeout(() => {
-            this.headerRect = this.header.nativeElement?.getBoundingClientRect();
-            this.myModelRect = this.myModel.nativeElement?.getBoundingClientRect();
+            this.headerRect.set(this.header.nativeElement?.getBoundingClientRect());
+            this.myModelRect.set(this.myModel.nativeElement?.getBoundingClientRect());
         }, 100);
     }
 

--- a/apps/web-giddh/src/app/shared/header/components/new-manage-groups-accounts/manage-groups-accounts.component.ts
+++ b/apps/web-giddh/src/app/shared/header/components/new-manage-groups-accounts/manage-groups-accounts.component.ts
@@ -1,5 +1,5 @@
 import { debounceTime, takeUntil } from 'rxjs/operators';
-import { ChangeDetectorRef, Component, ElementRef, EventEmitter, HostListener, OnDestroy, OnInit, Output, Renderer2, ViewChild, NgZone, ChangeDetectionStrategy } from '@angular/core';
+import { ChangeDetectorRef, Component, ElementRef, EventEmitter, HostListener, OnDestroy, OnInit, Output, Renderer2, ViewChild, NgZone, ChangeDetectionStrategy, AfterViewChecked } from '@angular/core';
 import { Angular21ChangeDetectionService } from '../../../../services/angular21-change-detection.service';
 import { AppState } from '../../../../store/roots';
 import { Store, select } from '@ngrx/store';
@@ -20,7 +20,7 @@ import { IOption } from 'apps/web-giddh/src/app/app.constant';
     standalone: false,
     changeDetection: ChangeDetectionStrategy.Default
 })
-export class ManageGroupsAccountsComponent implements OnInit, OnDestroy {
+export class ManageGroupsAccountsComponent implements OnInit, OnDestroy, AfterViewChecked {
     @Output() public closeEvent: EventEmitter<boolean> = new EventEmitter(true);
     /** Instance of master component */
     @ViewChild('master', { static: false }) public master: MasterComponent;

--- a/apps/web-giddh/src/app/shared/header/components/new-manage-groups-accounts/manage-groups-accounts.component.ts
+++ b/apps/web-giddh/src/app/shared/header/components/new-manage-groups-accounts/manage-groups-accounts.component.ts
@@ -180,7 +180,9 @@ export class ManageGroupsAccountsComponent implements OnInit, OnDestroy, AfterVi
      * @memberof ManageGroupsAccountsComponent
      */
     public ngAfterViewInit(): void {
-        this.updateBodyHeight();
+        setTimeout(() => {
+            this.updateBodyHeight();
+        }, 100);
     }
 
     /**

--- a/apps/web-giddh/src/app/shared/header/components/new-manage-groups-accounts/manage-groups-accounts.component.ts
+++ b/apps/web-giddh/src/app/shared/header/components/new-manage-groups-accounts/manage-groups-accounts.component.ts
@@ -1,5 +1,5 @@
 import { debounceTime, takeUntil } from 'rxjs/operators';
-import { AfterViewChecked, ChangeDetectorRef, Component, ElementRef, EventEmitter, HostListener, OnDestroy, OnInit, Output, Renderer2, ViewChild, NgZone, ChangeDetectionStrategy, signal } from '@angular/core';
+import { ChangeDetectorRef, Component, ElementRef, EventEmitter, HostListener, OnDestroy, OnInit, Output, Renderer2, ViewChild, NgZone, ChangeDetectionStrategy } from '@angular/core';
 import { Angular21ChangeDetectionService } from '../../../../services/angular21-change-detection.service';
 import { AppState } from '../../../../store/roots';
 import { Store, select } from '@ngrx/store';
@@ -20,20 +20,19 @@ import { IOption } from 'apps/web-giddh/src/app/app.constant';
     standalone: false,
     changeDetection: ChangeDetectionStrategy.Default
 })
-export class ManageGroupsAccountsComponent implements OnInit, OnDestroy, AfterViewChecked {
+export class ManageGroupsAccountsComponent implements OnInit, OnDestroy {
     @Output() public closeEvent: EventEmitter<boolean> = new EventEmitter(true);
     /** Instance of master component */
     @ViewChild('master', { static: false }) public master: MasterComponent;
     @ViewChild('header', { static: true }) public header: ElementRef;
     @ViewChild('grpSrch', { static: true }) public groupSrch: ElementRef;
     /** Bounding rect of the header element, used to calculate scrollable body height */
-    public headerRect = signal<any>(null);
     public showForm: boolean = false;
     @ViewChild('myModel', { static: true }) public myModel: ElementRef;
     public breadcrumbPath: string[] = [];
     public breadcrumbUniquePath: string[] = [];
-    /** Bounding rect of the modal container element, used to calculate scrollable body height */
-    public myModelRect = signal<any>(null);
+    /** Computed body height = modal height - header height */
+    public bodyHeight: number = 0;
     public searchLoad: Observable<boolean>;
     public groupAndAccountSearchString$: Observable<string>;
     private groupSearchTerms = new Subject<string>();
@@ -48,7 +47,7 @@ export class ManageGroupsAccountsComponent implements OnInit, OnDestroy, AfterVi
     /** True if initial component load */
     public initialLoad: boolean = true;
     /** List of top shared groups */
-    public topSharedGroups = signal<any[]>([]);
+    public topSharedGroups: any[] = [];
     /** List of data searched */
     public searchedMasterData: any[] = [];
     /** True if account has unsaved changes */
@@ -86,9 +85,7 @@ export class ManageGroupsAccountsComponent implements OnInit, OnDestroy, AfterVi
 
     @HostListener('window:resize', ['$event'])
     public resizeEvent(e) {
-        this.headerRect.set(this.header.nativeElement?.getBoundingClientRect());
-        this.myModelRect.set(this.myModel.nativeElement?.getBoundingClientRect());
-        this.cdRef.detectChanges();
+        this.updateBodyHeight();
     }
 
     /**
@@ -169,14 +166,34 @@ export class ManageGroupsAccountsComponent implements OnInit, OnDestroy, AfterVi
         });
 
         document.querySelector('body')?.classList?.add('master-page');
-        setTimeout(() => {
-            this.headerRect.set(this.header.nativeElement?.getBoundingClientRect());
-            this.myModelRect.set(this.myModel.nativeElement?.getBoundingClientRect());
-        }, 100);
+        this.updateBodyHeight();
     }
 
     public ngAfterViewChecked() {
         this.changeDetectionService.safeChangeDetection(this.cdRef, this.ngZone);
+    }
+
+    /**
+     * Lifecycle hook called after view initialization
+     *
+     * @returns {void}
+     * @memberof ManageGroupsAccountsComponent
+     */
+    public ngAfterViewInit(): void {
+        this.updateBodyHeight();
+    }
+
+    /**
+     * Updates bodyHeight based on current modal and header bounding rects 
+     * 
+     * @memberof ManageGroupsAccountsComponent
+     * @returns {void}
+     */
+    private updateBodyHeight(): void {
+        const modelRect = this.myModel?.nativeElement?.getBoundingClientRect();
+        const headerRect = this.header?.nativeElement?.getBoundingClientRect();
+        this.bodyHeight = (modelRect?.height ?? 0) - (headerRect?.height ?? 0);
+        this.cdRef.detectChanges();
     }
 
     public searchGroups(term: string): void {
@@ -292,10 +309,10 @@ export class ManageGroupsAccountsComponent implements OnInit, OnDestroy, AfterVi
      * @memberof ManageGroupsAccountsComponent
      */
     private getTopSharedGroups(): void {
-        this.topSharedGroups.set([]);
+        this.topSharedGroups = [];
         this.groupService.getTopSharedGroups().pipe(takeUntil(this.destroyed$)).subscribe((response: any) => {
             if (response?.status === "success") {
-                this.topSharedGroups.set(response?.body?.results);
+                this.topSharedGroups = response?.body?.results;
                 this.changeDetectionService.triggerChangeDetection(this.cdRef, this.ngZone);
             } else {
                 this.changeDetectionService.safeChangeDetection(this.cdRef, this.ngZone);

--- a/apps/web-giddh/src/app/shared/header/components/new-manage-groups-accounts/manage-groups-accounts.component.ts
+++ b/apps/web-giddh/src/app/shared/header/components/new-manage-groups-accounts/manage-groups-accounts.component.ts
@@ -167,8 +167,10 @@ export class ManageGroupsAccountsComponent implements OnInit, OnDestroy, AfterVi
         });
 
         document.querySelector('body')?.classList?.add('master-page');
-        this.headerRect = this.header.nativeElement?.getBoundingClientRect();
-        this.myModelRect = this.myModel.nativeElement?.getBoundingClientRect();
+        setTimeout(() => {
+            this.headerRect = this.header.nativeElement?.getBoundingClientRect();
+            this.myModelRect = this.myModel.nativeElement?.getBoundingClientRect();
+        }, 100);
     }
 
     public ngAfterViewChecked() {

--- a/apps/web-giddh/src/app/shared/header/header.component.ts
+++ b/apps/web-giddh/src/app/shared/header/header.component.ts
@@ -12,7 +12,7 @@ import { CommonActions } from '../../actions/common.actions';
 import { CompanyCountry, CompanyCreateRequest, CompanyResponse, StatesRequest, Organization, StateDetailsRequest, OrganizationDetails } from '../../models/api-models/Company';
 import { UserDetails } from '../../models/api-models/loginModels';
 import { GroupWithAccountsAction } from '../../actions/groupwithaccounts.actions';
-import { NavigationEnd, NavigationError, NavigationStart, RouteConfigLoadEnd, Router } from '@angular/router';
+import { ActivatedRoute, NavigationEnd, NavigationError, NavigationStart, RouteConfigLoadEnd, Router } from '@angular/router';
 import { ElementViewContainerRef } from '../helpers/directives/elementViewChild/element.viewchild.directive';
 import { GeneralActions } from '../../actions/general/general.actions';
 import { createSelector } from 'reselect';
@@ -298,7 +298,8 @@ export class HeaderComponent implements OnInit, AfterViewInit, OnDestroy, AfterV
         @Inject(ServiceConfig) private serviceConfig,
         private elementRef: ElementRef,
         private renderer: Renderer2,
-        private giddhDatePipe: GiddhDatePipe
+        private giddhDatePipe: GiddhDatePipe,
+        private activeRoute: ActivatedRoute
     ) {
         const whiteLabel = this.generalService.getDecodedWhiteLabel();
         this.imgPath = Configuration.isElectron ? 'assets/images/' : (this.serviceConfig.AppUrl || environment.AppUrl) + environment.APP_FOLDER + 'assets/images/';
@@ -545,7 +546,11 @@ export class HeaderComponent implements OnInit, AfterViewInit, OnDestroy, AfterV
     }
 
     public ngOnInit() {
-        this.generalService.restoreRouteQueryFilters();
+        this.activeRoute.queryParams.pipe(distinctUntilChanged(), takeUntil(this.destroyed$)).subscribe(response => {
+            if (response.tab || response.required) {
+                this.generalService.restoreRouteQueryFilters();
+            }
+        });
         /** If this is true, it means we are in branch consolidated mode.  */
         this.store.pipe(select(select => select.branchConsolidated), takeUntil(this.destroyed$)).subscribe(response => {
             if (response) {

--- a/apps/web-giddh/src/app/shared/header/header.component.ts
+++ b/apps/web-giddh/src/app/shared/header/header.component.ts
@@ -1874,6 +1874,9 @@ export class HeaderComponent implements OnInit, AfterViewInit, OnDestroy, AfterV
     private saveLastState(): void {
         let companyUniqueName = null;
         let lastState = this.router.url;
+        if (this.generalService.currentSupportedQueryParam.includes(this.generalService.getCurrentPath(true).path)) {
+            lastState = this.generalService.getCurrentPath(true).path;
+        }
         lastState = lastState?.replace("/pages", "pages");
         this.store.pipe(select(state => state.session.companyUniqueName), take(1)).subscribe(response => companyUniqueName = response);
         let stateDetailsRequest = new StateDetailsRequest();

--- a/apps/web-giddh/src/app/shared/header/header.component.ts
+++ b/apps/web-giddh/src/app/shared/header/header.component.ts
@@ -618,6 +618,8 @@ export class HeaderComponent implements OnInit, AfterViewInit, OnDestroy, AfterV
             this.isLedgerAccSelected = false;
             const lastState = s?.toLowerCase();
 
+            this.generalService.restoreRouteQueryFilters();
+
             let lastStateHaveParams: boolean = lastState.includes('?');
             if (lastStateHaveParams) {
                 let tempParams = lastState.substr(lastState.lastIndexOf('?'));

--- a/apps/web-giddh/src/app/shared/header/header.component.ts
+++ b/apps/web-giddh/src/app/shared/header/header.component.ts
@@ -545,6 +545,7 @@ export class HeaderComponent implements OnInit, AfterViewInit, OnDestroy, AfterV
     }
 
     public ngOnInit() {
+        this.generalService.restoreRouteQueryFilters();
         /** If this is true, it means we are in branch consolidated mode.  */
         this.store.pipe(select(select => select.branchConsolidated), takeUntil(this.destroyed$)).subscribe(response => {
             if (response) {
@@ -617,8 +618,6 @@ export class HeaderComponent implements OnInit, AfterViewInit, OnDestroy, AfterV
         this.store.pipe(select(s => s.session.lastState), takeUntil(this.destroyed$)).subscribe(s => {
             this.isLedgerAccSelected = false;
             const lastState = s?.toLowerCase();
-
-            this.generalService.restoreRouteQueryFilters();
 
             let lastStateHaveParams: boolean = lastState.includes('?');
             if (lastStateHaveParams) {

--- a/apps/web-giddh/src/app/shared/header/header.component.ts
+++ b/apps/web-giddh/src/app/shared/header/header.component.ts
@@ -1596,6 +1596,9 @@ export class HeaderComponent implements OnInit, AfterViewInit, OnDestroy, AfterV
                 toDate: this.toDate,
             };
             this.isTodaysDateSelected = false;
+            if (this.generalService.currentSupportedQueryParam.includes(this.generalService.getCurrentPath(true).path)) {
+                this.generalService.saveRouteQueryFilters({ fromDate: this.fromDate, toDate: this.toDate });
+            }
             this.store.dispatch(this.companyActions.SetApplicationDate(dates));
         } else {
             this.isTodaysDateSelected = true;
@@ -1611,6 +1614,9 @@ export class HeaderComponent implements OnInit, AfterViewInit, OnDestroy, AfterV
                 period: null,
                 noOfTransactions: null
             };
+            if (this.generalService.currentSupportedQueryParam.includes(this.generalService.getCurrentPath(true).path)) {
+                this.generalService.saveRouteQueryFilters({ fromDate: dayjs().subtract(30, 'day').format(GIDDH_DATE_FORMAT), toDate: dayjs().format(GIDDH_DATE_FORMAT) });
+            }
             this.store.dispatch(this.companyActions.SetApplicationDate(dates));
         }
     }

--- a/apps/web-giddh/src/app/theme/other-tax/other-tax.component.ts
+++ b/apps/web-giddh/src/app/theme/other-tax/other-tax.component.ts
@@ -133,7 +133,7 @@ export class OtherTaxComponent implements OnInit, OnDestroy, AfterViewInit {
      * @memberof OtherTaxComponent
      */
     public createTaxDialog(): void {
-        this.taxAsideMenuRef = this.dialog.open(this.createTax, ASIDE_PANE_CONFIG);
+        this.taxAsideMenuRef = this.dialog.open(this.createTax, { ...ASIDE_PANE_CONFIG, autoFocus: false});
         this.openAccountDropdown = false; 
         this.taxAsideMenuRef.afterClosed().subscribe(() => {
             this.taxAsideMenuRef = null;

--- a/apps/web-giddh/src/app/vouchers/create/create.component.html
+++ b/apps/web-giddh/src/app/vouchers/create/create.component.html
@@ -740,6 +740,41 @@
                                             </div>
                                         </div>
 
+                                        <!-- Supply Fields Row - India only -->
+                                        @if (isIndianCompany) {
+                                            <!-- Place of Supply (Invoice / Credit Note / Estimate / Proforma) -->
+                                            @if (showPlaceOfSupply) {
+                                                <div class="col-6 mt-3" formGroupName="placeOfSupply">
+                                                    <reactive-dropdown-field
+                                                        appEnterNext
+                                                        [name]="'placeOfSupply'"
+                                                        [label]="localeData?.place_of_supply"
+                                                        [placeholder]="commonLocaleData?.app_state"
+                                                        formControlName="code"
+                                                        [options]="companyStateList$ | async"
+                                                        [forceClear]="forceClear"
+                                                        (selectedOption)="onSupplyStateSelect('placeOfSupply', $event)"
+                                                    ></reactive-dropdown-field>
+                                                </div>
+                                            }
+
+                                            <!-- Source of Supply (Purchase Bill / Debit Note / PO) -->
+                                            @if (showSourceDestinationOfSupply) {
+                                                <div class="col-6 mt-3" formGroupName="sourceOfSupply">
+                                                    <reactive-dropdown-field
+                                                        appEnterNext
+                                                        [name]="'sourceOfSupply'"
+                                                        [label]="localeData?.source_of_supply"
+                                                        [placeholder]="commonLocaleData?.app_state"
+                                                        formControlName="code"
+                                                        [options]="companyStateList$ | async"
+                                                        [forceClear]="forceClear"
+                                                        (selectedOption)="onSupplyStateSelect('sourceOfSupply', $event)"
+                                                    ></reactive-dropdown-field>
+                                                </div>
+                                            }
+                                        }
+
                                         <ng-container *ngIf="!invoiceType.isPurchaseOrder">
                                             <!-- Attention to -->
                                             <div class="col-6 mt-3">
@@ -1136,6 +1171,23 @@
                                         </div>
                                     </div>
                                 </div>
+                                @if (isIndianCompany && showSourceDestinationOfSupply) {
+                                    <ng-container formGroupName="account">
+                                        <!-- Destination of Supply -->
+                                        <div class="col-6 mt-3 pl-0" formGroupName="destinationOfSupply">
+                                            <reactive-dropdown-field
+                                                appEnterNext
+                                                [name]="'destinationOfSupply'"
+                                                [label]="localeData?.destination_of_supply"
+                                                [placeholder]="commonLocaleData?.app_state"
+                                                formControlName="code"
+                                                [options]="companyStateList$ | async"
+                                                [forceClear]="forceClear"
+                                                (selectedOption)="onSupplyStateSelect('destinationOfSupply', $event)"
+                                            ></reactive-dropdown-field>
+                                        </div>
+                                    </ng-container>
+                                }
 
                                 <!-- Row 3 -->
                                 <div

--- a/apps/web-giddh/src/app/vouchers/create/create.component.html
+++ b/apps/web-giddh/src/app/vouchers/create/create.component.html
@@ -1181,39 +1181,38 @@
                                         </div>
                                     </div>
                                 </div>
-                                @if (isIndianCompanyAndAccount && showSourceDestinationOfSupply) {
-                                    <ng-container formGroupName="account">
-                                        <!-- Destination of Supply -->
-                                        <div class="col-6 mt-3 pl-0" formGroupName="destinationOfSupply">
-                                            <reactive-dropdown-field
-                                                appEnterNext
-                                                [name]="'destinationOfSupply'"
-                                                [label]="localeData?.destination_of_supply"
-                                                [placeholder]="commonLocaleData?.app_state"
-                                                formControlName="code"
-                                                [options]="companyStateList$ | async"
-                                                [forceClear]="forceClear"
-                                                [required]="!!branchCurrentAddressInfo.taxNumber"
-                                                [showError]="
-                                                    invoiceForm.controls['account'].get('destinationOfSupply.code')?.touched &&
-                                                    invoiceForm.controls['account'].get('destinationOfSupply.code')?.invalid
-                                                "
-                                                (selectedOption)="onSupplyStateSelect('destinationOfSupply', $event)"
-                                            ></reactive-dropdown-field>
-                                        </div>
-                                    </ng-container>
-                                }
-
                                 <!-- Row 3 -->
-                                <div
-                                    class="row row-gap-15 mt-3 mb-3"
-                                    *ngIf="
-                                        invoiceType.isPurchaseInvoice &&
-                                        ((vendorPurchaseOrders$ | async)?.length || fieldFilteredOptions?.length)
-                                    "
-                                >
+                                <div class="row row-gap-15 mt-3 mb-3">
+                                    @if (isIndianCompanyAndAccount && showSourceDestinationOfSupply) {
+                                        <ng-container formGroupName="account">
+                                            <!-- Destination of Supply -->
+                                            <div class="col-6" formGroupName="destinationOfSupply">
+                                                <reactive-dropdown-field
+                                                    appEnterNext
+                                                    [name]="'destinationOfSupply'"
+                                                    [label]="localeData?.destination_of_supply"
+                                                    [placeholder]="commonLocaleData?.app_state"
+                                                    formControlName="code"
+                                                    [options]="companyStateList$ | async"
+                                                    [forceClear]="forceClear"
+                                                    [required]="!!branchCurrentAddressInfo.taxNumber"
+                                                    [showError]="
+                                                        invoiceForm.controls['account'].get('destinationOfSupply.code')?.touched &&
+                                                        invoiceForm.controls['account'].get('destinationOfSupply.code')?.invalid
+                                                    "
+                                                    (selectedOption)="onSupplyStateSelect('destinationOfSupply', $event)"
+                                                ></reactive-dropdown-field>
+                                            </div>
+                                        </ng-container>
+                                    }
                                     <!-- Purchase Order -->
-                                    <div class="col-6">
+                                    <div
+                                        class="col-6"
+                                        *ngIf="
+                                            invoiceType.isPurchaseInvoice &&
+                                            ((vendorPurchaseOrders$ | async)?.length || fieldFilteredOptions?.length)
+                                        "
+                                    >
                                         <mat-select
                                             name="linkedPO"
                                             formControlName="linkedPo"

--- a/apps/web-giddh/src/app/vouchers/create/create.component.html
+++ b/apps/web-giddh/src/app/vouchers/create/create.component.html
@@ -753,6 +753,11 @@
                                                         formControlName="code"
                                                         [options]="companyStateList$ | async"
                                                         [forceClear]="forceClear"
+                                                        [required]="true"
+                                                        [showError]="
+                                                            invoiceForm.controls['account'].get('placeOfSupply.code')?.touched &&
+                                                            invoiceForm.controls['account'].get('placeOfSupply.code')?.invalid
+                                                        "
                                                         (selectedOption)="onSupplyStateSelect('placeOfSupply', $event)"
                                                     ></reactive-dropdown-field>
                                                 </div>
@@ -769,6 +774,11 @@
                                                         formControlName="code"
                                                         [options]="companyStateList$ | async"
                                                         [forceClear]="forceClear"
+                                                        [required]="true"
+                                                        [showError]="
+                                                            invoiceForm.controls['account'].get('sourceOfSupply.code')?.touched &&
+                                                            invoiceForm.controls['account'].get('sourceOfSupply.code')?.invalid
+                                                        "
                                                         (selectedOption)="onSupplyStateSelect('sourceOfSupply', $event)"
                                                     ></reactive-dropdown-field>
                                                 </div>
@@ -1183,6 +1193,11 @@
                                                 formControlName="code"
                                                 [options]="companyStateList$ | async"
                                                 [forceClear]="forceClear"
+                                                [required]="true"
+                                                [showError]="
+                                                    invoiceForm.controls['account'].get('destinationOfSupply.code')?.touched &&
+                                                    invoiceForm.controls['account'].get('destinationOfSupply.code')?.invalid
+                                                "
                                                 (selectedOption)="onSupplyStateSelect('destinationOfSupply', $event)"
                                             ></reactive-dropdown-field>
                                         </div>

--- a/apps/web-giddh/src/app/vouchers/create/create.component.html
+++ b/apps/web-giddh/src/app/vouchers/create/create.component.html
@@ -753,7 +753,7 @@
                                                         formControlName="code"
                                                         [options]="companyStateList$ | async"
                                                         [forceClear]="forceClear"
-                                                        [required]="branchCurrentAddressInfo.taxNumber"
+                                                        [required]="!!branchCurrentAddressInfo.taxNumber"
                                                         [showError]="
                                                             invoiceForm.controls['account'].get('placeOfSupply.code')?.touched &&
                                                             invoiceForm.controls['account'].get('placeOfSupply.code')?.invalid
@@ -774,7 +774,7 @@
                                                         formControlName="code"
                                                         [options]="companyStateList$ | async"
                                                         [forceClear]="forceClear"
-                                                        [required]="branchCurrentAddressInfo.taxNumber"
+                                                        [required]="!!branchCurrentAddressInfo.taxNumber"
                                                         [showError]="
                                                             invoiceForm.controls['account'].get('sourceOfSupply.code')?.touched &&
                                                             invoiceForm.controls['account'].get('sourceOfSupply.code')?.invalid
@@ -1193,7 +1193,7 @@
                                                 formControlName="code"
                                                 [options]="companyStateList$ | async"
                                                 [forceClear]="forceClear"
-                                                [required]="branchCurrentAddressInfo.taxNumber"
+                                                [required]="!!branchCurrentAddressInfo.taxNumber"
                                                 [showError]="
                                                     invoiceForm.controls['account'].get('destinationOfSupply.code')?.touched &&
                                                     invoiceForm.controls['account'].get('destinationOfSupply.code')?.invalid

--- a/apps/web-giddh/src/app/vouchers/create/create.component.html
+++ b/apps/web-giddh/src/app/vouchers/create/create.component.html
@@ -741,7 +741,7 @@
                                         </div>
 
                                         <!-- Supply Fields Row - India only -->
-                                        @if (isIndianCompany) {
+                                        @if (isIndianCompanyAndAccount) {
                                             <!-- Place of Supply (Invoice / Credit Note / Estimate / Proforma) -->
                                             @if (showPlaceOfSupply) {
                                                 <div class="col-6 mt-3" formGroupName="placeOfSupply">
@@ -753,7 +753,7 @@
                                                         formControlName="code"
                                                         [options]="companyStateList$ | async"
                                                         [forceClear]="forceClear"
-                                                        [required]="true"
+                                                        [required]="branchCurrentAddressInfo.taxNumber"
                                                         [showError]="
                                                             invoiceForm.controls['account'].get('placeOfSupply.code')?.touched &&
                                                             invoiceForm.controls['account'].get('placeOfSupply.code')?.invalid
@@ -774,7 +774,7 @@
                                                         formControlName="code"
                                                         [options]="companyStateList$ | async"
                                                         [forceClear]="forceClear"
-                                                        [required]="true"
+                                                        [required]="branchCurrentAddressInfo.taxNumber"
                                                         [showError]="
                                                             invoiceForm.controls['account'].get('sourceOfSupply.code')?.touched &&
                                                             invoiceForm.controls['account'].get('sourceOfSupply.code')?.invalid
@@ -1181,7 +1181,7 @@
                                         </div>
                                     </div>
                                 </div>
-                                @if (isIndianCompany && showSourceDestinationOfSupply) {
+                                @if (isIndianCompanyAndAccount && showSourceDestinationOfSupply) {
                                     <ng-container formGroupName="account">
                                         <!-- Destination of Supply -->
                                         <div class="col-6 mt-3 pl-0" formGroupName="destinationOfSupply">
@@ -1193,7 +1193,7 @@
                                                 formControlName="code"
                                                 [options]="companyStateList$ | async"
                                                 [forceClear]="forceClear"
-                                                [required]="true"
+                                                [required]="branchCurrentAddressInfo.taxNumber"
                                                 [showError]="
                                                     invoiceForm.controls['account'].get('destinationOfSupply.code')?.touched &&
                                                     invoiceForm.controls['account'].get('destinationOfSupply.code')?.invalid

--- a/apps/web-giddh/src/app/vouchers/create/create.component.ts
+++ b/apps/web-giddh/src/app/vouchers/create/create.component.ts
@@ -659,6 +659,49 @@ export class VoucherCreateComponent implements OnInit, OnDestroy, AfterViewInit 
     }
 
     /**
+     * True if company country is India
+     *
+     * @readonly
+     * @type {boolean}
+     * @memberof VoucherCreateComponent
+     */
+    public get isIndianCompany(): boolean {
+        return this.company.countryCode === 'IN';
+    }
+
+    /**
+     * True if Place of Supply field should be shown (invoice / credit note / estimate / proforma)
+     *
+     * @readonly
+     * @type {boolean}
+     * @memberof VoucherCreateComponent
+     */
+    public get showPlaceOfSupply(): boolean {
+        return (
+            this.invoiceType.isSalesInvoice ||
+            this.invoiceType.isCashInvoice ||
+            this.invoiceType.isCreditNote ||
+            this.invoiceType.isEstimateInvoice ||
+            this.invoiceType.isProformaInvoice
+        );
+    }
+
+    /**
+     * True if Source of Supply and Destination of Supply fields should be shown (purchase bill / debit note / PO)
+     *
+     * @readonly
+     * @type {boolean}
+     * @memberof VoucherCreateComponent
+     */
+    public get showSourceDestinationOfSupply(): boolean {
+        return (
+            this.invoiceType.isPurchaseInvoice ||
+            this.invoiceType.isDebitNote ||
+            this.invoiceType.isPurchaseOrder
+        );
+    }
+
+    /**
      *
      * @readonly
      * @type {FormGroup}
@@ -1267,6 +1310,12 @@ export class VoucherCreateComponent implements OnInit, OnDestroy, AfterViewInit 
                                     voucherDetails.company?.shippingDetails
                                 );
                             }
+                            this.invoiceForm.get('account.placeOfSupply.name')?.setValue(voucherDetails.account?.placeOfSupply?.name || '');
+                            this.invoiceForm.get('account.placeOfSupply.code')?.setValue(voucherDetails.account?.placeOfSupply?.code || '');
+                            this.invoiceForm.get('account.sourceOfSupply.name')?.setValue(voucherDetails.account?.sourceOfSupply?.name || '');
+                            this.invoiceForm.get('account.sourceOfSupply.code')?.setValue(voucherDetails.account?.sourceOfSupply?.code || '');
+                            this.invoiceForm.get('account.destinationOfSupply.name')?.setValue(voucherDetails.account?.destinationOfSupply?.name || '');
+                            this.invoiceForm.get('account.destinationOfSupply.code')?.setValue(voucherDetails.account?.destinationOfSupply?.code || '');
 
                             this.invoiceForm.get("exchangeRate")?.patchValue(voucherDetails.exchangeRate);
                             this.invoiceForm.get("number")?.patchValue(this.isCopyMode ? null : voucherDetails.number);
@@ -2899,6 +2948,77 @@ export class VoucherCreateComponent implements OnInit, OnDestroy, AfterViewInit 
     }
 
     /**
+     * Returns the gstNumber of the default address (lowercased), or empty string if not found
+     *
+     * @private
+     * @param {any[]} addresses
+     * @returns {string}
+     * @memberof VoucherCreateComponent
+     */
+    private getDefaultAddressGstNumber(addresses: any[]): string {
+        if (!addresses?.length) {
+            return '';
+        }
+        const defaultAddr = addresses.find((a) => a.isDefault);
+        return defaultAddr?.gstNumber || '';
+    }
+
+    /**
+     * Sets default values for placeOfSupply, sourceOfSupply, destinationOfSupply
+     * based on account gstNumber (B2B vs B2C) and billing/shipping address states.
+     * Only applies when company country is India.
+     *
+     * @private
+     * @memberof VoucherCreateComponent
+     */
+    private setDefaultSupplyFields(): void {
+        if (!this.isIndianCompany || !this.invoiceForm) {
+            return;
+        }
+
+        const isB2C = this.getDefaultAddressGstNumber(this.account?.addresses) ? false : true;
+
+        if (this.showPlaceOfSupply) {
+            const stateSource = isB2C
+                ? this.invoiceForm.get('account.billingDetails.state')
+                : this.invoiceForm.get('account.shippingDetails.state');
+
+            this.invoiceForm.get('account.placeOfSupply')?.patchValue({
+                name: stateSource?.get('name')?.value || '',
+                code: stateSource?.get('code')?.value || '',
+            });
+        } else if (this.showSourceDestinationOfSupply) {
+            const sourceStateKey = isB2C ? 'account.billingDetails.state' : 'account.shippingDetails.state';
+            const destStateKey = isB2C ? 'company.billingDetails.state' : 'company.shippingDetails.state';
+
+            const sourceState = this.invoiceForm.get(sourceStateKey);
+            const destState = this.invoiceForm.get(destStateKey);
+
+            this.invoiceForm.get('account.sourceOfSupply')?.patchValue({
+                name: sourceState?.get('name')?.value || '',
+                code: sourceState?.get('code')?.value || '',
+            });
+            this.invoiceForm.get('account.destinationOfSupply')?.patchValue({
+                name: destState?.get('name')?.value || '',
+                code: destState?.get('code')?.value || '',
+            });
+        }
+    }
+
+    /**
+     * Callback when user selects a state from Place of Supply / Source of Supply / Destination of Supply dropdown
+     *
+     * @param {string} fieldName - 'placeOfSupply' | 'sourceOfSupply' | 'destinationOfSupply'
+     * @param {any} selectedOption
+     * @memberof VoucherCreateComponent
+     */
+    public onSupplyStateSelect(fieldName: string, selectedOption: any): void {
+        this.invoiceForm.get(`account.${fieldName}`)?.patchValue({
+            name: selectedOption?.label || ''
+        });
+    }
+
+    /**
      * Assigns account data in object
      *
      * @private
@@ -2980,6 +3100,7 @@ export class VoucherCreateComponent implements OnInit, OnDestroy, AfterViewInit 
             this.invoiceForm.controls["account"]?.get("mobileNumber").setValue(accountData?.mobileNo ?? "");
             this.account.mobileNumber = accountData?.mobileNo ?? "";
             this.updateDueDate();
+            this.setDefaultSupplyFields();
         } else {
             if (
                 !this.invoiceSettings?.invoiceSettings?.voucherAddressManualEnabled &&
@@ -3070,6 +3191,9 @@ export class VoucherCreateComponent implements OnInit, OnDestroy, AfterViewInit 
         }
         this.invoiceForm.controls[entityType]?.get(addressType).get("state").get("name").patchValue(state.name);
         this.invoiceForm.controls[entityType]?.get(addressType).get("state").get("code").patchValue(state.code);
+        if (!this.isUpdateMode && (entityType === 'company' || entityType === 'account')) {
+            this.setDefaultSupplyFields();
+        }
     }
 
     /**
@@ -3092,7 +3216,19 @@ export class VoucherCreateComponent implements OnInit, OnDestroy, AfterViewInit 
                 email: ["", Validators.email],
                 billingDetails: this.getAddressFormGroup(),
                 shippingDetails: this.getAddressFormGroup(),
-                customFields: this.formBuilder.array([])
+                customFields: this.formBuilder.array([]),
+                placeOfSupply: this.formBuilder.group({
+                    name: [''],
+                    code: [''],
+                }),
+                sourceOfSupply: this.formBuilder.group({
+                    name: [''],
+                    code: [''],
+                }),
+                destinationOfSupply: this.formBuilder.group({
+                    name: [''],
+                    code: [''],
+                })
             }),
             company: this.formBuilder.group({
                 billingDetails: this.getAddressFormGroup(),
@@ -5374,6 +5510,21 @@ export class VoucherCreateComponent implements OnInit, OnDestroy, AfterViewInit 
         }
 
         invoiceForm = this.vouchersUtilityService.formatVoucherObject(invoiceForm);
+
+        if (!this.isIndianCompany) {
+            delete invoiceForm.account?.placeOfSupply;
+            delete invoiceForm.account?.sourceOfSupply;
+            delete invoiceForm.account?.destinationOfSupply;
+        } else if (this.showPlaceOfSupply) {
+            delete invoiceForm.account?.sourceOfSupply;
+            delete invoiceForm.account?.destinationOfSupply;
+        } else if (this.showSourceDestinationOfSupply) {
+            delete invoiceForm.account?.placeOfSupply;
+        } else {
+            delete invoiceForm.account?.placeOfSupply;
+            delete invoiceForm.account?.sourceOfSupply;
+            delete invoiceForm.account?.destinationOfSupply;
+        }
 
         if (!this.currentVoucherFormDetails?.depositAllowed) {
             delete invoiceForm.deposits;

--- a/apps/web-giddh/src/app/vouchers/create/create.component.ts
+++ b/apps/web-giddh/src/app/vouchers/create/create.component.ts
@@ -3110,6 +3110,9 @@ export class VoucherCreateComponent implements OnInit, OnDestroy, AfterViewInit 
                 if (defaultAddress) {
                     this.fillBillingShippingAddress("company", "billingDetails", defaultAddress, index);
                     this.fillBillingShippingAddress("company", "shippingDetails", defaultAddress, index);
+                    if (!this.isUpdateMode) {
+                        this.setDefaultSupplyFields();
+                    }
                 }
             }
 

--- a/apps/web-giddh/src/app/vouchers/create/create.component.ts
+++ b/apps/web-giddh/src/app/vouchers/create/create.component.ts
@@ -888,6 +888,7 @@ export class VoucherCreateComponent implements OnInit, OnDestroy, AfterViewInit 
                         this.getCreatedTemplates();
                         this.getAccountOnboardingFormData();
                         this.searchStock();
+                        this.setDefaultSupplyFields();
 
                         if (!this.invoiceType.isPaymentInvoice && !this.invoiceType.isReceiptInvoice) {
                             this.getWarehouses();
@@ -2375,6 +2376,10 @@ export class VoucherCreateComponent implements OnInit, OnDestroy, AfterViewInit 
                     this.company.branch = response.find((branch) => !branch.parentBranch);
                 }
                 this.branchCurrentAddressInfo = this.company.branch.addresses.find((address)=>address.isDefault);
+                this.invoiceForm.get('account.destinationOfSupply')?.patchValue({
+                    name: this.branchCurrentAddressInfo.stateName || '',
+                    code: this.branchCurrentAddressInfo.stateCode || '',
+                });
             }
         });
     }
@@ -3008,18 +3013,16 @@ export class VoucherCreateComponent implements OnInit, OnDestroy, AfterViewInit 
             });
         } else if (this.showSourceDestinationOfSupply) {
             const sourceStateKey = isB2C ? 'account.billingDetails.state' : 'account.shippingDetails.state';
-            const destStateKey = isB2C ? 'company.billingDetails.state' : 'company.shippingDetails.state';
 
             const sourceState = this.invoiceForm.get(sourceStateKey);
-            const destState = this.invoiceForm.get(destStateKey);
 
             this.invoiceForm.get('account.sourceOfSupply')?.patchValue({
                 name: sourceState?.get('name')?.value || '',
                 code: sourceState?.get('code')?.value || '',
             });
             this.invoiceForm.get('account.destinationOfSupply')?.patchValue({
-                name: destState?.get('name')?.value || '',
-                code: destState?.get('code')?.value || '',
+                name: this.branchCurrentAddressInfo.stateName || '',
+                code: this.branchCurrentAddressInfo.stateCode || '',
             });
         }
     }
@@ -3175,6 +3178,7 @@ export class VoucherCreateComponent implements OnInit, OnDestroy, AfterViewInit 
                 }
             }
         }
+        this.changeDetection.detectChanges();
     }
 
     /**
@@ -5552,10 +5556,18 @@ export class VoucherCreateComponent implements OnInit, OnDestroy, AfterViewInit 
             delete invoiceForm.account?.destinationOfSupply;
         } else if (this.showSourceDestinationOfSupply) {
             delete invoiceForm.account?.placeOfSupply;
-        } else {
-            delete invoiceForm.account?.placeOfSupply;
-            delete invoiceForm.account?.sourceOfSupply;
-            delete invoiceForm.account?.destinationOfSupply;
+        }
+        if (this.isIndianCompanyAndAccount && !this.branchCurrentAddressInfo.taxNumber) {
+            if (this.showPlaceOfSupply && !invoiceForm.account?.placeOfSupply.code) {
+                delete invoiceForm.account?.placeOfSupply;
+            } else if (this.showSourceDestinationOfSupply) {
+                if (!invoiceForm.account?.sourceOfSupply.code) {
+                    delete invoiceForm.account?.sourceOfSupply;
+                }
+                if (!invoiceForm.account?.destinationOfSupply.code) {
+                    delete invoiceForm.account?.destinationOfSupply;
+                }
+            }
         }
 
         if (!this.currentVoucherFormDetails?.depositAllowed) {

--- a/apps/web-giddh/src/app/vouchers/create/create.component.ts
+++ b/apps/web-giddh/src/app/vouchers/create/create.component.ts
@@ -671,6 +671,19 @@ export class VoucherCreateComponent implements OnInit, OnDestroy, AfterViewInit 
         return this.company.countryCode === 'IN' && this.account.countryCode === 'IN';
     }
 
+    
+
+    /**
+     * True if voucher is a cash sales invoice (not purchase, debit note, or credit note)
+     *
+     * @readonly
+     * @type {boolean}
+     * @memberof VoucherCreateComponent
+     */
+    public get isCashSalesInvoice(): boolean {
+        return this.invoiceType.isCashInvoice && !this.invoiceType.isPurchaseInvoice && !this.invoiceType.isDebitNote && !this.invoiceType.isCreditNote;
+    }
+
     /**
      * True if Place of Supply field should be shown (invoice / credit note / estimate / proforma)
      *
@@ -681,7 +694,7 @@ export class VoucherCreateComponent implements OnInit, OnDestroy, AfterViewInit 
     public get showPlaceOfSupply(): boolean {
         return (
             this.invoiceType.isSalesInvoice ||
-            (this.invoiceType.isCashInvoice && !this.invoiceType.isPurchaseInvoice && !this.invoiceType.isDebitNote && !this.invoiceType.isCreditNote) ||
+            this.isCashSalesInvoice ||
             this.invoiceType.isCreditNote ||
             this.invoiceType.isEstimateInvoice ||
             this.invoiceType.isProformaInvoice

--- a/apps/web-giddh/src/app/vouchers/create/create.component.ts
+++ b/apps/web-giddh/src/app/vouchers/create/create.component.ts
@@ -5344,6 +5344,23 @@ export class VoucherCreateComponent implements OnInit, OnDestroy, AfterViewInit 
             }
         }
 
+        if (this.isIndianCompany) {
+            if (this.showPlaceOfSupply && !this.invoiceForm.get('account.placeOfSupply.code')?.value) {
+                this.invoiceForm.get('account.placeOfSupply.code')?.markAsTouched();
+                return false;
+            }
+            if (this.showSourceDestinationOfSupply) {
+                if (!this.invoiceForm.get('account.sourceOfSupply.code')?.value) {
+                    this.invoiceForm.get('account.sourceOfSupply.code')?.markAsTouched();
+                    return false;
+                }
+                if (!this.invoiceForm.get('account.destinationOfSupply.code')?.value) {
+                    this.invoiceForm.get('account.destinationOfSupply.code')?.markAsTouched();
+                    return false;
+                }
+            }
+        }
+
         if (invoiceForm.isRcmEntry) {
             let hasTaxes = true;
             const entriesArray = this.invoiceForm.get("entries") as FormArray;

--- a/apps/web-giddh/src/app/vouchers/create/create.component.ts
+++ b/apps/web-giddh/src/app/vouchers/create/create.component.ts
@@ -570,6 +570,8 @@ export class VoucherCreateComponent implements OnInit, OnDestroy, AfterViewInit 
     public isAccountChanged: boolean = false;
     /** True if recurring voucher */
     public isRecurringVoucher: any;
+    /** store branch current address information */
+    public branchCurrentAddressInfo: any = {};
 
     /**
      * Returns true, if invoice type is sales, proforma or estimate, for these vouchers we
@@ -665,8 +667,8 @@ export class VoucherCreateComponent implements OnInit, OnDestroy, AfterViewInit 
      * @type {boolean}
      * @memberof VoucherCreateComponent
      */
-    public get isIndianCompany(): boolean {
-        return this.company.countryCode === 'IN';
+    public get isIndianCompanyAndAccount(): boolean {
+        return this.company.countryCode === 'IN' && this.account.countryCode === 'IN';
     }
 
     /**
@@ -679,7 +681,7 @@ export class VoucherCreateComponent implements OnInit, OnDestroy, AfterViewInit 
     public get showPlaceOfSupply(): boolean {
         return (
             this.invoiceType.isSalesInvoice ||
-            this.invoiceType.isCashInvoice ||
+            (this.invoiceType.isCashInvoice && !this.invoiceType.isPurchaseInvoice && !this.invoiceType.isDebitNote && !this.invoiceType.isCreditNote) ||
             this.invoiceType.isCreditNote ||
             this.invoiceType.isEstimateInvoice ||
             this.invoiceType.isProformaInvoice
@@ -2359,6 +2361,7 @@ export class VoucherCreateComponent implements OnInit, OnDestroy, AfterViewInit 
                     // Find the HO branch
                     this.company.branch = response.find((branch) => !branch.parentBranch);
                 }
+                this.branchCurrentAddressInfo = this.company.branch.addresses.find((address)=>address.isDefault);
             }
         });
     }
@@ -2944,6 +2947,9 @@ export class VoucherCreateComponent implements OnInit, OnDestroy, AfterViewInit 
         if (defaultAddress) {
             this.fillBillingShippingAddress("account", "billingDetails", defaultAddress, index);
             this.fillBillingShippingAddress("account", "shippingDetails", defaultAddress, index);
+            if (!this.isUpdateMode) {
+                this.setDefaultSupplyFields();
+            }
         }
     }
 
@@ -2960,7 +2966,7 @@ export class VoucherCreateComponent implements OnInit, OnDestroy, AfterViewInit 
             return '';
         }
         const defaultAddr = addresses.find((a) => a.isDefault);
-        return defaultAddr?.gstNumber || '';
+        return defaultAddr?.gstNumber;
     }
 
     /**
@@ -2972,11 +2978,11 @@ export class VoucherCreateComponent implements OnInit, OnDestroy, AfterViewInit 
      * @memberof VoucherCreateComponent
      */
     private setDefaultSupplyFields(): void {
-        if (!this.isIndianCompany || !this.invoiceForm) {
+        if (!this.isIndianCompanyAndAccount || !this.invoiceForm) {
             return;
         }
 
-        const isB2C = this.getDefaultAddressGstNumber(this.account?.addresses) ? false : true;
+        const isB2C = !!this.getDefaultAddressGstNumber(this.account?.addresses);
 
         if (this.showPlaceOfSupply) {
             const stateSource = isB2C
@@ -3100,7 +3106,6 @@ export class VoucherCreateComponent implements OnInit, OnDestroy, AfterViewInit 
             this.invoiceForm.controls["account"]?.get("mobileNumber").setValue(accountData?.mobileNo ?? "");
             this.account.mobileNumber = accountData?.mobileNo ?? "";
             this.updateDueDate();
-            this.setDefaultSupplyFields();
         } else {
             if (
                 !this.invoiceSettings?.invoiceSettings?.voucherAddressManualEnabled &&
@@ -3191,9 +3196,6 @@ export class VoucherCreateComponent implements OnInit, OnDestroy, AfterViewInit 
         }
         this.invoiceForm.controls[entityType]?.get(addressType).get("state").get("name").patchValue(state.name);
         this.invoiceForm.controls[entityType]?.get(addressType).get("state").get("code").patchValue(state.code);
-        if (!this.isUpdateMode && (entityType === 'company' || entityType === 'account')) {
-            this.setDefaultSupplyFields();
-        }
     }
 
     /**
@@ -5344,7 +5346,7 @@ export class VoucherCreateComponent implements OnInit, OnDestroy, AfterViewInit 
             }
         }
 
-        if (this.isIndianCompany) {
+        if (this.isIndianCompanyAndAccount && !!this.branchCurrentAddressInfo.taxNumber) {
             if (this.showPlaceOfSupply && !this.invoiceForm.get('account.placeOfSupply.code')?.value) {
                 this.invoiceForm.get('account.placeOfSupply.code')?.markAsTouched();
                 return false;
@@ -5528,7 +5530,7 @@ export class VoucherCreateComponent implements OnInit, OnDestroy, AfterViewInit 
 
         invoiceForm = this.vouchersUtilityService.formatVoucherObject(invoiceForm);
 
-        if (!this.isIndianCompany) {
+        if (!this.isIndianCompanyAndAccount) {
             delete invoiceForm.account?.placeOfSupply;
             delete invoiceForm.account?.sourceOfSupply;
             delete invoiceForm.account?.destinationOfSupply;

--- a/apps/web-giddh/src/app/vouchers/list/list.component.ts
+++ b/apps/web-giddh/src/app/vouchers/list/list.component.ts
@@ -2515,9 +2515,8 @@ export class VoucherListComponent implements OnInit, OnDestroy {
     public setInitialAdvanceFilter(onlyResetValue: boolean = false): void {
         let universalDate;
         // get application date
-        this.componentStore.universalDate$.pipe(take(1)).subscribe(date => {
+        this.componentStore.universalDate$.pipe(filter(Boolean) ,take(1)).subscribe(date => {
             universalDate = date;
-        });
 
         // set date picker date as application date
         if (universalDate?.length > 1) {
@@ -2551,8 +2550,10 @@ export class VoucherListComponent implements OnInit, OnDestroy {
                 this.getRecurringVouchers();
             } else {
                 this.getVouchers(false);
+                this.getVoucherBalances();
             }
         }
+        });
     }
 
     /**

--- a/apps/web-giddh/src/app/vouchers/template/template-edit-filter/template-edit-filter.component.html
+++ b/apps/web-giddh/src/app/vouchers/template/template-edit-filter/template-edit-filter.component.html
@@ -374,7 +374,8 @@
                                             <div
                                                 *ngIf="
                                                     sectionSettings?.header.displayPlaceOfSupply &&
-                                                    customTemplate?.templateType !== templateTypeEnum.ThermalTemplate
+                                                    customTemplate?.templateType !== templateTypeEnum.ThermalTemplate &&
+                                                    (templateType === voucherTypeEnum.invoice || templateType === voucherTypeEnum.voucher)
                                                 "
                                             >
                                                 <mat-checkbox
@@ -384,6 +385,42 @@
                                                     (ngModelChange)="onChangeFieldVisibility()"
                                                 >
                                                     <span class="ml-2">{{ localeData?.place_of_supply }}</span>
+                                                </mat-checkbox>
+                                            </div>
+                                            <div
+                                                *ngIf="
+                                                    sectionSettings?.header.sourceOfSupply &&
+                                                    customTemplate?.templateType !== templateTypeEnum.ThermalTemplate &&
+                                                    (templateType === voucherTypeEnum.purchase_order ||
+                                                        templateType === voucherTypeEnum.purchase_bill ||
+                                                        templateType === voucherTypeEnum.voucher)
+                                                "
+                                            >
+                                                <mat-checkbox
+                                                    color="primary"
+                                                    name="sourceOfSupplyCheckbox"
+                                                    [(ngModel)]="customTemplate.sections['header'].data['sourceOfSupply'].display"
+                                                    (ngModelChange)="onChangeFieldVisibility()"
+                                                >
+                                                    <span class="ml-2">{{ localeData?.source_of_supply }}</span>
+                                                </mat-checkbox>
+                                            </div>
+                                            <div
+                                                *ngIf="
+                                                    sectionSettings?.header.destinationOfSupply &&
+                                                    customTemplate?.templateType !== templateTypeEnum.ThermalTemplate &&
+                                                    (templateType === voucherTypeEnum.purchase_order ||
+                                                        templateType === voucherTypeEnum.purchase_bill ||
+                                                        templateType === voucherTypeEnum.voucher)
+                                                "
+                                            >
+                                                <mat-checkbox
+                                                    color="primary"
+                                                    name="destinationOfSupplyCheckbox"
+                                                    [(ngModel)]="customTemplate.sections['header'].data['destinationOfSupply'].display"
+                                                    (ngModelChange)="onChangeFieldVisibility()"
+                                                >
+                                                    <span class="ml-2">{{ localeData?.destination_of_supply }}</span>
                                                 </mat-checkbox>
                                             </div>
                                             <!-- place of country -->

--- a/apps/web-giddh/src/assets/locale/all-items/en.json
+++ b/apps/web-giddh/src/assets/locale/all-items/en.json
@@ -21,7 +21,13 @@
                     "label": "Customer",
                     "link": "/pages/contact/customer",
                     "icon": "icon-customer",
-                    "description": "Manage customers, send reminders via SMS/Email"
+                    "description": "Manage customers, send reminders via SMS/Email",
+                    "additional": {
+                        "queryParams": {
+                            "tab": "customer",
+                            "tabIndex": 1
+                        }
+                    }
                 },
                 {
                     "label": "New Invoice",
@@ -310,7 +316,13 @@
                     "label": "Vendor",
                     "link": "/pages/contact/vendor",
                     "icon": "icon-vendor",
-                    "description": "Send Bulk SMS/Emails, Set reminders"
+                    "description": "Send Bulk SMS/Emails, Set reminders",
+                    "additional": {
+                        "queryParams": {
+                            "tab": "vendor",
+                            "tabIndex": 1
+                        }
+                    }
                 },
                 {
                     "label": "New Bill",

--- a/apps/web-giddh/src/assets/locale/all-items/hi.json
+++ b/apps/web-giddh/src/assets/locale/all-items/hi.json
@@ -21,7 +21,13 @@
                     "label": "ग्राहक",
                     "link": "/pages/contact/customer",
                     "icon": "icon-customer",
-                    "description": "ग्राहकों को प्रबंधित करें, एसएमएस/ईमेल के माध्यम से अनुस्मारक भेजें"
+                    "description": "ग्राहकों को प्रबंधित करें, एसएमएस/ईमेल के माध्यम से अनुस्मारक भेजें",
+                    "additional": {
+                        "queryParams": {
+                            "tab": "customer",
+                            "tabIndex": 1
+                        }
+                    }
                 },
                 {
                     "label": "नया चालान",
@@ -310,7 +316,13 @@
                     "label": "विक्रेता",
                     "link": "/pages/contact/vendor",
                     "icon": "icon-vendor",
-                    "description": "बल्क एसएमएस/ईमेल भेजें, रिमाइंडर सेट करें"
+                    "description": "बल्क एसएमएस/ईमेल भेजें, रिमाइंडर सेट करें",
+                    "additional": {
+                        "queryParams": {
+                            "tab": "vendor",
+                            "tabIndex": 1
+                        }
+                    }
                 },
                 {
                     "label": "नया बिल",

--- a/apps/web-giddh/src/assets/locale/all-items/mr.json
+++ b/apps/web-giddh/src/assets/locale/all-items/mr.json
@@ -21,7 +21,13 @@
                     "label": "ग्राहक",
                     "link": "/pages/contact/customer",
                     "icon": "icon-customer",
-                    "description": "ग्राहक व्यवस्थापित करा, एसएमएस / ईमेलद्वारे स्मरणपत्रे पाठवा"
+                    "description": "ग्राहक व्यवस्थापित करा, एसएमएस / ईमेलद्वारे स्मरणपत्रे पाठवा",
+                    "additional": {
+                        "queryParams": {
+                            "tab": "customer",
+                            "tabIndex": 1
+                        }
+                    }
                 },
                 {
                     "label": "नवीन चालान",
@@ -310,7 +316,13 @@
                     "label": "विक्रेता",
                     "link": "/pages/contact/vendor",
                     "icon": "icon-vendor",
-                    "description": "बल्क एसएमएस / ईमेल पाठवा, स्मरणपत्रे सेट करा"
+                    "description": "बल्क एसएमएस / ईमेल पाठवा, स्मरणपत्रे सेट करा",
+                    "additional": {
+                        "queryParams": {
+                            "tab": "vendor",
+                            "tabIndex": 1
+                        }
+                    }
                 },
                 {
                     "label": "नवीन विधेयक",

--- a/apps/web-giddh/src/assets/locale/sidebar-menu/en.json
+++ b/apps/web-giddh/src/assets/locale/sidebar-menu/en.json
@@ -23,6 +23,9 @@
                     "icon": "icon-customer",
                     "description": "Manage customers, send reminders via SMS/Email",
                     "additional": {
+                        "queryParams": {
+                            "tab": "customer"
+                        },
                         "createNew": {
                             "label": "+",
                             "link": "/pages/contact/customer",
@@ -155,7 +158,8 @@
                             "icon": "icon-advance-search",
                             "additional": {
                                 "queryParams": {
-                                    "groupBy": "duration"
+                                    "groupBy": "duration",
+                                    "required": "groupBy"
                                 },
                                 "matchQueryParams": true
                             }
@@ -166,7 +170,8 @@
                             "icon": "icon-advance-search",
                             "additional": {
                                 "queryParams": {
-                                    "groupBy": "salesPerson"
+                                    "groupBy": "salesPerson",
+                                    "required": "groupBy"
                                 },
                                 "matchQueryParams": true
                             }
@@ -177,7 +182,8 @@
                             "icon": "icon-advance-search",
                             "additional": {
                                 "queryParams": {
-                                    "groupBy": "state"
+                                    "groupBy": "state",
+                                    "required": "groupBy"
                                 },
                                 "matchQueryParams": true
                             }
@@ -188,7 +194,8 @@
                             "icon": "icon-advance-search",
                             "additional": {
                                 "queryParams": {
-                                    "groupBy": "country"
+                                    "groupBy": "country",
+                                    "required": "groupBy"
                                 },
                                 "matchQueryParams": true
                             }
@@ -438,7 +445,8 @@
                     "description": "Send Bulk SMS/Emails, Set reminders",
                     "additional": {
                         "queryParams": {
-                            "voucherVersion": 2
+                            "voucherVersion": 2,
+                            "tab": "vendor"
                         },
                         "createNew": {
                             "label": "+",

--- a/apps/web-giddh/src/assets/locale/sidebar-menu/en.json
+++ b/apps/web-giddh/src/assets/locale/sidebar-menu/en.json
@@ -24,7 +24,8 @@
                     "description": "Manage customers, send reminders via SMS/Email",
                     "additional": {
                         "queryParams": {
-                            "tab": "customer"
+                            "tab": "customer",
+                            "tabIndex": 1
                         },
                         "createNew": {
                             "label": "+",
@@ -446,7 +447,8 @@
                     "additional": {
                         "queryParams": {
                             "voucherVersion": 2,
-                            "tab": "vendor"
+                            "tab": "vendor",
+                            "tabIndex": 1
                         },
                         "createNew": {
                             "label": "+",

--- a/apps/web-giddh/src/assets/locale/sidebar-menu/hi.json
+++ b/apps/web-giddh/src/assets/locale/sidebar-menu/hi.json
@@ -23,6 +23,9 @@
                     "icon": "icon-customer",
                     "description": "ग्राहकों को प्रबंधित करें, एसएमएस/ईमेल के माध्यम से अनुस्मारक भेजें",
                     "additional": {
+                        "queryParams": {
+                            "tab": "customer"
+                        },
                         "createNew": {
                             "label": "+",
                             "link": "/pages/contact/customer",
@@ -155,7 +158,8 @@
                             "icon": "icon-view",
                             "additional": {
                                 "queryParams": {
-                                    "groupBy": "duration"
+                                    "groupBy": "duration",
+                                    "required": "groupBy"
                                 },
                                 "matchQueryParams": true
                             }
@@ -166,7 +170,8 @@
                             "icon": "icon-export",
                             "additional": {
                                 "queryParams": {
-                                    "groupBy": "salesPerson"
+                                    "groupBy": "salesPerson",
+                                    "required": "groupBy"
                                 },
                                 "matchQueryParams": true
                             }
@@ -177,7 +182,8 @@
                             "icon": "icon-export",
                             "additional": {
                                 "queryParams": {
-                                    "groupBy": "state"
+                                    "groupBy": "state",
+                                    "required": "groupBy"
                                 },
                                 "matchQueryParams": true
                             }
@@ -188,7 +194,8 @@
                             "icon": "icon-export",
                             "additional": {
                                 "queryParams": {
-                                    "groupBy": "country"
+                                    "groupBy": "country",
+                                    "required": "groupBy"
                                 },
                                 "matchQueryParams": true
                             }
@@ -438,7 +445,8 @@
                     "description": "बल्क एसएमएस/ईमेल भेजें, रिमाइंडर सेट करें",
                     "additional": {
                         "queryParams": {
-                            "voucherVersion": 2
+                            "voucherVersion": 2,
+                            "tab": "vendor"
                         },
                         "createNew": {
                             "label": "+",

--- a/apps/web-giddh/src/assets/locale/sidebar-menu/hi.json
+++ b/apps/web-giddh/src/assets/locale/sidebar-menu/hi.json
@@ -24,7 +24,8 @@
                     "description": "ग्राहकों को प्रबंधित करें, एसएमएस/ईमेल के माध्यम से अनुस्मारक भेजें",
                     "additional": {
                         "queryParams": {
-                            "tab": "customer"
+                            "tab": "customer",
+                            "tabIndex": 1
                         },
                         "createNew": {
                             "label": "+",
@@ -446,7 +447,8 @@
                     "additional": {
                         "queryParams": {
                             "voucherVersion": 2,
-                            "tab": "vendor"
+                            "tab": "vendor",
+                            "tabIndex": 1
                         },
                         "createNew": {
                             "label": "+",

--- a/apps/web-giddh/src/assets/locale/sidebar-menu/mr.json
+++ b/apps/web-giddh/src/assets/locale/sidebar-menu/mr.json
@@ -24,7 +24,8 @@
                     "description": "ग्राहक व्यवस्थापित करा, एसएमएस / ईमेलद्वारे स्मरणपत्रे पाठवा",
                     "additional": {
                         "queryParams": {
-                            "tab": "customer"
+                            "tab": "customer",
+                            "tabIndex": 1
                         },
                         "createNew": {
                             "label": "+",
@@ -446,7 +447,8 @@
                     "additional": {
                         "queryParams": {
                             "voucherVersion": 2,
-                            "tab": "vendor"
+                            "tab": "vendor",
+                            "tabIndex": 1
                         },
                         "createNew": {
                             "label": "+",

--- a/apps/web-giddh/src/assets/locale/sidebar-menu/mr.json
+++ b/apps/web-giddh/src/assets/locale/sidebar-menu/mr.json
@@ -23,6 +23,9 @@
                     "icon": "icon-customer",
                     "description": "ग्राहक व्यवस्थापित करा, एसएमएस / ईमेलद्वारे स्मरणपत्रे पाठवा",
                     "additional": {
+                        "queryParams": {
+                            "tab": "customer"
+                        },
                         "createNew": {
                             "label": "+",
                             "link": "/pages/contact/customer",
@@ -155,7 +158,8 @@
                             "icon": "icon-view",
                             "additional": {
                                 "queryParams": {
-                                    "groupBy": "duration"
+                                    "groupBy": "duration",
+                                    "required": "groupBy"
                                 },
                                 "matchQueryParams": true
                             }
@@ -166,7 +170,8 @@
                             "icon": "icon-export",
                             "additional": {
                                 "queryParams": {
-                                    "groupBy": "salesPerson"
+                                    "groupBy": "salesPerson",
+                                    "required": "groupBy"
                                 },
                                 "matchQueryParams": true
                             }
@@ -177,7 +182,8 @@
                             "icon": "icon-export",
                             "additional": {
                                 "queryParams": {
-                                    "groupBy": "state"
+                                    "groupBy": "state",
+                                    "required": "groupBy"
                                 },
                                 "matchQueryParams": true
                             }
@@ -188,7 +194,8 @@
                             "icon": "icon-export",
                             "additional": {
                                 "queryParams": {
-                                    "groupBy": "country"
+                                    "groupBy": "country",
+                                    "required": "groupBy"
                                 },
                                 "matchQueryParams": true
                             }
@@ -438,7 +445,8 @@
                     "description": "बल्क एसएमएस / ईमेल पाठवा, स्मरणपत्रे सेट करा",
                     "additional": {
                         "queryParams": {
-                            "voucherVersion": 2
+                            "voucherVersion": 2,
+                            "tab": "vendor"
                         },
                         "createNew": {
                             "label": "+",

--- a/apps/web-giddh/src/assets/locale/vouchers/en.json
+++ b/apps/web-giddh/src/assets/locale/vouchers/en.json
@@ -172,5 +172,8 @@
     "update_recurring_credit_note": "Update Recurring Credit Note",
     "update_recurring_debit_note": "Update Recurring Debit Note",
     "update_recurring_receipt": "Update Recurring Receipt",
-    "update_recurring_payment": "Update Recurring Payment"
+    "update_recurring_payment": "Update Recurring Payment",
+    "place_of_supply": "Place of Supply",
+    "source_of_supply": "Source of Supply",
+    "destination_of_supply": "Destination of Supply"
 }

--- a/apps/web-giddh/src/assets/locale/vouchers/hi.json
+++ b/apps/web-giddh/src/assets/locale/vouchers/hi.json
@@ -172,5 +172,8 @@
     "update_recurring_credit_note": "रिकरंग क्रेडिट नोट संशोधित करें",
     "update_recurring_debit_note": "रिकरंग डेबिट नोट संशोधित करें",
     "update_recurring_receipt": "रिकरंग रसीद संशोधित करें",
-    "update_recurring_payment": "रिकरंग भुगतान संशोधित करें"
+    "update_recurring_payment": "रिकरंग भुगतान संशोधित करें",
+    "place_of_supply": "आपूर्ति का स्थान",
+    "source_of_supply": "आपूर्ति का स्रोत",
+    "destination_of_supply": "आपूर्ति का गंतव्य"
 }

--- a/apps/web-giddh/src/assets/locale/vouchers/mr.json
+++ b/apps/web-giddh/src/assets/locale/vouchers/mr.json
@@ -172,5 +172,8 @@
     "update_recurring_credit_note": "रिकरंग क्रेडिट नोट संशोधित करा",
     "update_recurring_debit_note": "रिकरंग डेबिट नोट संशोधित करा",
     "update_recurring_receipt": "रिकरंग रसीद संशोधित करा",
-    "update_recurring_payment": "रिकरंग भुगतान संशोधित करा"
+    "update_recurring_payment": "रिकरंग भुगतान संशोधित करा",
+    "place_of_supply": "पुरवठ्याचे ठिकाण",
+    "source_of_supply": "पुरवठ्याचा स्रोत",
+    "destination_of_supply": "पुरवठ्याचे गंतव्य"
 }

--- a/apps/web-giddh/src/assets/locale/vouchers/preview/en.json
+++ b/apps/web-giddh/src/assets/locale/vouchers/preview/en.json
@@ -473,6 +473,8 @@
     "exchange_conversion_rate": "Exchange/Conversion Rate",
     "place_of_supply": "Place Of Supply",
     "country_of_supply": "Country of Supply",
+    "source_of_supply": "Source of Supply",
+    "destination_of_supply": "Destination of Supply",
     "failed_to_get_template_preview": "Failed to get template preview",
     "please_enter_template_name": "Please enter template name.",
     "template_saved_successfully": "Template Saved Successfully.",

--- a/apps/web-giddh/src/assets/locale/vouchers/preview/hi.json
+++ b/apps/web-giddh/src/assets/locale/vouchers/preview/hi.json
@@ -473,6 +473,8 @@
     "exchange_conversion_rate": "एक्सचेंज/कन्वर्ज़न रेट",
     "place_of_supply": "आपूर्ति का स्थान",
     "country_of_supply": "आपूर्ति का स्थान",
+    "source_of_supply": "आपूर्ति का स्रोत",
+    "destination_of_supply": "आपूर्ति का गंतव्य",
     "failed_to_get_template_preview": "टेम्पलेट पूर्वावलोकन उपलब्ध नहीं है",
     "please_enter_template_name": "कृपया टेम्पलेट नाम दर्ज करें।",
     "template_saved_successfully": "टेम्पलेट सफलतापूर्वक सहायक बनाया गया।",

--- a/apps/web-giddh/src/assets/locale/vouchers/preview/mr.json
+++ b/apps/web-giddh/src/assets/locale/vouchers/preview/mr.json
@@ -473,6 +473,8 @@
     "exchange_conversion_rate": "विनिमय/रूपांतरण दर",
     "place_of_supply": "पुरवठ्याचे ठिकाण",
     "country_of_supply": "पुरवठ्याचे ठिकाण",
+    "source_of_supply": "पुरवठ्याचा स्रोत",
+    "destination_of_supply": "पुरवठ्याचे गंतव्य",
     "failed_to_get_template_preview": "टेम्पलेट पूर्वावलोकन उपलब्ध नहीं है",
     "please_enter_template_name": "कृपया टेम्पलेट नाव प्रविष्ट करा",
     "template_saved_successfully": "टेम्पलेट सफलतापूर्वक सहायक बनाया गया।",


### PR DESCRIPTION
## **User description**
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)



* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Other information**:


___

## **CodeAnt-AI Description**
Persist and restore page filters and improve supply fields & ledger UX

### What Changed
- Contact, Aging Report and Sales Register preserve search, date and advanced filter state in URL and local storage so filters are restored when navigating back to those pages or switching tabs.
- Header saves/restores route-scoped query params (including tab and required report params) and only persists date filters for supported pages, reducing lost date selections across navigation.
- Aging Report and Contact pages show the clear-filter state correctly after restoring query params and save individual filter selections (search text, category, amount, branch, from/to dates) to URL so users see the same filtered list after returning.
- Voucher creation: Place of Supply / Source of Supply / Destination of Supply fields added for India flows; defaults are filled from account/company addresses and branch address, and the form enforces these fields when company branch has tax number.
- Ledger and New/Update entry panels pass and honor selected stock variant and apply pre-applied discounts to transactions so variant selection and applicable discounts persist and auto-apply as users pick stock/accounts.
- Reports UI: group-by, duration, sales-person, state and account multi-selects now persist selections to URL and restore; several report filters expose explicit save actions to persist choices.
- Several UI fixes: consistent clear-filter visibility using reactive signals, modal body height calculation in manage-groups-accounts, input/label spacing and a wider amount field in update-ledger-entry panel, and added localization/query params to sidebar/menu links.

### Impact
`✅ Restored filters when returning to Contacts/Aging Report/Reports`
`✅ Fewer lost date/search selections across navigation`
`✅ Clearer invoice supply defaults and validation for India`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
