### PR TITLE
Ankit | TEST | QA - Support Round off in Purchase and Sales register overview and detailed report

### DIFF
--- a/apps/web-giddh/src/app/ledger/ledger.component.ts
+++ b/apps/web-giddh/src/app/ledger/ledger.component.ts
@@ -3551,8 +3551,8 @@ export class LedgerComponent implements OnInit, OnDestroy {
                         data.body.stock?.groupTaxes ?? [],
                         data.body.taxes ?? [],
                         data.body.groupTaxes ?? []);
-
-                        if (data.body.oppositeAccount) {
+                        const isSundryDebtorCreditorAccount = data.body.oppositeAccount?.parentGroups?.includes(AccountingGroupEnum.SundryCreditors) || data.body.oppositeAccount?.parentGroups?.includes(AccountingGroupEnum.SundryDebtors);
+                        if (data.body.oppositeAccount && isSundryDebtorCreditorAccount) {
                             const stockAccountOtherTax = this.generalService.fetchTaxesOnPriority(
                                                     [],
                                                     [],

--- a/apps/web-giddh/src/app/models/api-models/Ledger.ts
+++ b/apps/web-giddh/src/app/models/api-models/Ledger.ts
@@ -249,6 +249,7 @@ export class TransactionsRequest {
     public accountCurrency: boolean = false;
     public branchUniqueName?: string;
     public paginationToken?: string = '';
+    public isTView?: boolean;
 }
 
 export interface ReconcileRequest {

--- a/apps/web-giddh/src/app/reports/components/purchase-register-component/purchase.register.component.ts
+++ b/apps/web-giddh/src/app/reports/components/purchase-register-component/purchase.register.component.ts
@@ -91,9 +91,9 @@ export class PurchaseRegisterComponent implements OnInit, OnDestroy {
         discountTotal: ["app_discount", false, "text-right"],
         tcsTotal: ["app_tcs", false, "text-right"],
         tdsTotal: ["app_tds", false, "text-right"],
+        roundOff: ["app_round_off", false, "text-right"],
         netPurchase: ["app_net_purchase", false, "text-right"],
-        cumulative: ["app_cumulative", false, "text-right"],
-        roundOff: ["app_round_off", false, "text-right"]
+        cumulative: ["app_cumulative", false, "text-right"]
     }
     /** Constant for duration */
     public durationEnum: typeof DurationEnum = DurationEnum;

--- a/apps/web-giddh/src/app/reports/components/purchase-register-expand-component/purchase.register.expand.component.html
+++ b/apps/web-giddh/src/app/reports/components/purchase-register-expand-component/purchase.register.expand.component.html
@@ -466,8 +466,15 @@
 
                         <!-- Round Off Column -->
                         <ng-container matColumnDef="app_round_off">
-                            <th mat-header-cell *matHeaderCellDef class="text-right">
-                                {{ commonLocaleData?.app_round_off }}
+                            <th mat-header-cell *matHeaderCellDef>
+                                <div class="d-flex justify-content-end align-items-center">
+                                    <div class="text-right">{{ commonLocaleData?.app_round_off }}</div>
+                                    <div class="icon-pointer">
+                                        <ng-container
+                                            *ngTemplateOutlet="sortingTemplate; context: { $implicit: 'roundOff' }"
+                                        ></ng-container>
+                                    </div>
+                                </div>
                             </th>
                             <td mat-cell *matCellDef="let item" class="text-right">
                                 @if (item?.roundOff !== null) {

--- a/apps/web-giddh/src/app/reports/components/purchase-register-expand-component/purchase.register.expand.component.ts
+++ b/apps/web-giddh/src/app/reports/components/purchase-register-expand-component/purchase.register.expand.component.ts
@@ -302,15 +302,15 @@ export class PurchaseRegisterExpandComponent implements OnInit, OnDestroy {
                 "checked": true,
             },
             {
-                "value": "net_purchase",
-                "label": "Net Purchase",
-                "checked": true,
-            },
-            {
                 "value": "app_round_off",
                 "label": "Round Off",
                 "checked": true,
                 "isCommonLocaleData": true
+            },
+            {
+                "value": "net_purchase",
+                "label": "Net Purchase",
+                "checked": true,
             }
         ];
 

--- a/apps/web-giddh/src/app/reports/components/sales-register-expand-component/sales.register.expand.component.html
+++ b/apps/web-giddh/src/app/reports/components/sales-register-expand-component/sales.register.expand.component.html
@@ -471,8 +471,13 @@
 
                     <!-- Round Off Column -->
                     <ng-container matColumnDef="app_round_off">
-                        <th mat-header-cell *matHeaderCellDef class="text-right">
-                            {{ commonLocaleData?.app_round_off }}
+                        <th mat-header-cell *matHeaderCellDef>
+                            <div class="d-flex justify-content-end align-items-center">
+                                <div class="text-right">{{ commonLocaleData?.app_round_off }}</div>
+                                <div class="icon-pointer">
+                                    <ng-container *ngTemplateOutlet="sortingTemplate; context: { $implicit: 'roundOff' }"></ng-container>
+                                </div>
+                            </div>
                         </th>
                         <td mat-cell *matCellDef="let item" class="text-right">
                             @if (item?.roundOff !== null) {

--- a/apps/web-giddh/src/app/reports/components/sales-register-expand-component/sales.register.expand.component.ts
+++ b/apps/web-giddh/src/app/reports/components/sales-register-expand-component/sales.register.expand.component.ts
@@ -290,15 +290,15 @@ public voucherNumberInput: UntypedFormControl = new UntypedFormControl();
                 "checked": true
             },
             {
-                "value": "net_sales",
-                "label": "Net Sales",
-                "checked": true
-            },
-            {
                 "value": "app_round_off",
                 "label": "Round Off",
                 "checked": true,
                 "isCommonLocaleData": true
+            },
+            {
+                "value": "net_sales",
+                "label": "Net Sales",
+                "checked": true
             }
         ];
 

--- a/apps/web-giddh/src/app/services/ledger.service.ts
+++ b/apps/web-giddh/src/app/services/ledger.service.ts
@@ -87,6 +87,9 @@ export class LedgerService {
             request.branchUniqueName = request.branchUniqueName !== this.companyUniqueName ? request.branchUniqueName : '';
             url = url.concat(`&branchUniqueName=${request.branchUniqueName}`);
         }
+        if (request.isTView) {
+            url = url.concat(`&isTView=${request.isTView}`);
+        }
         // tslint:disable-next-line:max-line-length
         const options = request.paginationToken ? { headers: { 'token': request.paginationToken } } : null;
         return this.http.get(url, null, options).pipe(map((res) => {

--- a/apps/web-giddh/src/app/shared/ledger-statement-t-view/ledger-statement.component.ts
+++ b/apps/web-giddh/src/app/shared/ledger-statement-t-view/ledger-statement.component.ts
@@ -459,7 +459,7 @@ export class LedgerStatementComponent implements OnInit, OnDestroy {
             }
             this.store.dispatch(this.ledgerActions.GetLedgerAccount(this.trxRequest.accountUniqueName));
             this.store.dispatch(this.ledgerActions.GetLedgerBalance(this.trxRequest));
-            this.store.dispatch(this.ledgerActions.GetTransactions({ ...this.trxRequest, from: fromDate, to: toDate }));
+            this.store.dispatch(this.ledgerActions.GetTransactions({ ...this.trxRequest, from: fromDate, to: toDate, isTView: true }));
             this.lc.transactionData$ = this.store.pipe(select(p => p.ledger.transactionsResponse), takeUntil(this.destroyed$), shareReplay(1));
             this.lc.activeAccount$ = this.store.pipe(select(p => p.ledger.account), takeUntil(this.destroyed$));
             this.lc.companyProfile$ = this.store.pipe(select(p => p.settings.profile), takeUntil(this.destroyed$));


### PR DESCRIPTION
## **User description**
https://app.clickup.com/t/86d2u881h


___

## **CodeAnt-AI Description**
**Show round-off alongside sales and purchase totals, and support sorting in transaction views**

### What Changed
- Moved the Round Off column before Net Sales and Net Purchase in sales and purchase register views.
- Added sorting for the Round Off column in both register tables.
- In ledger transaction views, the transaction request now marks the view so the correct transaction data is loaded.
- Default taxes are now applied only when the linked account is a sundry debtor or sundry creditor.

### Impact
`✅ Clearer sales and purchase totals`
`✅ Sortable round-off amounts`
`✅ More accurate ledger tax handling`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=J9K1DZV0h384-AJrfIRp-jVZ-CKpQNe9092PJZYHncE&org=Walkover-Web-Solution)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect tax calculations on ledger accounts when using non-sundry account types as opposite accounts.

* **New Features**
  * Added sorting functionality to the "Round Off" column in Purchase and Sales register reports.
  * Improved transaction view handling for T-View mode.

* **Style**
  * Reorganized column layouts in Purchase and Sales register reports for better data presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->