### PR TITLE
Ankit | Test | HMRC connected text is coming on VAT report when HMRC details not present on whitelabel

### DIFF
--- a/apps/web-giddh/src/app/vat-report/obligations/obligations.component.html
+++ b/apps/web-giddh/src/app/vat-report/obligations/obligations.component.html
@@ -130,7 +130,7 @@
                         <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
                     </table>
                     <section *ngIf="!tableDataSource?.length">
-                        <div *ngIf="hasTaxNumber">
+                        <div *ngIf="hasTaxNumber && connectToHMRCUrl !== null">
                             <div *ngIf="connectToHMRCUrl || isTaxRestrictedModule" class="position-center position-absolute">
                                 <div class="text-center">
                                     <a [disabled]="isTaxRestrictedModule" matButton="filled" [href]="connectToHMRCUrl">

--- a/apps/web-giddh/src/app/vat-report/obligations/obligations.component.ts
+++ b/apps/web-giddh/src/app/vat-report/obligations/obligations.component.ts
@@ -70,7 +70,12 @@ export class ObligationsComponent implements OnInit, OnDestroy {
     public isLoading = signal<boolean>(false);
     /** This will hold the boolean value to open/close setting sidebar popup */
     public asideGstSidebarMenuState: boolean = true;
-    /** Hold HMRC portal url */
+    /**
+     * Holds HMRC portal url
+     * - null: initial state or API failure (button hidden)
+     * - value: user needs to connect (button enabled with "connect_to_hmrc")
+     * - empty string: already connected (button disabled with "connected_to_hmrc")
+     */
     public connectToHMRCUrl: string = null;
     /** Observable to store the Tax Number */
     public taxNumber$: Observable<any> = this.componentStore.select(state => state.taxNumber);
@@ -172,6 +177,7 @@ export class ObligationsComponent implements OnInit, OnDestroy {
                     this.connectToHMRCUrl = response.body;
                 } else {
                     this.getVatObligations();
+                    this.connectToHMRCUrl = "";
                 }
             }
         });

--- a/apps/web-giddh/src/app/vat-report/vat-liabilities-payments/vat-liabilities-payments.component.html
+++ b/apps/web-giddh/src/app/vat-report/vat-liabilities-payments/vat-liabilities-payments.component.html
@@ -170,7 +170,7 @@
                         <tr mat-header-row *matHeaderRowDef="displayColumns"></tr>
                         <tr mat-row *matRowDef="let row; columns: displayColumns"></tr>
                     </table>
-                    <div *ngIf="!dataSource().length && hasTaxNumber">
+                    <div *ngIf="!dataSource().length && hasTaxNumber && connectToHMRCUrl !== null">
                         <div *ngIf="connectToHMRCUrl || isTaxRestrictedModule" class="position-center position-absolute">
                             <div class="text-center">
                                 <a [disabled]="isTaxRestrictedModule" matButton="filled" [href]="connectToHMRCUrl">

--- a/apps/web-giddh/src/app/vat-report/vat-liabilities-payments/vat-liabilities-payments.component.ts
+++ b/apps/web-giddh/src/app/vat-report/vat-liabilities-payments/vat-liabilities-payments.component.ts
@@ -79,7 +79,12 @@ export class VatLiabilitiesPayments implements OnInit, OnDestroy {
     private currentBranch: any = {};
     /** Hold true in production environment */
     public isProdMode: boolean = environment.PRODUCTION_ENV;
-    /** Hold HMRC portal url */
+    /**
+     * Holds HMRC portal url
+     * - null: initial state or API failure (button hidden)
+     * - value: user needs to connect (button enabled with "connect_to_hmrc")
+     * - empty string: already connected (button disabled with "connected_to_hmrc")
+     */
     public connectToHMRCUrl: string = null;
     /** True if API Call is in progress */
     public isLoading = signal<boolean>(false);
@@ -192,6 +197,7 @@ export class VatLiabilitiesPayments implements OnInit, OnDestroy {
                     this.connectToHMRCUrl = response.body;
                 } else {
                     this.getLiabilitiesPayment();
+                    this.connectToHMRCUrl = "";
                 }
             }
         });

--- a/apps/web-giddh/src/app/vat-report/vat-report-filters/vat-report-filters.component.html
+++ b/apps/web-giddh/src/app/vat-report/vat-report-filters/vat-report-filters.component.html
@@ -96,16 +96,18 @@
             </button>
         </div>
         <div *ngIf="isUKCompany">
-            <div class="text-right">
-                <a matButton="filled" [href]="connectToHMRCUrl" [disabled]="!connectToHMRCUrl || isTaxRestrictedModule">
-                    <ng-container *ngIf="connectToHMRCUrl || isTaxRestrictedModule">
-                        {{ localeData?.connect_to_hmrc }}
-                    </ng-container>
-                    <ng-container *ngIf="!connectToHMRCUrl && !isTaxRestrictedModule">
-                        {{ localeData?.connected_to_hmrc }}
-                    </ng-container>
-                </a>
-            </div>
+            @if (connectToHMRCUrl !== null) {
+                <div class="text-right">
+                    <a matButton="filled" [href]="connectToHMRCUrl" [disabled]="!connectToHMRCUrl || isTaxRestrictedModule">
+                        <ng-container *ngIf="connectToHMRCUrl || isTaxRestrictedModule">
+                            {{ localeData?.connect_to_hmrc }}
+                        </ng-container>
+                        <ng-container *ngIf="!connectToHMRCUrl && !isTaxRestrictedModule">
+                            {{ localeData?.connected_to_hmrc }}
+                        </ng-container>
+                    </a>
+                </div>
+            }
             <restricted-module-message
                 [restrictedModule]="restrictedModules.TaxFilling"
                 (onUpgradePlan)="buyPlan($event)"

--- a/apps/web-giddh/src/app/vat-report/vat-report-filters/vat-report-filters.component.ts
+++ b/apps/web-giddh/src/app/vat-report/vat-report-filters/vat-report-filters.component.ts
@@ -56,7 +56,12 @@ export class VatReportFiltersComponent implements OnInit, OnChanges {
     @Input() public currentTaxAuthorityUniqueName: string = null;
     /** True if current Tax uniqueName is US */
     @Input() public currentTaxUniqueName: string = null;
-    /** Hold HMRC portal url */
+    /**
+     * Holds HMRC portal url
+     * - null: initial state or API failure (button hidden)
+     * - value: user needs to connect (button enabled with "connect_to_hmrc")
+     * - empty string: already connected (button disabled with "connected_to_hmrc")
+     */
     @Input() public connectToHMRCUrl: string = null;
     /** Holds Current Currency Code for Zimbabwe report */
     @Input() public vatReportCurrencyCode: 'BWP' | 'USD' | 'GBP' | 'INR' | 'EUR' = 'BWP';

--- a/apps/web-giddh/src/app/vat-report/vat-report.component.ts
+++ b/apps/web-giddh/src/app/vat-report/vat-report.component.ts
@@ -61,7 +61,12 @@ export class VatReportComponent implements OnInit, OnDestroy {
     public isKenyaCompany: boolean = false;
     /** True if api call in progress */
     public isLoading: boolean = false;
-    /** Hold HMRC portal url */
+    /**
+     * Holds HMRC portal url
+     * - null: initial state or API failure (button hidden)
+     * - value: user needs to connect (button enabled with "connect_to_hmrc")
+     * - empty string: already connected (button disabled with "connected_to_hmrc")
+     */
     public connectToHMRCUrl: string = null;
     /** Holds Current Currency Code for Zimbabwe report */
     public vatReportCurrencyCode: 'BWP' | 'USD' | 'GBP' | 'INR' | 'EUR' = 'BWP';
@@ -218,8 +223,12 @@ export class VatReportComponent implements OnInit, OnDestroy {
      */
     public getURLHMRCAuthorization(): void {
         this.vatService.getHMRCAuthorization(this.activeCompany.uniqueName).pipe(takeUntil(this.destroyed$)).subscribe((res) => {
-            if (res?.body) {
-                this.connectToHMRCUrl = res?.body;
+            if (res.status === 'success') {
+                if (res?.body) {
+                    this.connectToHMRCUrl = res?.body;
+                } else {
+                    this.connectToHMRCUrl = "";
+                }
             }
         })
     }


### PR DESCRIPTION
## **User description**
https://app.clickup.com/t/3687137/86d34dzmz


___

## **CodeAnt-AI Description**
**Hide the HMRC connect prompt until its status is known**

### What Changed
- The HMRC connect button is no longer shown while VAT pages are still loading or if the HMRC check fails
- When HMRC is already connected, the page now shows the connected state instead of briefly showing the connect prompt
- VAT report, obligations, payments, and filters all use the same hidden-until-ready behavior

### Impact
`✅ No premature HMRC connect prompt`
`✅ Clearer connected state`
`✅ Fewer confusing VAT page flashes`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined HMRC connection state handling in VAT reporting module with explicit null and empty-string semantics.
  * VAT report UI elements for HMRC connection now conditionally render based on proper connection state initialization.

* **Documentation**
  * Expanded inline documentation describing the three HMRC connection states (initial/failed, needs connection, and already connected) across multiple components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->