### PR TITLE
Ankit | Test - In xls and CSV, don't map option is not coming and unable to change the automatic mapping

### DIFF
--- a/apps/web-giddh/src/app/add-company/add-company.component.ts
+++ b/apps/web-giddh/src/app/add-company/add-company.component.ts
@@ -341,6 +341,7 @@ export class AddCompanyComponent implements OnInit, AfterViewInit, OnDestroy {
                             this.formFields[response.fields[key].name] = response.fields[key];
                         }
                     });
+                    this.validateGstNumber();
                     this.changeDetection.detectChanges();
                 }
                 if (response.applicableTaxes) {
@@ -1548,10 +1549,6 @@ export class AddCompanyComponent implements OnInit, AfterViewInit, OnDestroy {
 
         if (queryParams.pincode) {
             this.secondStepForm.get('pincode')?.patchValue(queryParams.pincode);
-        }
-
-        if (queryParams.taxNumber) {
-            this.secondStepForm.get('gstin')?.patchValue(queryParams.taxNumber);
         }
 
         if (queryParams.taxNumber) {

--- a/apps/web-giddh/src/app/bank-reconciliation/bank-reconciliation.component.ts
+++ b/apps/web-giddh/src/app/bank-reconciliation/bank-reconciliation.component.ts
@@ -204,6 +204,9 @@ export class BankReconciliationComponent implements OnInit, OnDestroy {
     /** Subject to unsubscribe all observables */
     private readonly destroyed$ = new Subject<void>();
 
+    /** Sentinel label used to mark a column as explicitly unmapped; excluded from the final reconciliation payload */
+    public unmapHeader: string = "Don't Map";
+
     private readonly FIELD_ALIASES: Record<string, string[]> = {
         transactiondate: [
             'transactiondate', 'transaction date', 'txn date', 'txndate',
@@ -520,6 +523,7 @@ export class BankReconciliationComponent implements OnInit, OnDestroy {
             value: h
         }));
 
+        allGiddhOptions.unshift({ label: this.unmapHeader, value: this.unmapHeader });
         this.giddhFieldOptions.set(allGiddhOptions);
 
         const mappedFields: string[] = [];
@@ -538,7 +542,7 @@ export class BankReconciliationComponent implements OnInit, OnDestroy {
             return {
                 columnHeader: col.columnHeader,
                 columnNumber: parseInt(col.columnNumber, 10),
-                selectedGiddhField: matchedValue ?? '',
+                selectedGiddhField: matchedValue ?? this.unmapHeader,
                 availableOptions: [...allGiddhOptions]
             };
         });
@@ -577,7 +581,7 @@ export class BankReconciliationComponent implements OnInit, OnDestroy {
         this.mappingRows.update(rows =>
             rows.map((row) => {
                 let options = [...(this.giddhFieldOptions())];
-                options = options.filter(o => !allSelected.includes(o.value) || o.value === row.selectedGiddhField);
+                options = options.filter(o => !allSelected.includes(o.value) || o.value === row.selectedGiddhField || o.value === this.unmapHeader);
                 return { ...row, availableOptions: options };
             })
         );
@@ -593,7 +597,7 @@ export class BankReconciliationComponent implements OnInit, OnDestroy {
         if (!uploadResp?.requestId) return;
 
         const mappings: ReconciliationMapping[] = this.mappingRows()
-            .filter(row => row.selectedGiddhField)
+            .filter(row => row.selectedGiddhField && row.selectedGiddhField !== this.unmapHeader)
             .map(row => ({
                 columnHeader: row.columnHeader,
                 columnNumber: row.columnNumber,


### PR DESCRIPTION
## **User description**
https://app.clickup.com/t/86d2g2gd8


___

## **CodeAnt-AI Description**
**Allow users to leave reconciliation columns unmapped and validate GST during company setup**

### What Changed
- Added a **Don't Map** choice in bank reconciliation so users can explicitly skip columns they do not want to match
- Unmapped columns are now left out of the reconciliation request, preventing them from being sent as mapped fields
- After company details load, GST number checks now run automatically so validation is shown when GST data is already present
- When a tax number is filled from the setup flow, the company is marked as registered and the GST number is prefilled

### Impact
`✅ Fewer reconciliation mapping mistakes`
`✅ Easier handling of extra spreadsheet columns`
`✅ Earlier GST validation during company setup`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bank reconciliation now supports a "Don't Map" option to explicitly exclude columns from processing.

* **Bug Fixes**
  * GSTIN validation now automatically triggers when company form fields are loaded.
  * Improved handling of tax numbers from URL parameters with proper business type assignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->