### PR TITLE
Ankit | Test | Prod/Test - Something went wrong coming in create-pre-paid api

### DIFF
--- a/apps/web-giddh/src/app/subscription/buy-plan/buy-plan.component.ts
+++ b/apps/web-giddh/src/app/subscription/buy-plan/buy-plan.component.ts
@@ -643,7 +643,7 @@ export class BuyPlanComponent implements OnInit, OnDestroy {
                 // }
                 this.subscriptionId = response.subscriptionId;
 
-                if (response.dueAmount < 1) {
+                if (response.dueAmount < 1 && this.isAdvancePayment) {
                     this.navigateToRoute('/pages/user-details/subscription');
                     return;
                 }

--- a/apps/web-giddh/src/app/subscription/buy-plan/buy-plan.component.ts
+++ b/apps/web-giddh/src/app/subscription/buy-plan/buy-plan.component.ts
@@ -644,7 +644,7 @@ export class BuyPlanComponent implements OnInit, OnDestroy {
                 this.subscriptionId = response.subscriptionId;
 
                 if (response.dueAmount < 1) {
-                    this.navigateToNewCompany(response.subscriptionId);
+                    this.navigateToRoute('/pages/user-details/subscription');
                     return;
                 }
                 if (this.getStripeClientSecret(response)) {


### PR DESCRIPTION
https://app.clickup.com/t/3687137/86d3xm9eh
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)



* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Other information**:


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single conditional branch in buy-plan post-subscription navigation; no auth or payment API changes, but wrong routing could still affect advance-payment UX.
> 
> **Overview**
> After **create subscription** succeeds, the handler for **`dueAmount < 1`** no longer always sends users to **new company** onboarding.
> 
> For the **advance-payment** buy-plan route, a zero or near-zero due amount now navigates to **`/pages/user-details/subscription`** instead of **`navigateToNewCompany`**, so prepaid/advance flows finish on the subscription screen and avoid incorrect follow-up calls (e.g. create-pre-paid errors). Non-advance flows with **`dueAmount < 1`** skip this early exit and continue into the existing Stripe/payment branching.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17653ab9b2c8a2314d66b39b5edb8f1ae434483a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Advance-payment subscription purchases with no outstanding balance now correctly navigate to the subscription page.
  * Other zero-balance purchase flows continue navigating to the new-company page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->