### PR TITLE
Ankit | Test | Test - Getting console error  - Cannot read properties of undefined (reading 'label') >>  other tax tab >> on create entry ledger page

### DIFF
--- a/apps/web-giddh/src/app/ledger/ledger.component.ts
+++ b/apps/web-giddh/src/app/ledger/ledger.component.ts
@@ -3536,12 +3536,8 @@ export class LedgerComponent implements OnInit, OnDestroy {
                 const parentGroups = data.body.parentGroups;
                 const isSundryDebtorCreditorGroup = parentGroups.includes(AccountingGroupEnum.SundryCreditors) || parentGroups.includes(AccountingGroupEnum.SundryDebtors);
                 let taxes = [];
-                let otherTax = {
-                    appliedOtherTax: {
-                        name: '',
-                        uniqueName: ''
-                    }
-                };
+                let otherTax = new SalesOtherTaxesModal();
+                
                 const accountApplicableTaxes = this.lc.activeAccount.applicableTaxes ?? [];
                 const accountOtherApplicableTaxes = this.lc.activeAccount.otherApplicableTaxes ?? [];
                 const applicableTaxesExcludingOtherTaxes = accountApplicableTaxes.filter(applicableTax =>
@@ -3563,19 +3559,15 @@ export class LedgerComponent implements OnInit, OnDestroy {
                                                     [],
                                                     data.body.oppositeAccount.taxes ?? [],
                                                     data.body.oppositeAccount.groupTaxes ?? []);
-                            otherTax = {
-                                appliedOtherTax: {
-                                    name: '',
-                                    uniqueName: stockAccountOtherTax.length ? stockAccountOtherTax[0] : ''
-                                }
+                            otherTax.appliedOtherTax = {
+                                name: '',
+                                uniqueName: stockAccountOtherTax.length ? stockAccountOtherTax[0] : ''
                             };
                         }
                         if (prioritizedApplicableTaxes.length && !otherTax['uniqueName']) {
-                            otherTax = {
-                                appliedOtherTax: {
-                                    name: prioritizedApplicableTaxes[0]?.name,
-                                    uniqueName: prioritizedApplicableTaxes[0]?.uniqueName
-                                }
+                            otherTax.appliedOtherTax = {
+                                name: prioritizedApplicableTaxes[0]?.name,
+                                uniqueName: prioritizedApplicableTaxes[0]?.uniqueName
                             };
                         }
                 } else {
@@ -3584,18 +3576,14 @@ export class LedgerComponent implements OnInit, OnDestroy {
                     const remainingBodyTaxes = data.body.taxes.filter(tax =>
                                     !data.body.groupTaxes.includes(tax));
                     if (remainingBodyTaxes.length) {
-                        otherTax = {
-                            appliedOtherTax: {
-                                name: '',
-                                uniqueName: remainingBodyTaxes[0]
-                            }
+                        otherTax.appliedOtherTax = {
+                            name: '',
+                            uniqueName: remainingBodyTaxes[0]
                         };
                     } else if (data.body.applicableTaxes.length) {
-                        otherTax = {
-                            appliedOtherTax: {
-                                name: data.body.applicableTaxes[0].name,
-                                uniqueName: data.body.applicableTaxes[0].uniqueName
-                            }
+                        otherTax.appliedOtherTax = {
+                            name: data.body.applicableTaxes[0].name,
+                            uniqueName: data.body.applicableTaxes[0].uniqueName
                         };
                     }
                 }


### PR DESCRIPTION
## **User description**
…esModal class instantiation and update all otherTax assignments to use appliedOtherTax property directly

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)



* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Other information**:


___

## **CodeAnt-AI Description**
**Fix missing tax selection when creating a ledger entry**

### What Changed
- Ledger entry creation now builds the “other tax” value safely, avoiding a console error when the tax label is missing
- Tax selection on the ledger page now keeps the chosen tax details intact across different account and stock tax combinations
- Other tax fields are filled from the available tax data instead of being recreated in an incomplete state

### Impact
`✅ Fewer ledger entry crashes`
`✅ Clearer tax selection on create entry`
`✅ Fewer console errors when opening the other tax tab`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tax selection behavior in the ledger details view to keep tax values consistent across account types.
  * Fixed cases where the selected tax could be missing or incorrect when loading ledger information, especially for debtor/creditor and stock-related entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->