### PR TITLE
Ankit | Test | QA :- Add "Import>Bank statement" option under Imports section

### DIFF
--- a/apps/web-giddh/src/app/import-excel/import-excel.module.ts
+++ b/apps/web-giddh/src/app/import-excel/import-excel.module.ts
@@ -22,6 +22,7 @@ import { FormFieldsModule } from '../theme/form-fields/form-fields.module';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { GiddhDatePipe } from '../shared/pipes/giddh-date.pipe';
 import { GoToBranchComponent } from '../shared/go-to-branch/go-to-branch.component';
+import { GenericAsideMenuAccountModule } from '../shared/generic-aside-menu-account/generic.aside.menu.account.module';
 
 @NgModule({
     declarations: [
@@ -54,7 +55,8 @@ import { GoToBranchComponent } from '../shared/go-to-branch/go-to-branch.compone
         MatCheckboxModule,
         HamburgerMenuModule,
         GiddhDatePipe,
-        GoToBranchComponent
+        GoToBranchComponent,
+        GenericAsideMenuAccountModule
     ],
 })
 export class ImportExcelModule {

--- a/apps/web-giddh/src/app/import-excel/import-type-select/import-type-select.component.html
+++ b/apps/web-giddh/src/app/import-excel/import-type-select/import-type-select.component.html
@@ -70,7 +70,11 @@
                     </ng-container>
                     @if (isBranch || branches?.length === 1) {
                         <li>
-                            <a class="theme-foreground-color h-100" [routerLink]="['/pages', 'import', 'banktransactions']">
+                            <a
+                                class="theme-foreground-color h-100"
+                                [routerLink]="['/pages', 'import', 'banktransactions']"
+                                [queryParams]="{ returnUrl: '/pages/import/select-type' }"
+                            >
                                 <img [src]="imgPath + 'import-bank-statement.png'" alt="bank statement" />
                                 <p>
                                     {{ commonLocaleData?.app_import_type?.bank_statement }}

--- a/apps/web-giddh/src/app/import-excel/import-type-select/import-type-select.component.html
+++ b/apps/web-giddh/src/app/import-excel/import-type-select/import-type-select.component.html
@@ -68,20 +68,18 @@
                             </a>
                         </li>
                     </ng-container>
-                    @if (isBranch || branches?.length === 1) {
-                        <li>
-                            <a
-                                class="theme-foreground-color h-100"
-                                [routerLink]="['/pages', 'import', 'banktransactions']"
-                                [queryParams]="{ returnUrl: '/pages/import/select-type' }"
-                            >
-                                <img [src]="imgPath + 'import-bank-statement.png'" alt="bank statement" />
-                                <p>
-                                    {{ commonLocaleData?.app_import_type?.bank_statement }}
-                                </p>
-                            </a>
-                        </li>
-                    }
+                    <li>
+                        <a
+                            class="theme-foreground-color h-100"
+                            [routerLink]="['/pages', 'import', 'banktransactions']"
+                            [queryParams]="{ returnUrl: '/pages/import/select-type' }"
+                        >
+                            <img [src]="imgPath + 'import-bank-statement.png'" alt="bank statement" />
+                            <p>
+                                {{ commonLocaleData?.app_import_type?.bank_statement }}
+                            </p>
+                        </a>
+                    </li>
                 </ul>
             </div>
         </div>

--- a/apps/web-giddh/src/app/import-excel/import-wizard/import-wizard.component.ts
+++ b/apps/web-giddh/src/app/import-excel/import-wizard/import-wizard.component.ts
@@ -26,6 +26,8 @@ export class ImportWizardComponent implements OnInit, OnDestroy {
     public isUploadInProgress: boolean = false;
     public excelState: ImportExcelState;
     public mappedData: ImportExcelResponseData;
+    /** Return URL */
+    public returnUrl: string;
     public UploadExceltableResponse: UploadExceltableResponse = {
         failureCount: 0,
         message: '',
@@ -92,6 +94,9 @@ export class ImportWizardComponent implements OnInit, OnDestroy {
 
     public ngOnInit() {
         this.activatedRoute.url.pipe(takeUntil(this.destroyed$)).subscribe(p => this.entity = p[0].path);
+        this.activatedRoute.queryParams.pipe(takeUntil(this.destroyed$)).subscribe(params => {
+            this.returnUrl = params['returnUrl'];
+        });
 
         const importStatusRequest: ImportExcelStatusPaginatedResponse = new ImportExcelStatusPaginatedResponse();
 
@@ -198,7 +203,7 @@ export class ImportWizardComponent implements OnInit, OnDestroy {
     }
 
     public onBack() {
-        if (this.entity === "banktransactions" && this.mappedData?.accountUniqueName) {
+        if (this.entity === "banktransactions" && this.mappedData?.accountUniqueName && this.returnUrl?.startsWith('/page/ledger')) {
             this.router.navigate(['/pages', 'ledger', this.mappedData.accountUniqueName]);
         } else {
             this.step.update(s => s - 1);

--- a/apps/web-giddh/src/app/import-excel/upload-file/upload-file.component.html
+++ b/apps/web-giddh/src/app/import-excel/upload-file/upload-file.component.html
@@ -9,7 +9,9 @@
                   (entity === voucherType.AccountWise
                       ? commonLocaleData?.app_import_type?.account_wise
                       : commonLocaleData?.app_import_type?.voucher_wise)
-                : (title | titlecase)
+                : entity === voucherType.BankStatement
+                  ? commonLocaleData?.app_import_type?.bank_statement
+                  : (title | titlecase)
         }}
     </p>
     <div
@@ -112,6 +114,8 @@
                     [placeholder]="commonLocaleData?.app_select_account"
                     [options]="accountSearchResponse$ | async"
                     [(ngModel)]="accountUniqueName"
+                    [showCreateNew]="true"
+                    (createOption)="createNewAccount()"
                     [labelValue]="accountLabel"
                     [enableDynamicSearch]="true"
                     [isPaginationEnabled]="true"
@@ -170,3 +174,14 @@
     </div>
 </div>
 <!-- upload And Map Content end-->
+
+<ng-template #accountAsideMenu>
+    <generic-aside-menu-account
+        (closeAsideEvent)="accountAsideMenuRef.close()"
+        [selectedGrpUniqueName]="'bankaccounts'"
+        [commonLocaleData]="commonLocaleData"
+        [isBankAccount]="true"
+        [isDebtorCreditor]="false"
+        (addEvent)="addNewAccount($event)"
+    ></generic-aside-menu-account>
+</ng-template>

--- a/apps/web-giddh/src/app/import-excel/upload-file/upload-file.component.ts
+++ b/apps/web-giddh/src/app/import-excel/upload-file/upload-file.component.ts
@@ -1,11 +1,12 @@
-import { Component, EventEmitter, Input, OnDestroy, OnInit, Output } from '@angular/core';
+import { Component, EventEmitter, Input, OnDestroy, OnInit, Output, ViewChild } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
+import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { select, Store } from '@ngrx/store';
 import { saveAs } from 'file-saver';
 import { BehaviorSubject, Observable, ReplaySubject, of } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { SettingsBranchActions } from '../../actions/settings/branch/settings.branch.action';
-import { API_BULK_FETCH_LIMIT, BranchHierarchyType, SAMPLE_FILES_URL, IOption } from '../../app.constant';
+import { API_BULK_FETCH_LIMIT, ASIDE_PANE_CONFIG, BranchHierarchyType, SAMPLE_FILES_URL, IOption } from '../../app.constant';
 import { OrganizationType } from '../../models/user-login-state';
 import { GeneralService } from '../../services/general.service';
 import { ToasterService } from '../../services/toaster.service';
@@ -17,6 +18,8 @@ import { LedgerService } from '../../services/ledger.service';
 import { ImportExcelService } from '../../services/import-excel.service';
 import { CommonActions } from '../../actions/common.actions';
 import { FileTypeEnum } from '../../shared/Enums/common.enum';
+import { GenericAsideMenuAccountComponent } from '../../shared/generic-aside-menu-account/generic.aside.menu.account.component';
+import { AccountsAction } from '../../actions/accounts.actions';
 
 @Component({
     selector: 'upload-file',
@@ -87,6 +90,12 @@ export class UploadFileComponent implements OnInit, OnDestroy {
     public selectedFileExtension: string = '';
     /** Same debit credit column toggle for bank statement */
     public sameDebitCreditAmountColumn: boolean = false;
+    /** Dialog reference for the account aside pane */
+    private accountAsideMenuRef: MatDialogRef<any>;
+    /** Template reference for account aside menu */
+    @ViewChild('accountAsideMenu') public accountAsideMenu: any;
+    /** Observable for account creation success */
+    private createAccountIsSuccess$: Observable<boolean>;
 
     constructor(
         private toasterService: ToasterService,
@@ -95,10 +104,12 @@ export class UploadFileComponent implements OnInit, OnDestroy {
         private store: Store<AppState>,
         private generalService: GeneralService,
         private router: Router,
-        private ledgerComponentStore: LedgerComponentStore, // Commented out due to missing import
+        private ledgerComponentStore: LedgerComponentStore,
         private ledgerService: LedgerService,
         private importExcelService: ImportExcelService,
-        private commonAction: CommonActions
+        private commonAction: CommonActions,
+        private dialog: MatDialog,
+        private accountsAction: AccountsAction
     ) {
 
     }
@@ -220,6 +231,14 @@ export class UploadFileComponent implements OnInit, OnDestroy {
 
                 this.accountSearchResponseSubject.next(newOptions);
                 this.accountSearchRequest.isLoading = false;
+            }
+        });
+
+        // Subscribe to account creation success to refresh account list
+        this.createAccountIsSuccess$ = this.store.pipe(select(state => state.groupwithaccounts.createAccountIsSuccess), takeUntil(this.destroyed$));
+        this.createAccountIsSuccess$.subscribe(response => {
+            if (response) {
+                this.searchAccount('', 1);
             }
         });
     }
@@ -373,5 +392,29 @@ export class UploadFileComponent implements OnInit, OnDestroy {
         if (this.defaultCount === this.accountSearchRequest.count) {
             this.searchAccount(this.accountSearchRequest.q, this.accountSearchRequest.page + 1);
         }
+    }
+
+    /**
+     * Opens the account creation dialog for creating a new bank account.
+     *
+     * @memberof UploadFileComponent
+     */
+    public createNewAccount(): void {
+        this.accountAsideMenuRef = this.dialog.open(this.accountAsideMenu, ASIDE_PANE_CONFIG);
+
+        this.accountAsideMenuRef.afterClosed().pipe(takeUntil(this.destroyed$)).subscribe(() => {
+            this.accountAsideMenuRef = undefined;
+        });
+    }
+
+    /**
+     * Handles the add event from the account aside menu.
+     *
+     * @param {AddAccountRequest} event
+     * @memberof UploadFileComponent
+     */
+    public addNewAccount(event: any): void {
+        this.store.dispatch(this.accountsAction.createAccountV2(event.activeGroupUniqueName, event.accountRequest));
+        this.accountAsideMenuRef.close();
     }
 }

--- a/apps/web-giddh/src/app/ledger/components/import-statement/import-statement.component.ts
+++ b/apps/web-giddh/src/app/ledger/components/import-statement/import-statement.component.ts
@@ -102,7 +102,9 @@ export class ImportStatementComponent implements OnDestroy {
                 this.store.dispatch(this.commonAction.setImportBankTransactionsResponse(importVoucherSuccessResponse));
                 this.toaster.showSnackBar("success", this.inputData?.localeData?.import_success);
                 this.dialogRef.close(true);
-                this.router.navigate(['pages', 'import', this.entity === ImportStatementType.BankTransactions ? ImportStatementType.BankTransactions : VoucherType.AccountWise]);
+                this.router.navigate(['pages', 'import', this.entity === ImportStatementType.BankTransactions ? ImportStatementType.BankTransactions : VoucherType.AccountWise], {
+                    queryParams: { returnUrl: this.inputData?.returnUrl }
+                });
             }
         });
     }
@@ -131,7 +133,9 @@ export class ImportStatementComponent implements OnDestroy {
                     this.store.dispatch(this.commonAction.setImportBankTransactionsResponse(response.body));
                     this.toaster.showSnackBar("success", this.inputData?.localeData?.import_success);
                     this.dialogRef.close(true);
-                    this.router.navigate(['/pages/import/banktransactions']);
+                    this.router.navigate(['/pages/import/banktransactions'], {
+                        queryParams: { returnUrl: this.inputData?.returnUrl }
+                    });
                 } else {
                     this.toaster.showSnackBar("error", response?.message, response?.code);
                 }

--- a/apps/web-giddh/src/app/ledger/ledger.component.ts
+++ b/apps/web-giddh/src/app/ledger/ledger.component.ts
@@ -1364,7 +1364,7 @@ export class LedgerComponent implements OnInit, OnDestroy {
         this.isHideBankLedgerPopup = true;
         this.ledgerService.getAccountSearchPrediction(this.trxRequest.accountUniqueName, requestModel).pipe(takeUntil(this.destroyed$)).subscribe(response => {
             if (response?.status === "success" && response?.body?.length > 0) {
-                let mappedTransactions = response?.body?.filter(transaction => transaction?.account !== null);
+                let mappedTransactions = response?.body?.filter(transaction => transaction?.account !== undefined && transaction?.account !== null);
                 if (mappedTransactions?.length > 0) {
                     mappedTransactions?.forEach(transaction => {
                         let matchedTransaction = bankTransactions?.filter(bankTransaction => bankTransaction.transactionId === transaction?.uniqueName);
@@ -3073,7 +3073,8 @@ export class LedgerComponent implements OnInit, OnDestroy {
             data: {
                 accountUniqueName: this.lc.accountUnq,
                 localeData: this.localeData,
-                commonLocaleData: this.commonLocaleData
+                commonLocaleData: this.commonLocaleData,
+                returnUrl: this.router.url
             },
             role: 'alertdialog',
             ariaLabel: 'import',

--- a/apps/web-giddh/src/app/shared/header/header.component.html
+++ b/apps/web-giddh/src/app/shared/header/header.component.html
@@ -586,6 +586,7 @@
             subscribedPlan !== undefined &&
             subscribedPlan?.status === 'active' &&
             showAdvancePayment &&
+            remainingSubscriptionDays > 0 &&
             (((subscribedPlan?.duration === 'MONTHLY' || subscribedPlan?.duration === 'DAILY') && remainingSubscriptionDays <= 7) ||
                 (subscribedPlan?.duration === 'YEARLY' && remainingSubscriptionDays <= 30))
         "


### PR DESCRIPTION
## **User description**
https://app.clickup.com/t/3687137/86d3m6y6e


___

## **CodeAnt-AI Description**
**Add bank account creation and return navigation in the bank statement import flow**

### What Changed
- Bank statement imports now let users create a new bank account directly from the account picker and continue without leaving the import flow
- After creating an account, the account list refreshes so the new account can be selected right away
- The import flow now keeps track of where the user came from, and the back action returns to the ledger only when the import was opened from there
- The bank statement import entry point now passes the return destination through the flow so users can get back to the import type screen after finishing
- The prepaid renewal notice no longer appears when there are no subscription days left

### Impact
`✅ Shorter bank statement setup`
`✅ Fewer exits from the import flow`
`✅ Faster account selection after creating a new bank account`
`✅ Fewer renewal notices for expired subscriptions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bank statement imports now support creating a new account directly from the account selector.
  * Import flows now preserve your place when moving between related import screens.

* **Bug Fixes**
  * Improved return navigation after importing statements or vouchers.
  * Bank transaction matching now avoids incorrect matches when account data is missing.
  * Prepaid renewal alerts now appear only when there are remaining subscription days.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->