### PR TITLE
Ankit | Test |  Prod - State list is not coming on billing details page in new sign up when country get automatically selected

### DIFF
--- a/apps/web-giddh/src/app/subscription/change-billing/change-billing.component.html
+++ b/apps/web-giddh/src/app/subscription/change-billing/change-billing.component.html
@@ -118,7 +118,7 @@
                                     [placeholder]="commonLocaleData?.app_select_region"
                                     [options]="countyList"
                                     formControlName="code"
-                                    (selectedOption)="changeBillingForm.get('state')?.patchValue($event)"
+                                    (selectedOption)="selectState($event)"
                                 ></reactive-dropdown-field>
                             </div>
                         </div>


### PR DESCRIPTION
## **User description**
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)



* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Other information**:


___

## **CodeAnt-AI Description**
Fix state selection on the billing details page during new sign up

### What Changed
- When a region or state is chosen in billing details, the form now uses the same state handling flow in both dropdown cases
- This keeps the billing state field in sync when the country is auto-selected during new sign up

### Impact
`✅ Fewer missing state fields on billing details`
`✅ Smoother new sign-up billing setup`
`✅ Clearer address selection during checkout`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=hTxtBwLFSHFXjhDqMvejZiluKPTRHUPo1YvbdV5jz80&org=Walkover-Web-Solution)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
