### PR TITLE
Ankit | Test | Test -due amount and account balance API calling multiple times on Aging report and customer/vendor

### DIFF
--- a/apps/web-giddh/src/app/contact/aging-report/aging-report.component.ts
+++ b/apps/web-giddh/src/app/contact/aging-report/aging-report.component.ts
@@ -22,8 +22,8 @@ import { Store, select } from "@ngrx/store";
 import { AppState } from "../../store";
 import { AgingReportActions } from "../../actions/aging-report.actions";
 import { cloneDeep, map as lodashMap } from "../../lodash-optimized";
-import { Observable, of, ReplaySubject, Subject } from "rxjs";
-import { debounceTime, distinctUntilChanged, takeUntil } from "rxjs/operators";
+import { merge, Observable, of, ReplaySubject, Subject } from "rxjs";
+import { debounceTime, distinctUntilChanged, skip, take, takeUntil } from "rxjs/operators";
 import * as dayjs from "dayjs";
 import { ContactAdvanceSearchComponent } from "../advanceSearch/contactAdvanceSearch.component";
 import { GeneralService } from "../../services/general.service";
@@ -216,7 +216,6 @@ export class AgingReportComponent implements OnInit, OnDestroy {
         });
 
         this.searchStr$.pipe(
-            debounceTime(1000),
             distinctUntilChanged(),
             takeUntil(this.destroyed$),
         ).subscribe(term => {
@@ -272,7 +271,11 @@ export class AgingReportComponent implements OnInit, OnDestroy {
             }
         });
 
-        this.route.queryParams.pipe(debounceTime(700), distinctUntilChanged(), takeUntil(this.destroyed$)).subscribe(queryParams => {
+        const queryParams$ = this.route.queryParams.pipe(distinctUntilChanged());
+        merge(
+            queryParams$.pipe(take(1)),
+            queryParams$.pipe(skip(1), debounceTime(700))
+        ).pipe(takeUntil(this.destroyed$)).subscribe(queryParams => {
             if (queryParams.tab === 'aging-report') {
                 const restoredQ = queryParams.searchText || '';
                 this.searchStr = restoredQ;


### PR DESCRIPTION
## **User description**
https://app.clickup.com/t/86d2bkf82


___

## **CodeAnt-AI Description**
**Aging report search and saved filters load without delay**

### What Changed
- The aging report now runs the first saved URL state right away instead of waiting before loading results
- Search updates are applied immediately, so the report refreshes as soon as the user changes the text
- Later URL changes are still smoothed to avoid repeated refreshes while settings are being restored

### Impact
`✅ Faster aging report loading`
`✅ Quicker search results`
`✅ Fewer repeated report refreshes`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Search results in the aging report now update more responsively without delay
  * Optimized query parameter handling for faster initial page load

<!-- end of auto-generated comment: release notes by coderabbit.ai -->