### PR TITLE
Ankit | Test | UI : Export support in sales/purchase register with all filters like sales person, country and state (both overview and detailed)

### DIFF
--- a/apps/web-giddh/src/app/models/api-models/DaybookRequest.ts
+++ b/apps/web-giddh/src/app/models/api-models/DaybookRequest.ts
@@ -45,6 +45,12 @@ export class ExportBodyRequest {
     showInAccountCurrency?: boolean;
     ledgerAdvanceFilter?: any;
     type?: string;
+    groupBy?: string;
+    selectAll?: boolean;
+    accountUniqueNames?: string[];
+    salesPersonUniqueNames?: string[];
+    countryCodes?: string[];
+    stateCodes?: string[];
 }
 
 export interface DayBookRequestModel {

--- a/apps/web-giddh/src/app/new-inventory/component/stock-aging-report/stock-aging-report.component.ts
+++ b/apps/web-giddh/src/app/new-inventory/component/stock-aging-report/stock-aging-report.component.ts
@@ -238,7 +238,6 @@ export class StockAgingReportComponent implements OnInit, OnDestroy {
     public ngOnInit(): void {
         this.refreshLayoutCaches();
         this.isCompany = this.generalService.currentOrganizationType !== OrganizationType.Branch;
-        this.loadBranchesAndWarehouses();
         this.getProfile();
         // Route param `:category` drives the stock category filter for this
         // report (e.g. product, service, fixedassets, all).
@@ -247,7 +246,7 @@ export class StockAgingReportComponent implements OnInit, OnDestroy {
         // category-scoped data — it fires on initial navigation AND on any
         // subsequent category change.
         this.route.params.pipe(takeUntil(this.destroyed$)).subscribe(params => {
-            const category = params['category']?.toUpperCase() || '';
+            const category = params['category'] == 'fixedassets' ? 'FIXED_ASSETS' : params['category']?.toUpperCase() || '';
             if (category === this.selectedStockCategory) {
                 return;
             }
@@ -261,8 +260,7 @@ export class StockAgingReportComponent implements OnInit, OnDestroy {
             this.showStockNameSearchInput = false;
             this.refreshLayoutCaches();
             this.loadStockGroups();
-            this.getReport();
-            this.getReportTotals();
+            this.loadBranchesAndWarehouses();
         });
 
         // Local search filtering for the branch dropdown
@@ -353,6 +351,8 @@ export class StockAgingReportComponent implements OnInit, OnDestroy {
                 this.allBranches = response.body?.results?.filter((branch: any) => branch?.isCompany !== true) ?? [];
                 this.branches = [...this.allBranches];
             }
+            this.getReport();
+            this.getReportTotals();
             this.recomputeWarehouses();
             this.cdr.detectChanges();
         });
@@ -490,7 +490,7 @@ export class StockAgingReportComponent implements OnInit, OnDestroy {
     public getReport(): void {
         this.isLoading = true;
         const payload: any = {
-            branchUniqueNames: (this.isCompany && this.allBranches?.length > 1) ? this.selectedBranch : [this.generalService.currentBranchUniqueName],
+            branchUniqueNames: (this.isCompany && this.allBranches?.length > 1) ? (this.selectedBranch ?? []).filter(Boolean) : [this.generalService.currentBranchUniqueName],
             warehouseUniqueNames: this.selectedWarehouse,
             stockGroupUniqueNames: this.selectedStockGroup,
             searchText: this.searchText,
@@ -540,7 +540,7 @@ export class StockAgingReportComponent implements OnInit, OnDestroy {
      */
     public getReportTotals(): void {
         const payload: any = {
-            branchUniqueNames: (this.isCompany && this.allBranches?.length > 1) ? this.selectedBranch : [this.generalService.currentBranchUniqueName],
+            branchUniqueNames: (this.isCompany && this.allBranches?.length > 1) ? (this.selectedBranch ?? []).filter(Boolean) : [this.generalService.currentBranchUniqueName],
             warehouseUniqueNames: this.selectedWarehouse,
             stockGroupUniqueNames: this.selectedStockGroup,
             categoryUniqueNames: [this.selectedStockCategory]

--- a/apps/web-giddh/src/app/reports/components/purchase-register-component/purchase.register.component.ts
+++ b/apps/web-giddh/src/app/reports/components/purchase-register-component/purchase.register.component.ts
@@ -119,6 +119,13 @@ export class PurchaseRegisterComponent implements OnInit, OnDestroy {
     public filteredStateList = signal<IOption[]>([]);
     /** Filtered Sales Person List */
     public filteredSalesPersonList = signal<IOption[]>([]);
+    /** Complete option lists used to determine when all items are effectively selected (selectAll) */
+    public allOptions: { salesPerson: IOption[]; country: IOption[]; state: IOption[]; account: any[] } = {
+        salesPerson: [],
+        country: [],
+        state: [],
+        account: []
+    };
     /** Group by enum */
     public groupByEnum: typeof GroupBy = GroupBy;
     /** Date range */
@@ -148,7 +155,7 @@ export class PurchaseRegisterComponent implements OnInit, OnDestroy {
     /* Selected range label */
     public selectedRangeLabel: any = "";
     /** Supported groupBy values for export functionality */
-    public supportedExportGroupBy = signal<GroupBy[]>([GroupBy.Duration]);
+    public supportedExportGroupBy = signal<GroupBy[]>([GroupBy.Duration, GroupBy.SalesPerson, GroupBy.Country, GroupBy.State]);
     /** Current groupBy value selected in the report form */
     public currentGroupBy = signal<GroupBy>(GroupBy.Duration);
     /** Computed signal that determines if export button should be visible based on current groupBy */
@@ -258,7 +265,12 @@ constructor(
 
         this.getSalesPersonList();
         this.salesPersonList$.pipe(skip(1), take(1), filter(Boolean)).subscribe(res => {
+            this.allOptions.salesPerson = (res as IOption[]) ?? [];
             this.filteredSalesPersonList.set(res as IOption[]);
+        });
+
+        this.accountList$.pipe(takeUntil(this.destroyed$)).subscribe((res: any) => {
+            this.allOptions.account = res?.results ?? res ?? [];
         });
 
         /** Search for sales person dropdown */
@@ -318,6 +330,7 @@ constructor(
                     label: state.name,
                     value: state.code
                 })));
+                this.allOptions.state = this.stateList();
                 this.filteredStateList.set(this.stateList());
             }
         });
@@ -727,11 +740,67 @@ constructor(
     }
 
     /**
+     * Applies the current groupBy specific filters to the overview export request.
+     *
+     * @private
+     * @param {ExportBodyRequest} exportBodyRequest Export payload to be mutated.
+     * @memberof PurchaseRegisterComponent
+     */
+    private applyOverviewGroupByFilters(exportBodyRequest: ExportBodyRequest): void {
+        const groupBy = this.currentGroupBy();
+        const accountUniqueNames = this.reportForm?.get('accountUniqueNames')?.value ?? [];
+        const salesPersonUniqueNames = this.reportForm?.get('salesPersonUniqueNames')?.value ?? [];
+        const countryCodes = this.reportForm?.get('countryCodes')?.value ?? [];
+        const stateCodes = this.reportForm?.get('stateCodes')?.value ?? [];
+
+        
+        exportBodyRequest.groupBy = groupBy;
+        
+        const isAllAccounts = this.isAllSelected(accountUniqueNames, this.allOptions.account?.length);
+        exportBodyRequest.accountUniqueNames = isAllAccounts ? [] : accountUniqueNames;
+        
+        if (groupBy === GroupBy.Duration) {
+            exportBodyRequest.interval = this.interval;
+        } else if (groupBy === GroupBy.SalesPerson) {
+            const isAllSalesPerson = this.isAllSelected(salesPersonUniqueNames, this.allOptions.salesPerson?.length);
+            exportBodyRequest.salesPersonUniqueNames = isAllSalesPerson ? [] : salesPersonUniqueNames;
+            exportBodyRequest.selectAll = isAllSalesPerson || isAllAccounts;
+        } else if (groupBy === GroupBy.Country) {
+            const isAllCountries = this.isAllSelected(countryCodes, this.allOptions.country?.length);
+            exportBodyRequest.countryCodes = isAllCountries ? [] : countryCodes;
+            exportBodyRequest.selectAll = isAllCountries || isAllAccounts;
+        } else if (groupBy === GroupBy.State) {
+            const isAllStates = this.isAllSelected(stateCodes, this.allOptions.state?.length);
+            const countryCode = this.reportForm?.get('countryCode')?.value;
+            exportBodyRequest.stateCodes = isAllStates ? [] : stateCodes;
+            exportBodyRequest.countryCodes = countryCode ? [countryCode] : [];
+            exportBodyRequest.selectAll = isAllStates || isAllAccounts;
+        }
+    }
+
+    /**
+     * Determines whether a multi-select filter effectively represents "select all".
+     * Returns true when nothing is selected (default = all) or when every available option is selected.
+     *
+     * @private
+     * @param {any[]} selected Currently selected values
+     * @param {number} total Total number of available options
+     * @returns {boolean}
+     * @memberof PurchaseRegisterComponent
+     */
+    private isAllSelected(selected: any[], total: number): boolean {
+        const selectedCount = selected?.length ?? 0;
+        const totalCount = total ?? 0;
+        return selectedCount === 0 || selectedCount === totalCount;
+    }
+
+    /**
      * Exports purchase register overview report
      *
      * @memberof PurchaseRegisterComponent
      */
     public export(): void {
+        const groupBy = this.currentGroupBy();
         let startDate = this.activeFinacialYr?.financialYearStarts?.toString();
         let endDate = this.activeFinacialYr?.financialYearEnds?.toString();
         if (this.selectedMonth) {
@@ -739,14 +808,18 @@ constructor(
             startDate = startEndDate.firstDay;
             endDate = startEndDate.lastDay;
         }
+        if (groupBy && groupBy !== GroupBy.Duration && this.dateRange?.from && this.dateRange?.to) {
+            startDate = this.dateRange.from;
+            endDate = this.dateRange.to;
+        }
 
         let exportBodyRequest: ExportBodyRequest = new ExportBodyRequest();
         exportBodyRequest.from = startDate;
         exportBodyRequest.to = endDate;
         exportBodyRequest.exportType = "PURCHASE_REGISTER_OVERVIEW_EXPORT";
         exportBodyRequest.fileType = "CSV";
-        exportBodyRequest.interval = this.interval;
         exportBodyRequest.branchUniqueName = this.currentBranch?.uniqueName;
+        this.applyOverviewGroupByFilters(exportBodyRequest);
         this.ledgerService.exportData(exportBodyRequest).pipe(takeUntil(this.destroyed$)).subscribe(response => {
             if (response?.status === 'success') {
                 this._toaster.successToast(response?.body);
@@ -1002,6 +1075,7 @@ constructor(
                     label: country.countryName || country.name,
                     value: country.alpha2CountryCode || country.code
                 })));
+                this.allOptions.country = this.countryList();
                 this.filteredCountryList.set(this.countryList());
             }
         });

--- a/apps/web-giddh/src/app/reports/components/purchase-register-expand-component/purchase.register.expand.component.ts
+++ b/apps/web-giddh/src/app/reports/components/purchase-register-expand-component/purchase.register.expand.component.ts
@@ -93,7 +93,7 @@ export class PurchaseRegisterExpandComponent implements OnInit, OnDestroy {
     /** Holds page size options for pagination */
     public pageSizeOptions: number[] = PAGE_SIZE_OPTIONS;
     /** Supported groupBy values for export functionality */
-    public supportedExportGroupBy = signal<GroupBy[]>([GroupBy.Duration]);
+    public supportedExportGroupBy = signal<GroupBy[]>([GroupBy.Duration, GroupBy.SalesPerson, GroupBy.Country, GroupBy.State]);
     /** Current groupBy value selected in the report form */
     public currentGroupBy = signal<GroupBy | null>(null);
     /** Computed signal that determines if export button should be visible based on current groupBy */
@@ -516,7 +516,13 @@ export class PurchaseRegisterExpandComponent implements OnInit, OnDestroy {
      * @memberof PurchaseRegisterExpandComponent
      */
     public export(): void {
-        let exportData = {
+        const groupBy = this.currentGroupBy();
+        const salesPersonUniqueName = this.getDetailedPurchaseRequestFilter?.salesPersonUniqueName;
+        const countryCode = this.getDetailedPurchaseRequestFilter?.countryCode;
+        const stateCode = this.getDetailedPurchaseRequestFilter?.stateCode;
+        const accountUniqueNames = this.getDetailedPurchaseRequestFilter?.accountUniqueNames ?? [];
+
+        let exportData: any = {
             from: this.from,
             to: this.to,
             exportType: "PURCHASE_REGISTER_DETAILED_EXPORT",
@@ -526,7 +532,12 @@ export class PurchaseRegisterExpandComponent implements OnInit, OnDestroy {
             branchUniqueName: this.getDetailedPurchaseRequestFilter?.branchUniqueName,
             commonLocaleData: this.commonLocaleData,
             localeData: this.localeData,
-            activeCompanyCountryCode: this.activeCompanyCountryCode
+            activeCompanyCountryCode: this.activeCompanyCountryCode,
+            groupBy: groupBy,
+            accountUniqueNames: accountUniqueNames,
+            salesPersonUniqueNames: groupBy === GroupBy.SalesPerson && salesPersonUniqueName ? [salesPersonUniqueName] : [],
+            countryCodes: (groupBy === GroupBy.Country || groupBy === GroupBy.State) && countryCode ? [countryCode] : [],
+            stateCodes: groupBy === GroupBy.State && stateCode ? [stateCode] : []
         };
         this.dialog.open(SalesPurchaseRegisterExportComponent, {
                     width: "630px",

--- a/apps/web-giddh/src/app/reports/components/report-details-components/report.details.component.ts
+++ b/apps/web-giddh/src/app/reports/components/report-details-components/report.details.component.ts
@@ -117,6 +117,13 @@ export class ReportsDetailsComponent implements OnInit, OnDestroy {
     public filteredStateList = signal<IOption[]>([]);
     /** Filtered Sales Person List */
     public filteredSalesPersonList = signal<IOption[]>([]);
+    /** Complete option lists used to determine when all items are effectively selected (selectAll) */
+    public allOptions: { salesPerson: IOption[]; country: IOption[]; state: IOption[]; account: any[] } = {
+        salesPerson: [],
+        country: [],
+        state: [],
+        account: []
+    };
     /** Group by enum */
     public groupByEnum: typeof GroupBy = GroupBy;
     /** Date range */
@@ -146,7 +153,7 @@ export class ReportsDetailsComponent implements OnInit, OnDestroy {
     /* Selected range label */
     public selectedRangeLabel: any = "";
     /** Supported groupBy values for export functionality */
-    public supportedExportGroupBy = signal<GroupBy[]>([GroupBy.Duration]);
+    public supportedExportGroupBy = signal<GroupBy[]>([GroupBy.Duration, GroupBy.SalesPerson, GroupBy.Country, GroupBy.State]);
     /** Current groupBy value selected in the report form */
     public currentGroupBy = signal<GroupBy>(GroupBy.Duration);
     /** Computed signal that determines if export button should be visible based on current groupBy */
@@ -255,7 +262,12 @@ constructor(
 
         this.getSalesPersonList();
         this.salesPersonList$.pipe(skip(1), take(1), filter(Boolean)).subscribe(res => {
+            this.allOptions.salesPerson = (res as IOption[]) ?? [];
             this.filteredSalesPersonList.set(res as IOption[]);
+        });
+
+        this.accountList$.pipe(takeUntil(this.destroyed$)).subscribe((res: any) => {
+            this.allOptions.account = res?.results ?? res ?? [];
         });
 
         /** Search for sales person dropdown */
@@ -308,6 +320,7 @@ constructor(
                     label: state.name,
                     value: state.code
                 })));
+                this.allOptions.state = this.stateList();
                 this.filteredStateList.set(this.stateList());
             }
         });
@@ -745,11 +758,67 @@ constructor(
     }
 
     /**
+     * Applies the current groupBy specific filters to the overview export request.
+     *
+     * @private
+     * @param {ExportBodyRequest} exportBodyRequest Export payload to be mutated.
+     * @memberof ReportsDetailsComponent
+     */
+    private applyOverviewGroupByFilters(exportBodyRequest: ExportBodyRequest): void {
+        const groupBy = this.currentGroupBy();
+        const accountUniqueNames = this.reportForm?.get('accountUniqueNames')?.value ?? [];
+        const salesPersonUniqueNames = this.reportForm?.get('salesPersonUniqueNames')?.value ?? [];
+        const countryCodes = this.reportForm?.get('countryCodes')?.value ?? [];
+        const stateCodes = this.reportForm?.get('stateCodes')?.value ?? [];
+
+        
+        exportBodyRequest.groupBy = groupBy;
+        
+        const isAllAccounts = this.isAllSelected(accountUniqueNames, this.allOptions.account?.length);
+        exportBodyRequest.accountUniqueNames = isAllAccounts ? [] : accountUniqueNames;
+        
+        if (groupBy === GroupBy.Duration) {
+            exportBodyRequest.interval = this.interval;
+        } else if (groupBy === GroupBy.SalesPerson) {
+            const isAllSalesPerson = this.isAllSelected(salesPersonUniqueNames, this.allOptions.salesPerson?.length);
+            exportBodyRequest.salesPersonUniqueNames = isAllSalesPerson ? [] : salesPersonUniqueNames;
+            exportBodyRequest.selectAll = isAllSalesPerson || isAllAccounts;
+        } else if (groupBy === GroupBy.Country) {
+            const isAllCountries = this.isAllSelected(countryCodes, this.allOptions.country?.length);
+            exportBodyRequest.countryCodes = isAllCountries ? [] : countryCodes;
+            exportBodyRequest.selectAll = isAllCountries || isAllAccounts;
+        } else if (groupBy === GroupBy.State) {
+            const isAllStates = this.isAllSelected(stateCodes, this.allOptions.state?.length);
+            const countryCode = this.reportForm?.get('countryCode')?.value;
+            exportBodyRequest.stateCodes = isAllStates ? [] : stateCodes;
+            exportBodyRequest.countryCodes = countryCode ? [countryCode] : [];
+            exportBodyRequest.selectAll = isAllStates || isAllAccounts;
+        }
+    }
+
+    /**
+     * Determines whether a multi-select filter effectively represents "select all".
+     * Returns true when nothing is selected (default = all) or when every available option is selected.
+     *
+     * @private
+     * @param {any[]} selected Currently selected values
+     * @param {number} total Total number of available options
+     * @returns {boolean}
+     * @memberof ReportsDetailsComponent
+     */
+    private isAllSelected(selected: any[], total: number): boolean {
+        const selectedCount = selected?.length ?? 0;
+        const totalCount = total ?? 0;
+        return selectedCount === 0 || selectedCount === totalCount;
+    }
+
+    /**
      * Exports sales register overview report
      *
      * @memberof ReportsDetailsComponent
      */
     public export(): void {
+        const groupBy = this.currentGroupBy();
         let startDate = this.activeFinacialYr?.financialYearStarts?.toString();
         let endDate = this.activeFinacialYr?.financialYearEnds?.toString();
         if (this.selectedMonth) {
@@ -757,14 +826,18 @@ constructor(
             startDate = startEndDate.firstDay;
             endDate = startEndDate.lastDay;
         }
+        if (groupBy && groupBy !== GroupBy.Duration && this.dateRange?.from && this.dateRange?.to) {
+            startDate = this.dateRange.from;
+            endDate = this.dateRange.to;
+        }
 
         let exportBodyRequest: ExportBodyRequest = new ExportBodyRequest();
         exportBodyRequest.from = startDate;
         exportBodyRequest.to = endDate;
         exportBodyRequest.exportType = "SALES_REGISTER_OVERVIEW_EXPORT";
         exportBodyRequest.fileType = "CSV";
-        exportBodyRequest.interval = this.interval;
         exportBodyRequest.branchUniqueName = this.currentBranch?.uniqueName;
+        this.applyOverviewGroupByFilters(exportBodyRequest);
         this.ledgerService.exportData(exportBodyRequest).pipe(takeUntil(this.destroyed$)).subscribe(response => {
             if (response?.status === 'success') {
                 this._toaster.successToast(response?.body);
@@ -1012,6 +1085,7 @@ constructor(
                     label: country.countryName || country.name,
                     value: country.alpha2CountryCode || country.code
                 })));
+                this.allOptions.country = this.countryList();
                 this.filteredCountryList.set(this.countryList());
             }
         });

--- a/apps/web-giddh/src/app/reports/components/sales-register-expand-component/sales.register.expand.component.ts
+++ b/apps/web-giddh/src/app/reports/components/sales-register-expand-component/sales.register.expand.component.ts
@@ -95,7 +95,7 @@ public voucherNumberInput: UntypedFormControl = new UntypedFormControl();
     /** Holds page size options for pagination */
     public pageSizeOptions: number[] = PAGE_SIZE_OPTIONS;
     /** Supported groupBy values for export functionality */
-    public supportedExportGroupBy = signal<GroupBy[]>([GroupBy.Duration]);
+    public supportedExportGroupBy = signal<GroupBy[]>([GroupBy.Duration, GroupBy.SalesPerson, GroupBy.Country, GroupBy.State]);
     /** Current groupBy value selected in the report form */
     public currentGroupBy = signal<GroupBy | null>(null);
     /** Computed signal that determines if export button should be visible based on current groupBy */
@@ -479,7 +479,13 @@ public voucherNumberInput: UntypedFormControl = new UntypedFormControl();
      * @memberof SalesRegisterExpandComponent
      */
     public export(): void {
-        let exportData = {
+        const groupBy = this.currentGroupBy();
+        const salesPersonUniqueName = this.getDetailedsalesRequestFilter?.salesPersonUniqueName;
+        const countryCode = this.getDetailedsalesRequestFilter?.countryCode;
+        const stateCode = this.getDetailedsalesRequestFilter?.stateCode;
+        const accountUniqueNames = this.getDetailedsalesRequestFilter?.accountUniqueNames ?? [];
+
+        let exportData: any = {
             from: this.from,
             to: this.to,
             exportType: "SALES_REGISTER_DETAILED_EXPORT",
@@ -489,7 +495,12 @@ public voucherNumberInput: UntypedFormControl = new UntypedFormControl();
             branchUniqueName: this.getDetailedsalesRequestFilter?.branchUniqueName,
             commonLocaleData: this.commonLocaleData,
             localeData: this.localeData,
-            activeCompanyCountryCode: this.activeCompanyCountryCode
+            activeCompanyCountryCode: this.activeCompanyCountryCode,
+            groupBy: groupBy && groupBy !== GroupBy.Duration ? groupBy : undefined,
+            accountUniqueNames: accountUniqueNames,
+            salesPersonUniqueNames: groupBy === GroupBy.SalesPerson && salesPersonUniqueName ? [salesPersonUniqueName] : [],
+            countryCodes: (groupBy === GroupBy.Country || groupBy === GroupBy.State) && countryCode ? [countryCode] : [],
+            stateCodes: groupBy === GroupBy.State && stateCode ? [stateCode] : []
         }
         this.dialog.open(SalesPurchaseRegisterExportComponent, {
                     width: '630px',

--- a/apps/web-giddh/src/app/reports/sales-purchase-register-export/sales-purchase-register-export.component.ts
+++ b/apps/web-giddh/src/app/reports/sales-purchase-register-export/sales-purchase-register-export.component.ts
@@ -95,6 +95,21 @@ export class SalesPurchaseRegisterExportComponent implements OnInit {
         exportBodyRequest.isExpanded = this.inputData?.expand;
         exportBodyRequest.q = this.inputData?.q;
         exportBodyRequest.branchUniqueName = this.inputData?.branchUniqueName;
+        if (this.inputData?.groupBy) {
+            exportBodyRequest.groupBy = this.inputData.groupBy;
+        }
+        if (this.inputData?.accountUniqueNames?.length) {
+            exportBodyRequest.accountUniqueNames = this.inputData.accountUniqueNames;
+        }
+        if (this.inputData?.salesPersonUniqueNames?.length) {
+            exportBodyRequest.salesPersonUniqueNames = this.inputData.salesPersonUniqueNames;
+        }
+        if (this.inputData?.countryCodes?.length) {
+            exportBodyRequest.countryCodes = this.inputData.countryCodes;
+        }
+        if (this.inputData?.stateCodes?.length) {
+            exportBodyRequest.stateCodes = this.inputData.stateCodes;
+        }
         exportBodyRequest.columnsToExport = ["Account UniqueName"];
         if (this.exportForm.value.showVoucherType) {
             exportBodyRequest.columnsToExport.push("Voucher Type");


### PR DESCRIPTION
## **User description**
https://app.clickup.com/t/3687137/86d3w99qq


___

## **CodeAnt-AI Description**
Support filtered sales and purchase register exports and fix stock aging report loading

### What Changed
- Sales and purchase register exports now support grouping and filtering by salesperson, account, country, and state in both overview and detailed reports.
- Exports correctly handle “all” selections and use the chosen date range for grouped reports.
- Stock aging reports now load branch and warehouse data before fetching results, recognize the fixed-assets category, and ignore empty branch filters.

### Impact
`✅ Filtered sales and purchase CSV exports`
`✅ Grouped exports by salesperson, country, or state`
`✅ Correct stock aging results for fixed assets and branch filters`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded sales and purchase register exports with grouping by duration, salesperson, country, or state.
  * Added export filtering by accounts, salespeople, countries, and states, including select-all handling.
  * Export requests now preserve selected grouping and date ranges.
* **Bug Fixes**
  * Improved stock aging report loading for branches, warehouses, and fixed assets.
  * Prevented invalid or empty branch selections from affecting report results.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->