### PR TITLE
Ankit | Test | QA - Support of Arabic language in template for UAE companies.

### DIFF
--- a/apps/web-giddh/src/app/ledger/components/new-ledger-entry-panel/new-ledger-entry-panel.component.ts
+++ b/apps/web-giddh/src/app/ledger/components/new-ledger-entry-panel/new-ledger-entry-panel.component.ts
@@ -545,6 +545,7 @@ export class NewLedgerEntryPanelComponent implements OnInit, OnDestroy, OnChange
     }
 
     public ngOnChanges(changes: SimpleChanges): void {
+        console.log(this.currentTxn);
         if (changes?.currentTxn?.currentValue?.selectedAccount) {
             this.currentTxn.taxInclusiveAmount = giddhRoundOff(this.currentTxn.amount, this.giddhBalanceDecimalPlaces);
             if (!this.currentTxn?.isStock) {

--- a/apps/web-giddh/src/app/ledger/components/new-ledger-entry-panel/new-ledger-entry-panel.component.ts
+++ b/apps/web-giddh/src/app/ledger/components/new-ledger-entry-panel/new-ledger-entry-panel.component.ts
@@ -545,7 +545,6 @@ export class NewLedgerEntryPanelComponent implements OnInit, OnDestroy, OnChange
     }
 
     public ngOnChanges(changes: SimpleChanges): void {
-        console.log(this.currentTxn);
         if (changes?.currentTxn?.currentValue?.selectedAccount) {
             this.currentTxn.taxInclusiveAmount = giddhRoundOff(this.currentTxn.amount, this.giddhBalanceDecimalPlaces);
             if (!this.currentTxn?.isStock) {

--- a/apps/web-giddh/src/app/ledger/components/update-ledger-entry-panel/update-ledger-entry-panel.component.ts
+++ b/apps/web-giddh/src/app/ledger/components/update-ledger-entry-panel/update-ledger-entry-panel.component.ts
@@ -2953,6 +2953,8 @@ export class UpdateLedgerEntryPanelComponent implements OnInit, AfterViewInit, O
      * @memberof UpdateLedgerEntryPanelComponent
      */
     public duplicateEntry(): void {
+        this.openAndCloseDiscountDropdown(false);
+        this.openAndCloseTaxDropdown(false);
         this.closeUpdateLedgerModal.emit({
             transactionDetails: this.transactionDetails
         });

--- a/apps/web-giddh/src/app/ledger/ledger.component.ts
+++ b/apps/web-giddh/src/app/ledger/ledger.component.ts
@@ -3684,7 +3684,7 @@ export class LedgerComponent implements OnInit, OnDestroy {
                     value: event?.value,
                     isHilighted: true,
                     applicableTaxes: txn.duplicateEntry ? [] : taxes,
-                    otherTax: otherTax,
+                    otherTax: txn?.duplicateEntry ? txn.selectedAccount?.otherTax : otherTax,
                     currency: data.body.currency,
                     currencySymbol: data.body.currencySymbol,
                     email: data.body.emails,
@@ -3697,14 +3697,16 @@ export class LedgerComponent implements OnInit, OnDestroy {
                     accountApplicableDiscounts: txn.duplicateEntry ? txn?.discounts : data.body.applicableDiscounts,
                     parentGroups: event.additional?.stock ? data.body.oppositeAccount.parentGroups : data.body.parentGroups, // added due to parentGroups is getting null in search API
                 };
-                this.lc.blankLedger.otherTaxModal = {
-                    ...this.lc.blankLedger.otherTaxModal,
-                    appliedOtherTax: {
-                        name: otherTax?.appliedOtherTax?.name,
-                        uniqueName: otherTax?.appliedOtherTax?.uniqueName
-                    }
-                };
-                this.lc.blankLedger.isOtherTaxesApplicable = !!otherTax?.appliedOtherTax?.uniqueName;
+                if (!txn?.duplicateEntry) {
+                    this.lc.blankLedger.otherTaxModal = {
+                        ...this.lc.blankLedger.otherTaxModal,
+                        appliedOtherTax: {
+                            name: otherTax?.appliedOtherTax?.name,
+                            uniqueName: otherTax?.appliedOtherTax?.uniqueName
+                        }
+                    };
+                    this.lc.blankLedger.isOtherTaxesApplicable = !!otherTax?.appliedOtherTax?.uniqueName;
+                }
                 if (txn?.selectedAccount && txn.selectedAccount.stock) {
                     txn.selectedAccount.stock.rate = Number((txn.selectedAccount.stock.rate / this.lc.blankLedger?.exchangeRate).toFixed(RATE_FIELD_PRECISION));
                 }
@@ -3726,7 +3728,7 @@ export class LedgerComponent implements OnInit, OnDestroy {
                 if (txn?.selectedAccount?.stock) {
                     const stock = txn?.inventory?.stock;
                     if (txn?.duplicateEntry) {
-                        const unitRate = stock.unitRates.find(unitRate => unitRate.stockUnitUniqueName === txn?.inventory?.unit?.uniqueName) || stock.unitRates[0];
+                        const unitRate = stock.unitRates?.find(unitRate => unitRate.stockUnitUniqueName === txn?.inventory?.unit?.uniqueName) || stock.unitRates?.[0];
                         const defaultUnit = {
                             stockUnitCode: unitRate.stockUnitCode,
                             code: unitRate.stockUnitCode,
@@ -3804,7 +3806,9 @@ export class LedgerComponent implements OnInit, OnDestroy {
                         this.lc.blankLedger.salesPersonName = this.ledgerAccountResponse.salesPerson?.name || this.lc.blankLedger.salesPersonName || '';
                     }
                 }
-                this.preparePreAppliedDiscounts(txn);
+                if (!txn?.duplicateEntry) { 
+                    this.preparePreAppliedDiscounts(txn);
+                }
                 // check if selected account category allows to show taxationDiscountBox in newEntry popup
                 txn.showTaxationDiscountBox = this.getCategoryNameFromAccountUniqueName(txn);
                 txn.showOtherTax = this.showOtherTax(txn);

--- a/apps/web-giddh/src/app/search/components/search-filter/search-filter.component.html
+++ b/apps/web-giddh/src/app/search/components/search-filter/search-filter.component.html
@@ -26,7 +26,7 @@
                             [options]="queryTypes"
                             [required]="true"
                             (selectedOption)="item?.get('queryType').patchValue($event.value)"
-                            [labelValue]="resetValues ? (item?.get('queryType').value === 'closingBalance' ? 'Closing Balance' : '') : ''"
+                            [labelValue]="getOptionLabel(queryTypes, item?.get('queryType')?.value)"
                             [placeholder]="commonLocaleData?.app_select_type"
                             [label]="localeData?.whose"
                         ></reactive-dropdown-field>
@@ -34,7 +34,7 @@
                             class="width-query-differs mr-3"
                             [options]="queryDiffers"
                             (selectedOption)="item?.get('queryDiffer').patchValue($event.value)"
-                            [labelValue]="resetValues ? item?.get('queryDiffer').value : ''"
+                            [labelValue]="getOptionLabel(queryDiffers, item?.get('queryDiffer')?.value)"
                             [required]="true"
                             [placeholder]="localeData?.select_query"
                             [label]="localeData?.is"

--- a/apps/web-giddh/src/app/search/components/search-filter/search-filter.component.ts
+++ b/apps/web-giddh/src/app/search/components/search-filter/search-filter.component.ts
@@ -124,7 +124,7 @@ export class SearchFilterComponent implements OnInit {
         if (!value || !options?.length) {
             return '';
         }
-        const match = options.find(o => o?.value === value);
+        const match = options.find(option => option?.value === value);
         return match ? match.label : '';
     }
 

--- a/apps/web-giddh/src/app/search/components/search-filter/search-filter.component.ts
+++ b/apps/web-giddh/src/app/search/components/search-filter/search-filter.component.ts
@@ -1,6 +1,6 @@
 import { Component, EventEmitter, OnInit, Output, ViewChild, Input } from '@angular/core';
 import { SearchDataSet } from '../../../models/api-models/Search';
-import { UntypedFormArray, UntypedFormBuilder, UntypedFormGroup, Validators } from '@angular/forms';
+import { FormArray, FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { digitsOnly } from '../../../shared/helpers/customValidationHelper';
 import { MatAutocompleteTrigger } from '@angular/material/autocomplete';
 
@@ -31,8 +31,8 @@ export class SearchFilterComponent implements OnInit {
     public queryTypes = [];
     public queryDiffers = [];
     public balType = [];
-    public searchQueryForm: UntypedFormGroup;
-    public searchDataSet: UntypedFormArray;
+    public searchQueryForm: FormGroup;
+    public searchDataSet: FormArray;
     public toggleFilters: boolean = false;
     /* It reset the status for Filter by Account  */
     public resetValues: boolean = false;
@@ -40,17 +40,24 @@ export class SearchFilterComponent implements OnInit {
     /**
      * TypeScript public modifiers
      */
-    constructor(private fb: UntypedFormBuilder) {
+    constructor(private fb: FormBuilder) {
         this.searchQueryForm = this.fb.group({
-            searchQuery: this.fb.array([this.fb.group({
-                queryType: ['', Validators.required],
-                openingBalanceType: ['DEBIT', Validators.required],
-                closingBalanceType: ['DEBIT', Validators.required],
-                queryDiffer: ['', Validators.required],
-                amount: ['', [Validators.required, digitsOnly]],
-            })])
+            searchQuery: this.fb.array([this.getDefaultSearchFormGroup()])
         });
-        this.searchDataSet = this.searchQueryForm.controls['searchQuery'] as UntypedFormArray;
+        this.searchDataSet = this.searchQueryForm.controls['searchQuery'] as FormArray;
+    }
+
+    /**
+     * Returns the default form group configuration for a search query row
+     */
+    private getDefaultSearchFormGroup() {
+        return this.fb.group({
+            queryType: ['', Validators.required],
+            openingBalanceType: ['DEBIT', Validators.required],
+            closingBalanceType: ['DEBIT', Validators.required],
+            queryDiffer: ['', Validators.required],
+            amount: ['', [Validators.required, digitsOnly]],
+        });
     }
 
     public ngOnInit() {
@@ -99,8 +106,11 @@ export class SearchFilterComponent implements OnInit {
     }
 
     public resetQuery() {
-        this.searchDataSet.controls = [];
-        this.addSearchRow();
+        this.searchDataSet.clear();
+        this.searchDataSet.push(this.getDefaultSearchFormGroup());
+        this.searchQueryForm.markAsPristine();
+        this.searchQueryForm.markAsUntouched();
+        this.searchQueryForm.updateValueAndValidity();
         this.resetValues = true;
         this.isFiltered.emit(false);
     }
@@ -119,7 +129,7 @@ export class SearchFilterComponent implements OnInit {
     }
 
     public removeSearchRow() {
-        let arr = this.searchQueryForm.controls['searchQuery'] as UntypedFormArray;
+        let arr = this.searchQueryForm.controls['searchQuery'] as FormArray;
         arr.removeAt(-1);
     }
 

--- a/apps/web-giddh/src/app/search/components/search-filter/search-filter.component.ts
+++ b/apps/web-giddh/src/app/search/components/search-filter/search-filter.component.ts
@@ -105,6 +105,19 @@ export class SearchFilterComponent implements OnInit {
         this.isFiltered.emit(false);
     }
 
+    /**
+     * Returns the label for a given option value from an options list.
+     * Used to keep dropdown display in sync with the underlying FormControl value
+     * after the filter menu is reopened.
+     */
+    public getOptionLabel(options: { label: string; value: string }[], value: string): string {
+        if (!value || !options?.length) {
+            return '';
+        }
+        const match = options.find(o => o?.value === value);
+        return match ? match.label : '';
+    }
+
     public removeSearchRow() {
         let arr = this.searchQueryForm.controls['searchQuery'] as UntypedFormArray;
         arr.removeAt(-1);

--- a/apps/web-giddh/src/app/search/components/search-grid/search-grid.component.ts
+++ b/apps/web-giddh/src/app/search/components/search-grid/search-grid.component.ts
@@ -240,7 +240,13 @@ export class SearchGridComponent implements OnInit, OnDestroy {
         if (!isFiltered) {
             this.searchResponseFiltered$ = this.searchResponse$;
             this.FilterByAPIEvent.emit(null);
-            this.pageChangeEvent.emit(1);
+            this.checkboxInfo.selectedPage = 1;
+            const legacyEvent = {
+                page: 1,
+                itemsPerPage: 1,
+                count: this.countPerPage
+            };
+            this.pageChangeEvent.emit(legacyEvent);
             this.selectAllCustomer = false;
             this.selectedItems = [];
         }

--- a/apps/web-giddh/src/app/search/components/search-grid/search-grid.component.ts
+++ b/apps/web-giddh/src/app/search/components/search-grid/search-grid.component.ts
@@ -239,7 +239,9 @@ export class SearchGridComponent implements OnInit, OnDestroy {
     public resetFilters(isFiltered) {
         if (!isFiltered) {
             this.searchResponseFiltered$ = this.searchResponse$;
-            this.FilterByAPIEvent.emit(null);
+            const defaultQuery = this.createSearchQueryReqObj();
+            this.formattedQuery = this.formatQuery(defaultQuery, []);
+            this.FilterByAPIEvent.emit(this.formattedQuery);
             this.checkboxInfo.selectedPage = 1;
             const legacyEvent = {
                 page: 1,

--- a/apps/web-giddh/src/app/search/components/sidebar-components/search.sidebar.component.ts
+++ b/apps/web-giddh/src/app/search/components/sidebar-components/search.sidebar.component.ts
@@ -170,15 +170,12 @@ export class SearchSidebarComponent implements OnInit, OnChanges, OnDestroy {
 
     public ngOnChanges(changes: any) {
         if ('pageChangeEvent' in changes && changes['pageChangeEvent'].currentValue) {
-            if (changes['pageChangeEvent'].firstChange || (!changes['pageChangeEvent'].previousValue || changes['pageChangeEvent'].currentValue.page !== changes['pageChangeEvent'].previousValue.page)) {
-                let page = changes.pageChangeEvent.currentValue.page;
-                this.paginationPageNumber = page;
-                if (this.filterEventQuery) {
-                    this.getClosingBalance(false, null, this.paginationPageNumber, this.filterEventQuery);
-                } else {
-                    this.getClosingBalance(false, null, page);
-                }
-
+            let page = changes.pageChangeEvent.currentValue.page;
+            this.paginationPageNumber = page;
+            if (this.filterEventQuery) {
+                this.getClosingBalance(false, null, this.paginationPageNumber, this.filterEventQuery);
+            } else {
+                this.getClosingBalance(false, null, page);
             }
         }
 

--- a/apps/web-giddh/src/app/shared/advance-receipt-adjustment/advance-receipt-adjustment.component.html
+++ b/apps/web-giddh/src/app/shared/advance-receipt-adjustment/advance-receipt-adjustment.component.html
@@ -11,7 +11,7 @@
             <span>{{ localeData?.page_heading }}</span>
         </div>
     }
-    <mat-dialog-content class="dialog-body font-size-15 adjustments-list">
+    <mat-dialog-content class="dialog-body font-size-15 max-h-500">
         <giddh-page-loader *ngIf="showLoader()"></giddh-page-loader>
         <div class="row h-100" [hidden]="showLoader()">
             <div class="col-md-12 d-flex flex-column">

--- a/apps/web-giddh/src/app/subscription/buy-plan/buy-plan.component.ts
+++ b/apps/web-giddh/src/app/subscription/buy-plan/buy-plan.component.ts
@@ -642,6 +642,11 @@ export class BuyPlanComponent implements OnInit, OnDestroy {
                 //     this.openCashfreeDialog(response?.redirectLink);
                 // }
                 this.subscriptionId = response.subscriptionId;
+
+                if (response.dueAmount < 1) {
+                    this.navigateToNewCompany(response.subscriptionId);
+                    return;
+                }
                 if (this.getStripeClientSecret(response)) {
                     if (this.payType === 'trial') {
                         this.navigateToNewCompany(response.subscriptionId);

--- a/apps/web-giddh/src/app/vouchers/adjust-payment-dialog/adjust-payment-dialog.component.html
+++ b/apps/web-giddh/src/app/vouchers/adjust-payment-dialog/adjust-payment-dialog.component.html
@@ -8,7 +8,7 @@
     <div cdkFocusInitial class="dialog-header">
         <span class="font-size-16">{{ localeData?.page_heading }}</span>
     </div>
-    <div mat-dialog-content class="dialog-body">
+    <div mat-dialog-content class="dialog-body max-h-500">
         <div class="row">
             <div class="col-md-12">
                 <span class="theme-foreground-color" *ngIf="isUpdateMode && isVoucherModule">

--- a/apps/web-giddh/src/app/vouchers/template/template-edit-filter/template-edit-filter.component.html
+++ b/apps/web-giddh/src/app/vouchers/template/template-edit-filter/template-edit-filter.component.html
@@ -2743,9 +2743,14 @@
                                                                     ? null
                                                                     : 200
                                                             "
-                                                            [class.error-box]="isCharacterLimitExceeded(200, customTemplate.message1 || '')"
+                                                            [class.error-box]="
+                                                                isCharacterLimitExceeded(
+                                                                    200,
+                                                                    customTemplate.sections['footer'].data['message1']?.value || ''
+                                                                )
+                                                            "
                                                             [placeholder]="localeData?.footer_text"
-                                                            [(ngModel)]="customTemplate.message1"
+                                                            [(ngModel)]="customTemplate.sections['footer'].data['message1'].value"
                                                             name="msg11"
                                                             (ngModelChange)="onChangeFieldVisibility()"
                                                             [disabled]="!customTemplate.sections['footer'].data['message1']?.display"
@@ -2755,7 +2760,7 @@
                                                                 suggestionSuffix: '}',
                                                             }"
                                                             [appTributeMentionValues]="suggestionList"
-                                                            (focus)="onCharacterFieldFocus('', 'message1', '')"
+                                                            (focus)="onCharacterFieldFocus('footer', 'message1', 'value')"
                                                             (blur)="onCharacterFieldBlur()"
                                                             [attr.lang]="primaryLangCode"
                                                             [attr.dir]="primaryLangDirection"
@@ -2764,8 +2769,13 @@
                                                 </td>
                                                 <td class="p-2 text-center">
                                                     <span class="font-size-12">
-                                                        @if (isCharacterFieldFocused('', 'message1', '')) {
-                                                            {{ getRemainingCharacters(200, customTemplate?.message1) }}/{{ 200 }}
+                                                        @if (isCharacterFieldFocused('footer', 'message1', 'value')) {
+                                                            {{
+                                                                getRemainingCharacters(
+                                                                    200,
+                                                                    customTemplate.sections['footer'].data['message1']?.value
+                                                                )
+                                                            }}/{{ 200 }}
                                                         }
                                                     </span>
                                                 </td>
@@ -2832,7 +2842,9 @@
                                                                     )
                                                                 "
                                                                 [placeholder]="localeData?.footer_text"
-                                                                [(ngModel)]="customTemplate.secondaryMessage1"
+                                                                [(ngModel)]="
+                                                                    customTemplate.sections['footer'].data['message1'].secondaryValue
+                                                                "
                                                                 name="msg2"
                                                                 (ngModelChange)="onChangeFieldVisibility()"
                                                                 [disabled]="!customTemplate.sections['footer'].data['message1']?.display"
@@ -2851,10 +2863,13 @@
                                                     </td>
                                                     <td class="p-2 text-center">
                                                         <span class="font-size-12">
-                                                            @if (isCharacterFieldFocused('', 'secondaryMessage1', '')) {
-                                                                {{ getRemainingCharacters(200, customTemplate?.secondaryMessage1) }}/{{
-                                                                    200
-                                                                }}
+                                                            @if (isCharacterFieldFocused('footer', 'message1', 'secondaryValue')) {
+                                                                {{
+                                                                    getRemainingCharacters(
+                                                                        200,
+                                                                        customTemplate.sections['footer'].data['message1']?.secondaryValue
+                                                                    )
+                                                                }}/{{ 200 }}
                                                             }
                                                         </span>
                                                     </td>

--- a/apps/web-giddh/src/app/vouchers/template/template-edit-filter/template-edit-filter.component.html
+++ b/apps/web-giddh/src/app/vouchers/template/template-edit-filter/template-edit-filter.component.html
@@ -1117,7 +1117,7 @@
                                                         labelRow;
                                                         context: {
                                                             rowId: 'customerEmailRow',
-                                                            showInputField: !isThermalTemplate,
+                                                            showInputField: isTallyTemplate,
                                                             showCheckbox: true,
                                                             section: 'header',
                                                             field: 'customerEmail',
@@ -1138,7 +1138,7 @@
                                                         labelRow;
                                                         context: {
                                                             rowId: 'customerMobileNumberRow',
-                                                            showInputField: true,
+                                                            showInputField: isTallyTemplate,
                                                             showCheckbox: true,
                                                             section: 'header',
                                                             field: 'customerMobileNumber',
@@ -1604,27 +1604,6 @@
                                                             name: 'tableshowVariantImage',
                                                             label: localeData?.show_variant_image,
                                                             maxLength: 15,
-                                                            showSecondaryLabel: showSecondaryLabel,
-                                                        }
-                                                    "
-                                                ></ng-container>
-                                            }
-
-                                            <!-- date -->
-                                            @if (sectionSettings?.table.date && !isThermalTemplate) {
-                                                <ng-container
-                                                    *ngTemplateOutlet="
-                                                        labelRow;
-                                                        context: {
-                                                            rowId: 'dateRow',
-                                                            showInputField: true,
-                                                            showCheckbox: true,
-                                                            section: 'table',
-                                                            field: 'date',
-                                                            callbacks: [onChangeFieldVisibility],
-                                                            name: 'tabledate',
-                                                            label: commonLocaleData?.app_date,
-                                                            maxLength: 10,
                                                             showSecondaryLabel: showSecondaryLabel,
                                                         }
                                                     "
@@ -2702,7 +2681,7 @@
 
                                         <!-- Message 1 -->
                                         @if (sectionSettings?.footer?.message1) {
-                                            <tr id="message1Row1">
+                                            <tr id="message1Row1Label">
                                                 <td class="p-2 vertical-align-top">
                                                     <mat-checkbox
                                                         color="primary"
@@ -2717,7 +2696,7 @@
                                                 <td class="p-2" [attr.colspan]="showSecondaryLabel ? 2 : 1">
                                                     @if (!isThermalTemplate) {
                                                         <!-- Label for Note 1 (Declaration:) -->
-                                                        <div class="mb-3">
+                                                        <div class="d-flex align-items-center column-gap-1">
                                                             <ng-container
                                                                 *ngTemplateOutlet="
                                                                     labelRowInput;
@@ -2734,7 +2713,24 @@
                                                             ></ng-container>
                                                         </div>
                                                     }
-
+                                                </td>
+                                                <td class="p-2 text-center">
+                                                    <span class="font-size-12">
+                                                        @if (isCharacterFieldFocused('footer', 'message1', 'label')) {
+                                                            {{
+                                                                getRemainingCharacters(
+                                                                    15,
+                                                                    customTemplate?.sections?.['footer']?.data?.['message1']?.label
+                                                                )
+                                                            }}/{{ 15 }}
+                                                        }
+                                                    </span>
+                                                </td>
+                                            </tr>
+                                            <tr id="message1Row1Content">
+                                                <td class="p-2"></td>
+                                                <td class="p-2"></td>
+                                                <td class="p-2" [attr.colspan]="showSecondaryLabel ? 2 : 1">
                                                     <!-- Content for Note 1 which show below Declaration: -->
                                                     <mat-form-field appearance="outline" class="initial-height w-100 address-text">
                                                         <mat-label>{{ primaryLabel }}</mat-label>
@@ -2747,9 +2743,7 @@
                                                                     ? null
                                                                     : 200
                                                             "
-                                                            [class.error-box]="
-                                                                isCharacterLimitExceeded(200, customTemplate.sections['message1'] || '')
-                                                            "
+                                                            [class.error-box]="isCharacterLimitExceeded(200, customTemplate.message1 || '')"
                                                             [placeholder]="localeData?.footer_text"
                                                             [(ngModel)]="customTemplate.message1"
                                                             name="msg11"
@@ -2769,23 +2763,21 @@
                                                     </mat-form-field>
                                                 </td>
                                                 <td class="p-2 text-center">
-                                                    @if (isCharacterFieldFocused('', 'message1', '')) {
-                                                        <span class="font-size-12">
-                                                            {{ getRemainingCharacters(200, customTemplate?.sections?.['message1']) }}/{{
-                                                                200
-                                                            }}
-                                                        </span>
-                                                    }
+                                                    <span class="font-size-12">
+                                                        @if (isCharacterFieldFocused('', 'message1', '')) {
+                                                            {{ getRemainingCharacters(200, customTemplate?.message1) }}/{{ 200 }}
+                                                        }
+                                                    </span>
                                                 </td>
                                             </tr>
 
                                             @if (!isThermalTemplate && showSecondaryLabel) {
-                                                <tr id="message1Row2">
+                                                <tr id="message1Row2Label">
                                                     <td class="p-2"></td>
                                                     <td class="p-2"></td>
                                                     <td class="p-2" [attr.colspan]="showSecondaryLabel ? 2 : 1">
                                                         <!-- Label for Note 1 (Declaration:) -->
-                                                        <div class="mb-3">
+                                                        <div class="d-flex align-items-center column-gap-1">
                                                             <ng-container
                                                                 *ngTemplateOutlet="
                                                                     labelRowInput;
@@ -2801,7 +2793,25 @@
                                                                 "
                                                             ></ng-container>
                                                         </div>
-
+                                                    </td>
+                                                    <td class="p-2 text-center">
+                                                        <span class="font-size-12">
+                                                            @if (isCharacterFieldFocused('footer', 'message1', 'secondaryLabel')) {
+                                                                {{
+                                                                    getRemainingCharacters(
+                                                                        15,
+                                                                        customTemplate?.sections?.['footer']?.data?.['message1']
+                                                                            ?.secondaryLabel
+                                                                    )
+                                                                }}/{{ 15 }}
+                                                            }
+                                                        </span>
+                                                    </td>
+                                                </tr>
+                                                <tr id="message1Row2Content">
+                                                    <td class="p-2"></td>
+                                                    <td class="p-2"></td>
+                                                    <td class="p-2" [attr.colspan]="showSecondaryLabel ? 2 : 1">
                                                         <!-- Content for Note 1 which show below Declaration: -->
                                                         <mat-form-field appearance="outline" class="initial-height w-100 address-text">
                                                             <mat-label>{{ secondaryLabel }}</mat-label>
@@ -2840,17 +2850,13 @@
                                                         </mat-form-field>
                                                     </td>
                                                     <td class="p-2 text-center">
-                                                        @if (isCharacterFieldFocused('footer', 'message1', 'secondaryLabel')) {
-                                                            <span class="font-size-12">
-                                                                {{
-                                                                    getRemainingCharacters(
-                                                                        200,
-                                                                        customTemplate?.sections?.['footer']?.data?.['message1']
-                                                                            ?.secondaryLabel
-                                                                    )
-                                                                }}/{{ 200 }}
-                                                            </span>
-                                                        }
+                                                        <span class="font-size-12">
+                                                            @if (isCharacterFieldFocused('', 'secondaryMessage1', '')) {
+                                                                {{ getRemainingCharacters(200, customTemplate?.secondaryMessage1) }}/{{
+                                                                    200
+                                                                }}
+                                                            }
+                                                        </span>
                                                     </td>
                                                 </tr>
                                             }
@@ -3111,44 +3117,46 @@
             ></mat-checkbox>
         </td>
 
-        <td class="p-2">
+        <td class="p-2" [attr.colspan]="showInputField ? null : showSecondaryLabel && !isThermalTemplate ? 3 : 2">
             {{ label }}
         </td>
 
-        <td class="p-2">
-            <ng-container
-                *ngTemplateOutlet="
-                    labelRowInput;
-                    context: {
-                        key: 'label',
-                        showInputField: showInputField,
-                        section: section,
-                        field: field,
-                        name: name,
-                        maxLength: maxLength,
-                        callbacks: callbacks,
-                    }
-                "
-            ></ng-container>
-        </td>
-
-        @if (showSecondaryLabel && !isThermalTemplate) {
+        @if (showInputField) {
             <td class="p-2">
                 <ng-container
                     *ngTemplateOutlet="
                         labelRowInput;
                         context: {
-                            key: 'secondaryLabel',
+                            key: 'label',
                             showInputField: showInputField,
                             section: section,
                             field: field,
-                            name: name + 'Secondary',
+                            name: name,
                             maxLength: maxLength,
-                            callbacks: [onChangeFieldVisibility],
+                            callbacks: callbacks,
                         }
                     "
                 ></ng-container>
             </td>
+
+            @if (showSecondaryLabel && !isThermalTemplate) {
+                <td class="p-2">
+                    <ng-container
+                        *ngTemplateOutlet="
+                            labelRowInput;
+                            context: {
+                                key: 'secondaryLabel',
+                                showInputField: showInputField,
+                                section: section,
+                                field: field,
+                                name: name + 'Secondary',
+                                maxLength: maxLength,
+                                callbacks: [onChangeFieldVisibility],
+                            }
+                        "
+                    ></ng-container>
+                </td>
+            }
         }
 
         <td class="p-2 text-center">

--- a/apps/web-giddh/src/app/vouchers/template/template-edit-filter/template-edit-filter.component.ts
+++ b/apps/web-giddh/src/app/vouchers/template/template-edit-filter/template-edit-filter.component.ts
@@ -434,11 +434,11 @@ export class TemplateEditFilterComponent implements OnInit {
             }
              
             if (footerData?.message1?.display) {
-                if (this.customTemplate.message1 === undefined || this.customTemplate.message1 === null) {
-                    this.customTemplate.message1 = "We declare that this invoice shows the actual price of the services rendered and that all particulars are true and correct.";
+                if (this.customTemplate.sections['footer'].data['message1'].value === undefined || this.customTemplate.sections['footer'].data['message1'].value === null) {
+                    this.customTemplate.sections['footer'].data['message1'].value = "We declare that this invoice shows the actual price of the services rendered and that all particulars are true and correct.";
                 }
-                if (this.customTemplate.secondaryMessage1 === undefined || this.customTemplate.secondaryMessage1 === null) {
-                    this.customTemplate.secondaryMessage1 = "";
+                if (this.customTemplate.sections['footer'].data['message1'].secondaryValue === undefined || this.customTemplate.sections['footer'].data['message1'].secondaryValue === null) {
+                    this.customTemplate.sections['footer'].data['message1'].secondaryValue = "";
                 }
             }
 

--- a/apps/web-giddh/src/app/vouchers/template/template-edit-filter/template-edit-filter.component.ts
+++ b/apps/web-giddh/src/app/vouchers/template/template-edit-filter/template-edit-filter.component.ts
@@ -434,8 +434,12 @@ export class TemplateEditFilterComponent implements OnInit {
             }
              
             if (footerData?.message1?.display) {
-                this.customTemplate.message1 = "We declare that this invoice shows the actual price of the services rendered and that all particulars are true and correct.";
-                this.customTemplate.secondaryMessage1 = "";
+                if (this.customTemplate.message1 === undefined || this.customTemplate.message1 === null) {
+                    this.customTemplate.message1 = "We declare that this invoice shows the actual price of the services rendered and that all particulars are true and correct.";
+                }
+                if (this.customTemplate.secondaryMessage1 === undefined || this.customTemplate.secondaryMessage1 === null) {
+                    this.customTemplate.secondaryMessage1 = "";
+                }
             }
 
             if (this.customTemplate?.language2Code && !this.selectedSecondaryLang().value) {


### PR DESCRIPTION
## **User description**
https://app.clickup.com/t/3687137/86d3wcku6
https://app.clickup.com/t/3687137/86d3ymt89
https://app.clickup.com/t/3687137/86d3vtx2e
https://app.clickup.com/t/3687137/86d3xm9eh
https://app.clickup.com/t/3687137/86d3y2rpn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search filter labels and ensured pagination resets and updates reliably.
  * Corrected sidebar refresh behavior when pagination changes.
  * Subscriptions with no outstanding balance now proceed directly to company setup.
  * Preserved existing voucher template messages during editing.
  * Improved ledger duplication by retaining tax details and preventing dropdown-related issues.

* **UI Improvements**
  * Added consistent maximum-height handling to adjustment dialogs.
  * Refined Tally template fields, multilingual footer messages, character counters, and layout behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Ledger duplication and subscription payment routing affect financial entry accuracy and onboarding; search reset now always hits the API on filter clear and pagination, which changes list behavior.
> 
> **Overview**
> Fixes **ledger entry duplication** so copied lines keep existing taxes, discounts, stock/unit rates, and other-tax settings instead of re-applying account defaults; duplicate flow also closes discount/tax dropdowns before reopening the modal.
> 
> **Account search** filter dropdowns now show labels from form values via `getOptionLabel`, reset clears the form array cleanly, and clearing filters reloads the default query on page 1 through the API; sidebar pagination changes always trigger balance fetches.
> 
> **Buy plan** skips Stripe/PayPal when `dueAmount` is under 1 and goes straight to new company setup.
> 
> **Voucher template editor** binds footer Note 1 to `sections.footer.data.message1` (value/secondaryValue) without overwriting saved text; Tally-only label inputs for customer email/mobile; table **date** row removed from the filter UI; `labelRow` layout adjusted for non-input rows.
> 
> Adjustment dialogs use a **max height** (`max-h-500`) instead of the previous adjustments-list class.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83f9bfe8ace55f0f77f30df300be9e5c98b2d490. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
Fix search behavior, ledger duplication, subscription setup, and voucher template editing

### What Changed
- Search filters now retain their selected labels, reset cleanly, and return to the first page with refreshed results.
- Duplicating ledger entries preserves existing taxes, discounts, stock rates, and warehouse details without reopening adjustment controls.
- Subscriptions with no amount due now proceed directly to company setup.
- Editing voucher templates preserves existing footer messages instead of replacing them with default text.
- Tally template fields and note editing now use the correct visibility, character counts, and layout; adjustment dialogs have a consistent maximum height.

### Impact
`✅ Reliable search filter resets`
`✅ Accurate duplicated ledger entries`
`✅ Faster setup for zero-balance subscriptions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
