### PR TITLE
Ankit | Test | Prod - Note is getting remove from template setting when disabling the setting unchecking the checkbox

### DIFF
--- a/apps/web-giddh/src/app/vouchers/template-edit-dialog/template-edit-dialog.component.ts
+++ b/apps/web-giddh/src/app/vouchers/template-edit-dialog/template-edit-dialog.component.ts
@@ -150,7 +150,7 @@ export class TemplateEditDialogComponent implements OnInit, OnDestroy {
         data.sections['footer'].data['textUnderSlogan'] = { label: '', display: false };
       } else if (textUnderSlogan) {
         textUnderSlogan.display = false;
-        textUnderSlogan.label = '';
+        textUnderSlogan.label = textUnderSlogan.label || '';
       }
     }
   }
@@ -265,7 +265,7 @@ export class TemplateEditDialogComponent implements OnInit, OnDestroy {
     const msg1 = data?.sections?.['footer']?.data?.['message1'];
     if (msg1 && (!msg1?.display || !msg1?.label)) {
       msg1.display = false;
-      msg1.label = '';
+      msg1.label = msg1.label || '';
     }
   }
 

--- a/apps/web-giddh/src/app/vouchers/template/template-edit-filter/template-edit-filter.component.html
+++ b/apps/web-giddh/src/app/vouchers/template/template-edit-filter/template-edit-filter.component.html
@@ -182,8 +182,6 @@
                                     [options]="presetFontsSize"
                                     (selectedOption)="onFontSizeSelect($event)"
                                     [(ngModel)]="customTemplate.fontSize"
-                                    (onClear)="selectedFontSize = ''"
-                                    [labelValue]="selectedFontSize"
                                     [placeholder]="localeData?.select_different_fonts_size"
                                 ></reactive-dropdown-field>
                             </div>

--- a/apps/web-giddh/src/app/vouchers/template/template-edit-filter/template-edit-filter.component.ts
+++ b/apps/web-giddh/src/app/vouchers/template/template-edit-filter/template-edit-filter.component.ts
@@ -79,8 +79,6 @@ export class TemplateEditFilterComponent implements OnInit {
     private destroyed$: ReplaySubject<boolean> = new ReplaySubject(1);
     /** True, if delete button should be shown */
     public showDeleteButton: boolean = false;
-    /** Size of the selected font */
-    public selectedFontSize: string = "";
     /** Default image size */
     public defaultImageSize: string = 'S';
     /** Controls visibility of template UI sections */
@@ -598,9 +596,6 @@ export class TemplateEditFilterComponent implements OnInit {
         }
         if (this.customTemplate?.fontSize) {
             this.customTemplate.fontSize = this.customTemplate?.fontSize.toString();
-            (Array.isArray(this.templateFontsSize) ? this.templateFontsSize : []).forEach(fontSize => {
-                if (fontSize?.value == this.customTemplate?.fontSize) this.selectedFontSize = fontSize?.label;
-            });
         }
     }
 


### PR DESCRIPTION
## **User description**
https://app.clickup.com/t/86d2grzex


___

## **CodeAnt-AI Description**
**Keep footer text when template fields are turned off**

### What Changed
- Disabling footer fields like the note and message no longer wipes out the text already entered
- Turning those fields back on now keeps the previous text instead of starting blank
- The font size picker still works as before, with unused selection state removed

### Impact
`✅ Fewer lost template edits`
`✅ Safer toggle changes in voucher templates`
`✅ Less retyping after disabling and re-enabling footer fields`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced label preservation in template edit dialog footer fields to maintain existing labels instead of clearing them when display settings change.

* **Refactor**
  * Streamlined font size dropdown in template editor by removing unnecessary clear handler and label value binding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->