### PR TITLE
Ankit | Test | Prod - Page is not getting scrolled up when mandatory field is not set on voucher

### DIFF
--- a/apps/web-giddh/src/app/reports/components/purchase-register-component/purchase.register.component.ts
+++ b/apps/web-giddh/src/app/reports/components/purchase-register-component/purchase.register.component.ts
@@ -482,7 +482,7 @@ constructor(
                 this.reportForm.get('salesPersonUniqueNames').patchValue(registerReportFilters?.salesPersonUniqueNames ?? []);
                 this.reportForm.get('accountUniqueNames').patchValue(registerReportFilters?.accountUniqueNames ?? []);
                 this.reportForm.get('countryCodes').patchValue(registerReportFilters?.countryCodes ?? []);
-                this.reportForm.get('countryCode').patchValue(registerReportFilters?.countryCode ?? '');
+                this.reportForm.get('countryCode').patchValue(registerReportFilters?.countryCode || activeCompany.countryV2?.alpha2CountryCode);
                 this.reportForm.get('stateCodes').patchValue(registerReportFilters?.stateCodes ?? []);
                 return activeCompany;
             }))),

--- a/apps/web-giddh/src/app/settings/financial-year/financial-year.component.ts
+++ b/apps/web-giddh/src/app/settings/financial-year/financial-year.component.ts
@@ -82,10 +82,8 @@ export class FinancialYearComponent implements OnInit, OnDestroy {
     public setYearRange() {
         let endYear = dayjs().year();
         let startYear = dayjs().subtract(7, 'year').year();
-        const currentMonth = dayjs().month() + 1;
-        const financialYearStartMonth = this.FYPeriodOptions.find(option => option.value === this.selectedFYPeriod)?.additional?.startMonth;
-        let yearArray = range(startYear, endYear + (currentMonth >= financialYearStartMonth ? 1 : 0));
-        this.yearOptions = yearArray?.map((year: number) => {
+        let yearArray = range(startYear, endYear);
+        this.yearOptions = yearArray?.map(year => {
             return { label: String(year), value: year };
         });
     }
@@ -203,9 +201,9 @@ export class FinancialYearComponent implements OnInit, OnDestroy {
             this.options.placeholder = this.commonLocaleData?.app_select_option;
 
             this.FYPeriodOptions = [
-                { label: this.localeData?.financial_year_period_options?.jan_dec, value: 'JAN-DEC', additional: { startMonth: 1, endMonth: 12 } },
-                { label: this.localeData?.financial_year_period_options?.apr_mar, value: 'APR-MAR', additional: { startMonth: 4, endMonth: 3 } },
-                { label: this.localeData?.financial_year_period_options?.july_july, value: 'JULY-JULY', additional: { startMonth: 7, endMonth: 6 } }
+                { label: this.localeData?.financial_year_period_options?.jan_dec, value: 'JAN-DEC'},
+                { label: this.localeData?.financial_year_period_options?.apr_mar, value: 'APR-MAR'},
+                { label: this.localeData?.financial_year_period_options?.july_july, value: 'JULY-JULY'}
             ];
 
             if (this.financialYearObj?.financialYearPeriod) {

--- a/apps/web-giddh/src/app/shared/header/components/account-add-new-details/account-add-new-details.component.html
+++ b/apps/web-giddh/src/app/shared/header/components/account-add-new-details/account-add-new-details.component.html
@@ -415,7 +415,6 @@
                                     "
                                     [type]="'text'"
                                     [formControl]="addAccountForm.controls.addresses?.controls?.[i].controls?.pincode"
-                                    [allowDecimalDigitsOnly]="true"
                                     (change)="openConfirmLeaveDialog()"
                                 ></input-field>
                             </div>

--- a/apps/web-giddh/src/app/shared/header/components/account-add-new-details/account-add-new-details.component.ts
+++ b/apps/web-giddh/src/app/shared/header/components/account-add-new-details/account-add-new-details.component.ts
@@ -4,6 +4,7 @@ import {
     AfterViewInit,
     ChangeDetectorRef,
     Component,
+    ElementRef,
     EventEmitter,
     Input,
     OnChanges,
@@ -241,6 +242,7 @@ export class AccountAddNewDetailsComponent implements OnInit, OnChanges, AfterVi
         private commonActions: CommonActions,
         private _generalActions: GeneralActions,
         private changeDetectorRef: ChangeDetectorRef,
+        private elementRef: ElementRef,
         protected generalService: GeneralService,
         private groupService: GroupService,
         private groupWithAccountsAction: GroupWithAccountsAction,
@@ -1505,6 +1507,23 @@ export class AccountAddNewDetailsComponent implements OnInit, OnChanges, AfterVi
         if (firstErrorTab) {
             this.goToTab(firstErrorTab.index);
         }
+        this.scrollToFirstInvalidField();
+    }
+
+    /**
+     * Scrolls the sidebar panel to the first invalid form field
+     *
+     * @private
+     * @memberof AccountAddNewDetailsComponent
+     */
+    private scrollToFirstInvalidField(): void {
+        setTimeout(() => {
+            const hostEl: HTMLElement = this.elementRef.nativeElement;
+            const firstInvalid = hostEl.querySelector<HTMLElement>(
+                'input.ng-invalid, mat-select.ng-invalid, reactive-dropdown-field.ng-invalid, input-field.ng-invalid, select-field.ng-invalid, textarea.ng-invalid'
+            );
+            firstInvalid?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        }, 300);
     }
 
     /**

--- a/apps/web-giddh/src/app/shared/header/components/account-update-new-details/account-update-new-details.component.html
+++ b/apps/web-giddh/src/app/shared/header/components/account-update-new-details/account-update-new-details.component.html
@@ -397,7 +397,6 @@
                                     "
                                     [type]="'text'"
                                     [formControl]="addAccountForm.controls.addresses?.controls?.[i].controls?.pincode"
-                                    [allowDecimalDigitsOnly]="true"
                                     (change)="openConfirmLeaveDialog()"
                                 ></input-field>
                             </div>

--- a/apps/web-giddh/src/app/shared/header/components/account-update-new-details/account-update-new-details.component.ts
+++ b/apps/web-giddh/src/app/shared/header/components/account-update-new-details/account-update-new-details.component.ts
@@ -327,6 +327,7 @@ export class AccountUpdateNewDetailsComponent implements OnInit, OnDestroy, OnCh
         private groupService: GroupService,
         private invoiceService: InvoiceService,
         private changeDetectorRef: ChangeDetectorRef,
+        private elementRef: ElementRef,
         private settingsDiscountService: SettingsDiscountService,
         private customFieldsService: CustomFieldsService,
         private http: HttpClient,
@@ -2717,6 +2718,23 @@ export class AccountUpdateNewDetailsComponent implements OnInit, OnDestroy, OnCh
         if (firstErrorTab) {
             this.goToTab(firstErrorTab.index);
         }
+        this.scrollToFirstInvalidField();
+    }
+
+    /**
+     * Scrolls the sidebar panel to the first invalid form field
+     *
+     * @private
+     * @memberof AccountUpdateNewDetailsComponent
+     */
+    private scrollToFirstInvalidField(): void {
+        setTimeout(() => {
+            const hostEl: HTMLElement = this.elementRef.nativeElement;
+            const firstInvalid = hostEl.querySelector<HTMLElement>(
+                'input.ng-invalid, mat-select.ng-invalid, reactive-dropdown-field.ng-invalid, input-field.ng-invalid, select-field.ng-invalid, textarea.ng-invalid'
+            );
+            firstInvalid?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        }, 300);
     }
 
     /**

--- a/apps/web-giddh/src/app/theme/form-fields/reactive-dropdown-field/reactive-dropdown-field.component.ts
+++ b/apps/web-giddh/src/app/theme/form-fields/reactive-dropdown-field/reactive-dropdown-field.component.ts
@@ -261,7 +261,7 @@ export class ReactiveDropdownFieldComponent implements ControlValueAccessor, OnI
             }
 
             // Always try to set label value when options change, regardless of previous value
-            if (changes?.options && this.isFirstKeystroke()) {
+            if (changes?.options && !this.isFirstKeystroke()) {
                 // Use setTimeout to ensure the value is properly set before trying to find the label
                 setTimeout(() => {
                     this.setLabelValue(null);


### PR DESCRIPTION
## **User description**
https://app.clickup.com/t/86d2gt621. Prod - Page is not getting scrolled up when mandatory field is not set on voucher


___

## **CodeAnt-AI Description**
**Scroll to the first invalid field and tighten country/postal code handling**

### What Changed
- When a form has validation errors, the page now scrolls to the first invalid field so the error is easier to find in the account add and edit side panels.
- Postal code fields no longer accept decimal values.
- Purchase register filters now fall back to the company’s country when no saved country is available.
- Financial year options now show a fixed year range instead of changing based on the selected period and current month.
- Dropdown fields refresh their label after options change, which helps the selected value stay visible after typing.

### Impact
`✅ Faster correction of form errors`
`✅ Fewer invalid postal code entries`
`✅ Clearer country filters in purchase reports`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected pincode field validation to accept all numeric inputs in account forms
  * Fixed dropdown label recalculation timing in form fields

* **Improvements**
  * Added automatic smooth scrolling to the first invalid field when form validation errors occur
  * Enhanced country code initialization in purchase reports to use company settings as fallback
  * Streamlined financial year period configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->