### PR TITLE
Ankit | Test | Prod- Purchase register overview API is getting failed with error message -"Country not found with code"

### DIFF
--- a/apps/web-giddh/src/app/reports/components/purchase-register-component/purchase.register.component.ts
+++ b/apps/web-giddh/src/app/reports/components/purchase-register-component/purchase.register.component.ts
@@ -322,7 +322,7 @@ constructor(
         });
 
         // Subscribe to countryCode changes to automatically load states
-        this.reportForm.get('countryCode')?.valueChanges.pipe(takeUntil(this.destroyed$)).subscribe(countryCode => {
+        this.reportForm.get('countryCode')?.valueChanges.pipe(filter(Boolean), debounceTime(500), distinctUntilChanged(), takeUntil(this.destroyed$)).subscribe(countryCode => {
             if (countryCode) {
                 this.loadStates(countryCode);
             } else {
@@ -942,10 +942,10 @@ constructor(
             this.removeKeysFromObject(requestObject, keysToRemove);
         }
         this.currentGroupBy.set(requestObject.groupBy);
-        if (requestObject.groupBy === GroupBy.State && !requestObject.countryCode) {
+        if (requestObject.groupBy === GroupBy.State && !requestObject.country?.code) {
             if (this.activeCompany?.countryV2?.alpha2CountryCode) {
-                this.reportForm.get('countryCode')?.setValue(this.activeCompany.countryV2.alpha2CountryCode);
-                requestObject.countryCode = this.activeCompany.countryV2.alpha2CountryCode;
+                this.reportForm.get('countryCode')?.patchValue(this.activeCompany.countryV2.alpha2CountryCode, { emitEvent: false });
+                requestObject.country = { code: this.activeCompany.countryV2.alpha2CountryCode };
             } else {
                 return;
             }

--- a/apps/web-giddh/src/app/reports/components/report-details-components/report.details.component.ts
+++ b/apps/web-giddh/src/app/reports/components/report-details-components/report.details.component.ts
@@ -312,7 +312,7 @@ constructor(
         });
 
         // Subscribe to countryCode changes to automatically load states
-        this.reportForm.get('countryCode')?.valueChanges.pipe(filter(Boolean), distinctUntilChanged(), takeUntil(this.destroyed$)).subscribe(countryCode => {
+        this.reportForm.get('countryCode')?.valueChanges.pipe(filter(Boolean), debounceTime(500), distinctUntilChanged(), takeUntil(this.destroyed$)).subscribe(countryCode => {
             if (countryCode) {
                 this.loadStates(countryCode);
             } else {
@@ -947,10 +947,10 @@ constructor(
             this.removeKeysFromObject(requestObject, keysToRemove);
         }
         this.currentGroupBy.set(requestObject.groupBy);
-        if (requestObject.groupBy === GroupBy.State && !requestObject.countryCode) {
+        if (requestObject.groupBy === GroupBy.State && !requestObject.country?.code) {
             if (this.activeCompany?.countryV2?.alpha2CountryCode) {
-                this.reportForm.get('countryCode')?.setValue(this.activeCompany.countryV2.alpha2CountryCode);
-                requestObject.countryCode = this.activeCompany.countryV2.alpha2CountryCode;
+                this.reportForm.get('countryCode')?.patchValue(this.activeCompany.countryV2.alpha2CountryCode, { emitEvent: false });
+                requestObject.country = { code: this.activeCompany.countryV2.alpha2CountryCode };
             } else {
                 return;
             }
@@ -1039,7 +1039,6 @@ constructor(
                 countryCode: event.value,
                 stateCodes: null,
             });
-            this.getSalesRegister(this.dateRange.from, this.dateRange.to);
         }
     }
 }


### PR DESCRIPTION
## **User description**
https://app.clickup.com/t/86d299bj8


___

## **CodeAnt-AI Description**
**Fix state-based report loading when country is changed**

### What Changed
- Changing the country now waits briefly before loading states, which prevents repeated requests while the selection is still changing
- When grouping by state, the report now uses the selected country consistently so purchase and sales registers load instead of failing with “Country not found with code”
- Selecting a country no longer triggers an extra report refresh; the report updates through the normal filter flow

### Impact
`✅ Fewer duplicate country/state requests`
`✅ Fewer state-grouping load failures`
`✅ Clearer country-based report filtering`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=yg-UY5USal23FqTCYo-Qw2qfRGyIbkklIZkIAbrCAMw&org=Walkover-Web-Solution)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized country selection handling in purchase and sales reports for faster response times with debounced updates.

* **Bug Fixes**
  * Fixed country code handling in state grouping for reports.
  * Improved state loading behavior when switching countries in report filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->