### PR TITLE
Ankit | Test | Test -  Getting TypeError: Cannot set properties of null (setting 'applicableTaxes') on mapping transaction in ledger

### DIFF
--- a/apps/web-giddh/src/app/contact/aging-report/aging-report.component.ts
+++ b/apps/web-giddh/src/app/contact/aging-report/aging-report.component.ts
@@ -362,8 +362,9 @@ export class AgingReportComponent implements OnInit, OnDestroy {
         this.isAdvanceSearchApplied = false;
         this.dueAmountReportRequest.q = '';
         this.showClearFilter.set(false);
+        this.dueAmountReportRequest.sortBy = 'name';
+        this.dueAmountReportRequest.sort = 'asc';
         this.generalService.saveRouteQueryFilters(null, true);
-        this.sort("name", "asc");
     }
 
     /**

--- a/apps/web-giddh/src/app/ledger/components/new-ledger-entry-panel/new-ledger-entry-panel.component.ts
+++ b/apps/web-giddh/src/app/ledger/components/new-ledger-entry-panel/new-ledger-entry-panel.component.ts
@@ -1216,7 +1216,9 @@ export class NewLedgerEntryPanelComponent implements OnInit, OnDestroy, OnChange
         }
 
         if (!event.relatedTarget || !this.entryContent?.nativeElement.contains(event.relatedTarget)) {
-            this.currentTxn.selectedAccount.applicableTaxes = this.currentTxn.taxesVm;
+            if (this.currentTxn?.selectedAccount?.applicableTaxes) {
+                this.currentTxn.selectedAccount.applicableTaxes = this.currentTxn.taxesVm;
+            }
             this.clickedOutsideEvent.emit(event);
         }
     }

--- a/apps/web-giddh/src/app/ledger/components/update-ledger-entry-panel/update-ledger-entry-panel.component.ts
+++ b/apps/web-giddh/src/app/ledger/components/update-ledger-entry-panel/update-ledger-entry-panel.component.ts
@@ -964,7 +964,7 @@ export class UpdateLedgerEntryPanelComponent implements OnInit, AfterViewInit, O
         }
         if (this.isAdvanceReceipt) {
             requestObj.voucherType = 'rcpt';
-            requestObj.transactions[0].amount = this.vm.grandTotal;
+            requestObj.transactions[0].amount = requestObj.isOtherTaxesApplicable ? this.vm.grandTotal : this.vm.advanceReceiptAmount;
         }
 
         if (this.voucherApiVersion === 2) {

--- a/apps/web-giddh/src/app/ledger/ledger.component.ts
+++ b/apps/web-giddh/src/app/ledger/ledger.component.ts
@@ -1981,6 +1981,10 @@ export class LedgerComponent implements OnInit, OnDestroy {
                 blankTransactionObj = this.adjustmentUtilityService.getAdjustmentObject(blankTransactionObj);
             }
             const model = cloneDeep(blankTransactionObj);
+            if (model.transactions[0]?.subVoucher === "ADVANCE_RECEIPT" && !model.isOtherTaxesApplicable) {
+                /** Here key 'taxInclusiveAmount' represents the amount of the advance receipt, exclusive of tax (if tax is applied) */
+                model.transactions[0].amount = model.transactions[0].taxInclusiveAmount;
+            }
             if (eWayBillResponse && Object.keys(eWayBillResponse).length > 0) {
                 model.ewayBillDetails = eWayBillResponse;
             }

--- a/apps/web-giddh/src/app/shared/header/components/account-add-new-details/account-add-new-details.component.html
+++ b/apps/web-giddh/src/app/shared/header/components/account-add-new-details/account-add-new-details.component.html
@@ -5,7 +5,7 @@
     (commonLocaleData)="commonLocaleData = $event"
     (translationComplete)="translationComplete($event)"
 >
-    <form class="create-acc-form" [formGroup]="addAccountForm" (ngSubmit)="submit()">
+    <form class="create-acc-form" [formGroup]="addAccountForm">
         <div>
             <div class="upper-form">
                 <div class="row pb-4">
@@ -966,7 +966,7 @@
 <ng-template #templateForSaveButton>
     <div class="row pt-4" *ngIf="voucherApiVersion === 2">
         <div class="col-sm-12">
-            <button matButton="filled" aria-label="save" type="submit">
+            <button matButton="filled" aria-label="save" (click)="submit()">
                 {{ commonLocaleData?.app_save }}
             </button>
         </div>

--- a/apps/web-giddh/src/app/shared/header/components/account-add-new-details/account-add-new-details.component.ts
+++ b/apps/web-giddh/src/app/shared/header/components/account-add-new-details/account-add-new-details.component.ts
@@ -772,7 +772,7 @@ export class AccountAddNewDetailsComponent implements OnInit, OnChanges, AfterVi
     }
 
     /**
-     * Removes GST details form at specified index and focuses on submit button
+     * Removes GST details form at specified index and moves focus to the save button.
      * @param i - Index of the form to remove
      * @memberof AccountAddNewDetailsComponent
      */
@@ -780,17 +780,8 @@ export class AccountAddNewDetailsComponent implements OnInit, OnChanges, AfterVi
         const addresses = this.addAccountForm.get('addresses') as FormArray;
         addresses.removeAt(i);
 
-        // Focus on submit button after removing address
         setTimeout(() => {
-            try {
-                const submitBtn = this.renderer.selectRootElement('button[type="submit"], button[aria-label="save"]', true);
-                if (submitBtn) {
-                    submitBtn.focus();
-                }
-            } catch (error) {
-                // Silently handle case where submit button doesn't exist
-
-            }
+            document.querySelector<HTMLButtonElement>('button[aria-label="save"]')?.focus();
         }, 100);
     }
 


### PR DESCRIPTION
## **User description**
https://app.clickup.com/t/86d2bg35f. -[Test -  Getting TypeError: Cannot set properties of null (setting 'applicableTaxes') on mapping transaction in ledger]
https://app.clickup.com/t/86d2h18x1. -[Prod - Account is getting created with remove button click on customer page]
https://app.clickup.com/t/86d25qhwj. -[Prod - Advance receipt with wrong amount is getting created from ledger with tax and other tax]


___

## **CodeAnt-AI Description**
**Fix advance receipt amounts and avoid form errors in ledger and account entry screens**

### What Changed
- Advance receipts now use the correct amount when taxes are not applied, preventing wrong receipt totals.
- Ledger entry updates no longer try to copy tax details when the account or tax data is missing, which avoids a null error while closing the form.
- Removing GST address details now returns focus to the Save button, and account creation uses the Save button click directly.
- Clearing the aging report search now also resets the sort back to name in ascending order.

### Impact
`✅ Correct advance receipt totals`
`✅ Fewer ledger save errors`
`✅ Cleaner form keyboard flow`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed aging report reset functionality to properly maintain sort order
  * Improved stability of data entry forms during user interactions
  * Corrected amount calculations for advance receipts based on tax applicability
  * Enhanced form submission behavior and focus management in account configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->