### PR TITLE
Divyanshu | Test | QA : Integration of Stripe

### DIFF
--- a/apps/web-giddh/src/app/subscription/buy-plan/buy-plan.component.ts
+++ b/apps/web-giddh/src/app/subscription/buy-plan/buy-plan.component.ts
@@ -2320,24 +2320,21 @@ export class BuyPlanComponent implements OnInit, OnDestroy {
     }
 
     /**
-     * Clears all Stripe-related sessionStorage items to prevent stale data
-     * from being reused on subsequent visits.
+     * Clears Stripe form sessionStorage items after redirect is handled.
+     * Keeps subscription_id and is_change_plan for saveStripePaymentSuccess$.
      *
      * @private
      * @memberof BuyPlanComponent
      */
     private clearStripeSessionData(): void {
-        sessionStorage.removeItem('stripe_subscription_id');
-        sessionStorage.removeItem('stripe_is_change_plan');
-        sessionStorage.removeItem('stripe_payment_intent_id');
-        sessionStorage.removeItem('stripe_subscription_request');
-        sessionStorage.removeItem('stripe_duration');
-        sessionStorage.removeItem('stripe_plan_unique_name');
-        sessionStorage.removeItem('stripe_amount_paid');
         sessionStorage.removeItem('stripe_subscription_form');
         sessionStorage.removeItem('stripe_selected_plan');
         sessionStorage.removeItem('stripe_region_value');
         sessionStorage.removeItem('stripe_region_label');
+        sessionStorage.removeItem('stripe_duration');
+        sessionStorage.removeItem('stripe_plan_unique_name');
+        sessionStorage.removeItem('stripe_amount_paid');
+        sessionStorage.removeItem('stripe_subscription_request');
     }
 
     /**

--- a/apps/web-giddh/src/app/subscription/buy-plan/buy-plan.component.ts
+++ b/apps/web-giddh/src/app/subscription/buy-plan/buy-plan.component.ts
@@ -278,6 +278,8 @@ export class BuyPlanComponent implements OnInit, OnDestroy {
     public removePromoCode: boolean = false;
     /** True when page was loaded after a Stripe payment failure redirect */
     private restoringFromStripeFailure: boolean = false;
+    /** Holds the duration value restored from sessionStorage during Stripe failure recovery */
+    private restoredDuration: string = '';
     /** Hold true in production environment */
     public isProdMode: boolean = environment.PRODUCTION_ENV;
     /** This will hold option selected state */
@@ -1490,6 +1492,12 @@ export class BuyPlanComponent implements OnInit, OnDestroy {
      */
     public getAllPlans(): void {
         this.planList$.pipe(filter(Boolean), take(1)).subscribe(response => {
+            // If we just finished restoring from a Stripe failure, do NOT re-run the default
+            // plan selection logic — the restoration already set the correct plan and duration.
+            if (!this.restoringFromStripeFailure && this.restoredDuration) {
+                this.restoredDuration = '';
+                return;
+            }
             if (response?.length) {
                 this.allPlans = response;
                 this.monthlyPlans = response?.filter(plan =>
@@ -1502,10 +1510,14 @@ export class BuyPlanComponent implements OnInit, OnDestroy {
                 this.monthlyPlans = this.monthlyPlans.sort((a, b) => a.monthlyAmount - b.monthlyAmount);
                 this.yearlyPlans = this.yearlyPlans.sort((a, b) => a.yearlyAmount - b.yearlyAmount);
                 if (!this.subscriptionId) {
-                    if (this.yearlyPlans?.length) {
-                        this.firstStepForm.get('duration').patchValue(PlanDuration.YEARLY);
-                    } else {
-                        this.firstStepForm.get('duration').patchValue(PlanDuration.MONTHLY);
+                    // When restoring from a Stripe failure, the duration was already restored
+                    // from sessionStorage; do NOT overwrite it with the default yearly fallback.
+                    if (!this.restoringFromStripeFailure) {
+                        if (this.yearlyPlans?.length) {
+                            this.firstStepForm.get('duration').patchValue(PlanDuration.YEARLY);
+                        } else {
+                            this.firstStepForm.get('duration').patchValue(PlanDuration.MONTHLY);
+                        }
                     }
                 } else if (this.viewSubscriptionData?.period) {
                     this.firstStepForm.get('duration').patchValue(this.viewSubscriptionData?.period);
@@ -1539,11 +1551,25 @@ export class BuyPlanComponent implements OnInit, OnDestroy {
         // plans so the plan-selection step (step 0) shows the right list, then exit –
         // do NOT reset selectedPlan, planUniqueName, or the payment provider.
         if (this.restoringFromStripeFailure) {
+            // Use the restored duration directly instead of isYearly() signal which may
+            // have been overwritten by earlier getAllPlans() calls before restoration.
+            const useYearly = this.restoredDuration === PlanDuration.YEARLY;
             const filteredPlans = !this.subscriptionId
-                ? (this.isYearly() ? this.yearlyPlans : this.monthlyPlans)
+                ? (useYearly ? this.yearlyPlans : this.monthlyPlans)
                 : (this.viewSubscriptionData?.period === PlanDuration.YEARLY ? this.yearlyPlans : this.monthlyPlans);
             filteredPlans?.forEach(plan => { this.inputData.push(plan); });
+            // Re-select the previously selected plan from the restored form value
+            // instead of leaving it as whatever was set by an earlier getAllPlans() call.
+            const restoredPlanUniqueName = this.firstStepForm.get('planUniqueName')?.value;
+            if (restoredPlanUniqueName) {
+                const restoredPlan = this.allPlans?.find((p: any) => p.uniqueName === restoredPlanUniqueName);
+                if (restoredPlan) {
+                    this.selectedPlan.set(restoredPlan);
+                }
+            }
             this.restoringFromStripeFailure = false;
+            // Do NOT clear restoredDuration here; the planList$ subscription in
+            // handleStripeRedirectFailure may fire after setPlans and still needs it.
             this.changeDetection.detectChanges();
             return;
         }
@@ -1598,10 +1624,6 @@ export class BuyPlanComponent implements OnInit, OnDestroy {
         }
         if (this.selectedPlan()?.uniqueName && reqObj?.countryCode) {
             this.componentStore.getCalculationData(reqObj);
-        }
-        if (!this.removePromoCode && !this.thirdStepForm.get('paymentProvider')?.value) {
-            // Clear the payment provider initially
-            this.thirdStepForm.get('paymentProvider')?.patchValue(null);
         }
 
         const entityCode = this.selectedPlan()?.entityCode;
@@ -2071,17 +2093,24 @@ export class BuyPlanComponent implements OnInit, OnDestroy {
         };
 
         this.showStripePaymentElement = true;
-        this.stripeDialogRef = this.dialog.open(StripePaymentDialogComponent, {
-            panelClass: ['mat-dialog-sm'],
-            disableClose: true,
-            data: dialogData
-        });
+        // Pre-load Stripe.js before opening the dialog so the payment element
+        // renders instantly instead of waiting for the CDN fetch.
+        this.loadStripeScript().then(() => {
+            this.stripeDialogRef = this.dialog.open(StripePaymentDialogComponent, {
+                panelClass: ['mat-dialog-sm'],
+                disableClose: true,
+                data: dialogData
+            });
 
-        this.stripeDialogRef.afterClosed().pipe(take(1)).subscribe(() => {
-            this.stripeDialogRef = null;
+            this.stripeDialogRef.afterClosed().pipe(take(1)).subscribe(() => {
+                this.stripeDialogRef = null;
+                this.showStripePaymentElement = false;
+                this.stripeClientSecret = '';
+                this.changeDetection.detectChanges();
+            });
+        }).catch(() => {
+            this.toasterService.showSnackBar('error', 'Failed to load Stripe payment library');
             this.showStripePaymentElement = false;
-            this.stripeClientSecret = '';
-            this.changeDetection.detectChanges();
         });
     }
 
@@ -2121,6 +2150,9 @@ export class BuyPlanComponent implements OnInit, OnDestroy {
                 } else {
                     this.toasterService.showSnackBar('error', 'Payment status: ' + paymentIntent.status);
                 }
+                // Clear cached form data regardless of payment status — we don't want stale
+                // sessionStorage values lingering after the redirect is handled.
+                this.clearStripeSessionData();
                 this.changeDetection.detectChanges();
             }).catch(() => {
                 this.isLoading = false;
@@ -2165,8 +2197,26 @@ export class BuyPlanComponent implements OnInit, OnDestroy {
         //  - secondStepForm required fields → must be valid for linear stepper to reach step 2
         //  - thirdStepForm.paymentProvider → was 'STRIPE' when Buy Now was clicked, so Stripe
         //    is automatically pre-selected without any extra work
+        let savedForm: any = null;
         if (savedFormStr) {
-            try { this.subscriptionForm.patchValue(JSON.parse(savedFormStr)); } catch {}
+            try { savedForm = JSON.parse(savedFormStr); } catch {}
+        }
+        if (savedForm) {
+            this.subscriptionForm.patchValue(savedForm);
+            // Explicitly re-apply payment provider because nested patchValue can be flaky
+            // with ControlValueAccessor components that use OnPush change detection.
+            if (savedForm.thirdStepForm?.paymentProvider) {
+                this.thirdStepForm.get('paymentProvider')?.setValue(savedForm.thirdStepForm.paymentProvider);
+            }
+            // Explicitly sync the selectedDuration signal so setPlans() picks the right list
+            // (valueChanges may not have fired yet by the time getAllPlans() runs).
+            const restoredDuration = savedForm.firstStepForm?.duration;
+            if (restoredDuration) {
+                this.selectedDuration.set(restoredDuration);
+                this.restoredDuration = restoredDuration;
+                // Also explicitly set the form control value so mat-button-toggle-group reflects it
+                this.firstStepForm.get('duration')?.setValue(restoredDuration, { emitEvent: true });
+            }
         }
 
         // Restore the full plan object into the signal so the review screen renders the
@@ -2194,10 +2244,15 @@ export class BuyPlanComponent implements OnInit, OnDestroy {
                 take(1),
                 takeUntil(this.destroyed$)
             ).subscribe((plans: any[]) => {
+                // Skip if setPlans() already handled the restoration (getAllPlans from newUserSelectCountry fires first)
+                if (!this.restoredDuration) {
+                    return;
+                }
                 this.allPlans = plans;
-                this.yearlyPlans = plans.filter((p: any) => p.period === PlanDuration.YEARLY);
-                this.monthlyPlans = plans.filter((p: any) => p.period === PlanDuration.MONTHLY);
-                const filteredPlans = this.isYearly() ? this.yearlyPlans : this.monthlyPlans;
+                this.yearlyPlans = plans.filter((p: any) => p.hasOwnProperty('yearlyAmount') && p?.yearlyAmount !== null);
+                this.monthlyPlans = plans.filter((p: any) => p.hasOwnProperty('monthlyAmount') && p?.monthlyAmount !== null);
+                const useYearly = this.restoredDuration === PlanDuration.YEARLY;
+                const filteredPlans = useYearly ? this.yearlyPlans : this.monthlyPlans;
                 this.inputData = [];
                 filteredPlans?.forEach(plan => { this.inputData.push(plan); });
                 const restoredPlan = plans.find((p: any) => p.uniqueName === savedPlanUniqueName);
@@ -2219,6 +2274,26 @@ export class BuyPlanComponent implements OnInit, OnDestroy {
         this.setFinalAmount();
 
         this.selectedStep = 2;
+        // Defer stepper navigation so the linear stepper sees valid forms after patchValue.
+        // Use next() twice instead of selectedIndex because linear stepper validates
+        // stepControl before allowing navigation.
+        setTimeout(() => {
+            if (this.stepperIcon) {
+                this.stepperIcon.next();
+                setTimeout(() => {
+                    if (this.stepperIcon) {
+                        this.stepperIcon.next();
+                    }
+                    // Re-apply Stripe after the stepper has rendered step 3 and the
+                    // payment-provider-selector ControlValueAccessor has initialized.
+                    // A longer delay is needed because the component uses OnPush CD.
+                    setTimeout(() => {
+                        this.thirdStepForm.get('paymentProvider')?.patchValue(PaymentProvider.STRIPE);
+                        this.changeDetection.detectChanges();
+                    }, 100);
+                }, 0);
+            }
+        }, 0);
 
         if (this.localeData?.payment_failed) {
             this.toasterService.showSnackBar('error', this.localeData.payment_failed);
@@ -2242,6 +2317,27 @@ export class BuyPlanComponent implements OnInit, OnDestroy {
             payment_intent_client_secret: null,
             redirect_status: null
         });
+    }
+
+    /**
+     * Clears all Stripe-related sessionStorage items to prevent stale data
+     * from being reused on subsequent visits.
+     *
+     * @private
+     * @memberof BuyPlanComponent
+     */
+    private clearStripeSessionData(): void {
+        sessionStorage.removeItem('stripe_subscription_id');
+        sessionStorage.removeItem('stripe_is_change_plan');
+        sessionStorage.removeItem('stripe_payment_intent_id');
+        sessionStorage.removeItem('stripe_subscription_request');
+        sessionStorage.removeItem('stripe_duration');
+        sessionStorage.removeItem('stripe_plan_unique_name');
+        sessionStorage.removeItem('stripe_amount_paid');
+        sessionStorage.removeItem('stripe_subscription_form');
+        sessionStorage.removeItem('stripe_selected_plan');
+        sessionStorage.removeItem('stripe_region_value');
+        sessionStorage.removeItem('stripe_region_label');
     }
 
     /**

--- a/apps/web-giddh/src/app/subscription/buy-plan/stripe-payment-dialog/stripe-payment-dialog.component.ts
+++ b/apps/web-giddh/src/app/subscription/buy-plan/stripe-payment-dialog/stripe-payment-dialog.component.ts
@@ -111,22 +111,36 @@ export class StripePaymentDialogComponent implements AfterViewInit, OnDestroy {
             this.error.set('Stripe client secret is missing.');
             return;
         }
-        this.loadStripeScript().then(() => {
-            try {
-                this.stripe = window['Stripe'](this.data.stripeKey);
-                const elements = this.stripe.elements({
-                    clientSecret: this.data.clientSecret,
-                    appearance: { theme: 'stripe' }
-                });
-                this.stripeElements = elements;
-                const paymentElement = elements.create('payment');
-                paymentElement.mount(this.stripePaymentElementRef.nativeElement);
-            } catch (err: any) {
-                this.error.set(err?.message || 'Failed to initialize Stripe.');
-            }
-        }).catch(() => {
-            this.error.set('Failed to load Stripe payment library.');
-        });
+        // Stripe.js is pre-loaded by the parent component before the dialog opens.
+        // If for some reason it is not available, fall back to dynamic loading.
+        if (window['Stripe']) {
+            this.mountStripeElement();
+        } else {
+            this.loadStripeScript().then(() => this.mountStripeElement()).catch(() => {
+                this.error.set('Failed to load Stripe payment library.');
+            });
+        }
+    }
+
+    /**
+     * Creates Stripe instance and mounts the payment element
+     *
+     * @private
+     * @memberof StripePaymentDialogComponent
+     */
+    private mountStripeElement(): void {
+        try {
+            this.stripe = window['Stripe'](this.data.stripeKey);
+            const elements = this.stripe.elements({
+                clientSecret: this.data.clientSecret,
+                appearance: { theme: 'stripe' }
+            });
+            this.stripeElements = elements;
+            const paymentElement = elements.create('payment');
+            paymentElement.mount(this.stripePaymentElementRef.nativeElement);
+        } catch (err: any) {
+            this.error.set(err?.message || 'Failed to initialize Stripe.');
+        }
     }
 
     /**


### PR DESCRIPTION
## **User description**
https://app.clickup.com/t/86d304a53
fix(sub): improve stripe failure recovery
- Pre-load stripe script for faster rendering
- Prevent overwriting restored plan selection
- Fix stepper navigation during restoration
- Add cleanup for stale stripe session data


___

## **CodeAnt-AI Description**
**Improve Stripe payment recovery and cleanup after failed checkout**

### What Changed
- Stripe payment loads sooner when the checkout dialog opens, so the payment form appears without waiting for the CDN in normal cases.
- Failed Stripe redirects now restore the selected plan, billing period, country, and payment method more reliably, and the checkout stepper returns to the correct step.
- Restored checkout values are no longer overwritten by default plan selection, which prevents the wrong plan or duration from showing after recovery.
- Stripe-related saved data is cleared after the redirect is handled, so old payment details are not reused on later visits.

### Impact
`✅ Faster payment form loading`
`✅ Fewer wrong-plan recoveries after Stripe failures`
`✅ Less stale checkout data after payment redirects`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved payment recovery when Stripe payment transactions fail or are interrupted
  * Enhanced reliability of Stripe payment dialog initialization and script loading
  * Strengthened session data cleanup after payment redirects to prevent stale payment information

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Walkover-Web-Solution/Giddh-New-Angular4-App/pull/16848?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->