### PR TITLE
Ankit | Test | QA - Support of Arabic language in template for UAE companies. [BUG]

### DIFF
--- a/apps/web-giddh/src/app/vouchers/template/template-edit-filter/template-edit-filter.component.html
+++ b/apps/web-giddh/src/app/vouchers/template/template-edit-filter/template-edit-filter.component.html
@@ -316,7 +316,7 @@
 
                             @if (customTemplate.enableSecondaryLanguage) {
                                 <!-- Secondary Label Language Dropdown -->
-                                <div class="mb-2 w-50">
+                                <div class="mb-2 w-50 pl-5">
                                     <reactive-dropdown-field
                                         [label]="localeData?.secondary_language"
                                         [placeholder]="localeData?.select_secondary_language"

--- a/apps/web-giddh/src/app/vouchers/template/template-edit-filter/template-edit-filter.component.html
+++ b/apps/web-giddh/src/app/vouchers/template/template-edit-filter/template-edit-filter.component.html
@@ -315,6 +315,18 @@
                             </mat-checkbox>
 
                             @if (customTemplate.enableSecondaryLanguage) {
+                                <!-- Secondary Label Language Dropdown -->
+                                <div class="mb-2 w-50">
+                                    <reactive-dropdown-field
+                                        [label]="localeData?.secondary_language"
+                                        [placeholder]="localeData?.select_secondary_language"
+                                        [options]="languageList()"
+                                        [required]="customTemplate.enableSecondaryLanguage"
+                                        (selectedOption)="onLanguageSelect($event)"
+                                        [(ngModel)]="customTemplate.language2Code"
+                                    ></reactive-dropdown-field>
+                                </div>
+
                                 <mat-checkbox
                                     color="primary"
                                     class="d-block"
@@ -328,26 +340,15 @@
                                 <mat-checkbox
                                     color="primary"
                                     class="d-block"
-                                    name="secondaryLabelFirst"
-                                    [(ngModel)]="customTemplate.secondaryLabelFirst"
+                                    name="showLanguage2DisplayedFirst"
+                                    [(ngModel)]="customTemplate.showLanguage2DisplayedFirst"
                                     (ngModelChange)="
-                                        onChangeDesignFieldVisibility('secondaryLabelFirst', customTemplate?.secondaryLabelFirst)
+                                        onChangeDesignFieldVisibility('showLanguage2DisplayedFirst', customTemplate?.showLanguage2DisplayedFirst)
                                     "
                                 >
                                     {{ localeData?.show_secondary_label_first }}
                                 </mat-checkbox>
 
-                                <!-- Secondary Label Language Dropdown -->
-                                <div class="mt-2 w-50">
-                                    <reactive-dropdown-field
-                                        [label]="localeData?.secondary_language"
-                                        [placeholder]="localeData?.select_secondary_language"
-                                        [options]="languageList()"
-                                        [required]="customTemplate.enableSecondaryLanguage"
-                                        (selectedOption)="onLanguageSelect($event)"
-                                        [(ngModel)]="customTemplate.language2Code"
-                                    ></reactive-dropdown-field>
-                                </div>
                             }
                         </div>
                     </mat-expansion-panel>
@@ -1609,6 +1610,25 @@
                                                     "
                                                 ></ng-container>
                                             }
+                                            <!-- date -->
+                                            @if (sectionSettings?.table.date && !isThermalTemplate) {
+                                                <ng-container
+                                                    *ngTemplateOutlet="
+                                                        labelRow;
+                                                        context: {
+                                                            rowId: 'dateRow',
+                                                            showInputField: false,
+                                                            showCheckbox: true,
+                                                            section: 'table',
+                                                            field: 'date',
+                                                            callbacks: [onChangeFieldVisibility],
+                                                            name: 'tabledate',
+                                                            label: commonLocaleData?.app_date,
+                                                            showSecondaryLabel: showSecondaryLabel
+                                                        }
+                                                    "
+                                                ></ng-container>
+                                            }
 
                                             <!-- item -->
                                             @if (sectionSettings?.table.item) {
@@ -2183,6 +2203,7 @@
                                                             callbacks: [onChangeFieldVisibility],
                                                             name: 'tableEntrySummaryPaid',
                                                             label: localeData?.entry_summary_paid,
+                                                            maxLength: 15,
                                                             showSecondaryLabel: showSecondaryLabel,
                                                         }
                                                     "
@@ -2203,6 +2224,7 @@
                                                             callbacks: [onChangeFieldVisibility],
                                                             name: 'tableEntrySummaryDueAmount',
                                                             label: localeData?.entry_summary_due_amount,
+                                                            maxLength: 15,
                                                             showSecondaryLabel: showSecondaryLabel,
                                                         }
                                                     "
@@ -2571,6 +2593,7 @@
                                                                 callbacks: [onChangeFieldVisibility],
                                                                 name: 'tableTaxBifurcationHsnSac',
                                                                 label: localeData?.tax_bifurcation_hsn_sac,
+                                                                maxLength: 15,
                                                                 showSecondaryLabel: showSecondaryLabel,
                                                             }
                                                         "
@@ -2591,6 +2614,7 @@
                                                                 callbacks: [onChangeFieldVisibility],
                                                                 name: 'tabletaxBifurcationTaxableValue',
                                                                 label: localeData?.tax_bifurcation_taxable_value,
+                                                                maxLength: 15,
                                                                 showSecondaryLabel: showSecondaryLabel,
                                                             }
                                                         "
@@ -2611,6 +2635,7 @@
                                                                 callbacks: [onChangeFieldVisibility],
                                                                 name: 'tabletaxBifurcationTotal',
                                                                 label: localeData?.tax_bifurcation_total,
+                                                                maxLength: 15,
                                                                 showSecondaryLabel: showSecondaryLabel,
                                                             }
                                                         "
@@ -2681,20 +2706,84 @@
 
                                         <!-- Message 1 -->
                                         @if (sectionSettings?.footer?.message1) {
-                                            <tr id="message1Row1Label">
-                                                <td class="p-2 vertical-align-top">
-                                                    <mat-checkbox
-                                                        color="primary"
-                                                        name="tmessage1Checkbox"
-                                                        [(ngModel)]="customTemplate.sections['footer'].data['message1'].display"
-                                                        (ngModelChange)="onChangeFieldVisibility()"
-                                                    ></mat-checkbox>
-                                                </td>
-                                                <td class="p-2 vertical-align-top">
-                                                    <span class="pt-2 d-inline-block">{{ localeData?.note_1 }}</span>
-                                                </td>
-                                                <td class="p-2" [attr.colspan]="showSecondaryLabel ? 2 : 1">
-                                                    @if (!isThermalTemplate) {
+                                            @if (isTemplateA || isThermalTemplate) {
+                                                <tr id="message1Row1Label">
+                                                    <td class="p-2 vertical-align-top">
+                                                        <mat-checkbox
+                                                            color="primary"
+                                                            name="tmessage1Checkbox"
+                                                            [(ngModel)]="customTemplate.sections['footer'].data['message1'].display"
+                                                            (ngModelChange)="onChangeFieldVisibility()"
+                                                        ></mat-checkbox>
+                                                    </td>
+                                                    <td class="p-2 vertical-align-top">
+                                                        <span class="pt-2 d-inline-block">{{ localeData?.note_1 }}</span>
+                                                    </td>
+                                                    <td class="p-2" [attr.colspan]="showSecondaryLabel ? 2 : 1">
+                                                        <!-- Content for Note 1 which show below Declaration: -->
+                                                        <mat-form-field appearance="outline" class="initial-height w-100 address-text">
+                                                            <mat-label>{{ primaryLabel }}</mat-label>
+                                                            <textarea
+                                                                matInput
+                                                                class="form-control"
+                                                                rows="3"
+                                                                [maxlength]="
+                                                                    customTemplate.sections['footer'].data['showNotesAtLastPage']?.display
+                                                                        ? null
+                                                                        : 200
+                                                                "
+                                                                [class.error-box]="
+                                                                    isCharacterLimitExceeded(
+                                                                        200,
+                                                                        customTemplate.sections['footer'].data['message1']?.value || ''
+                                                                    )
+                                                                "
+                                                                [placeholder]="localeData?.footer_text"
+                                                                [(ngModel)]="customTemplate.sections['footer'].data['message1'].value"
+                                                                name="msg11"
+                                                                (ngModelChange)="onChangeFieldVisibility()"
+                                                                [disabled]="!customTemplate.sections['footer'].data['message1']?.display"
+                                                                [appTributeMention]="{
+                                                                    trigger: '{',
+                                                                    suggestionPrefix: '{',
+                                                                    suggestionSuffix: '}',
+                                                                }"
+                                                                [appTributeMentionValues]="suggestionList"
+                                                                (focus)="onCharacterFieldFocus('footer', 'message1', 'value')"
+                                                                (blur)="onCharacterFieldBlur()"
+                                                                [attr.lang]="primaryLangCode"
+                                                                [attr.dir]="primaryLangDirection"
+                                                            ></textarea>
+                                                        </mat-form-field>
+                                                    </td>
+                                                    <td class="p-2 text-center">
+                                                        <span class="font-size-12">
+                                                            @if (isCharacterFieldFocused('footer', 'message1', 'value')) {
+                                                                {{
+                                                                    getRemainingCharacters(
+                                                                        200,
+                                                                        customTemplate.sections['footer'].data['message1']?.value
+                                                                    )
+                                                                }}/{{ 200 }}
+                                                            }
+                                                        </span>
+                                                    </td>
+                                                </tr>
+                                            }
+                                            @if (isTallyTemplate) {
+                                                <tr id="message1Row1Label">
+                                                    <td class="p-2 vertical-align-top">
+                                                        <mat-checkbox
+                                                            color="primary"
+                                                            name="tmessage1Checkbox"
+                                                            [(ngModel)]="customTemplate.sections['footer'].data['message1'].display"
+                                                            (ngModelChange)="onChangeFieldVisibility()"
+                                                        ></mat-checkbox>
+                                                    </td>
+                                                    <td class="p-2 vertical-align-top">
+                                                        <span class="pt-2 d-inline-block">{{ localeData?.note_1 }}</span>
+                                                    </td>
+                                                    <td class="p-2" [attr.colspan]="showSecondaryLabel ? 2 : 1">
                                                         <!-- Label for Note 1 (Declaration:) -->
                                                         <div class="d-flex align-items-center column-gap-1">
                                                             <ng-container
@@ -2712,74 +2801,74 @@
                                                                 "
                                                             ></ng-container>
                                                         </div>
-                                                    }
-                                                </td>
-                                                <td class="p-2 text-center">
-                                                    <span class="font-size-12">
-                                                        @if (isCharacterFieldFocused('footer', 'message1', 'label')) {
-                                                            {{
-                                                                getRemainingCharacters(
-                                                                    15,
-                                                                    customTemplate?.sections?.['footer']?.data?.['message1']?.label
-                                                                )
-                                                            }}/{{ 15 }}
-                                                        }
-                                                    </span>
-                                                </td>
-                                            </tr>
-                                            <tr id="message1Row1Content">
-                                                <td class="p-2"></td>
-                                                <td class="p-2"></td>
-                                                <td class="p-2" [attr.colspan]="showSecondaryLabel ? 2 : 1">
-                                                    <!-- Content for Note 1 which show below Declaration: -->
-                                                    <mat-form-field appearance="outline" class="initial-height w-100 address-text">
-                                                        <mat-label>{{ primaryLabel }}</mat-label>
-                                                        <textarea
-                                                            matInput
-                                                            class="form-control"
-                                                            rows="3"
-                                                            [maxlength]="
-                                                                customTemplate.sections['footer'].data['showNotesAtLastPage']?.display
-                                                                    ? null
-                                                                    : 200
-                                                            "
-                                                            [class.error-box]="
-                                                                isCharacterLimitExceeded(
-                                                                    200,
-                                                                    customTemplate.sections['footer'].data['message1']?.value || ''
-                                                                )
-                                                            "
-                                                            [placeholder]="localeData?.footer_text"
-                                                            [(ngModel)]="customTemplate.sections['footer'].data['message1'].value"
-                                                            name="msg11"
-                                                            (ngModelChange)="onChangeFieldVisibility()"
-                                                            [disabled]="!customTemplate.sections['footer'].data['message1']?.display"
-                                                            [appTributeMention]="{
-                                                                trigger: '{',
-                                                                suggestionPrefix: '{',
-                                                                suggestionSuffix: '}',
-                                                            }"
-                                                            [appTributeMentionValues]="suggestionList"
-                                                            (focus)="onCharacterFieldFocus('footer', 'message1', 'value')"
-                                                            (blur)="onCharacterFieldBlur()"
-                                                            [attr.lang]="primaryLangCode"
-                                                            [attr.dir]="primaryLangDirection"
-                                                        ></textarea>
-                                                    </mat-form-field>
-                                                </td>
-                                                <td class="p-2 text-center">
-                                                    <span class="font-size-12">
-                                                        @if (isCharacterFieldFocused('footer', 'message1', 'value')) {
-                                                            {{
-                                                                getRemainingCharacters(
-                                                                    200,
-                                                                    customTemplate.sections['footer'].data['message1']?.value
-                                                                )
-                                                            }}/{{ 200 }}
-                                                        }
-                                                    </span>
-                                                </td>
-                                            </tr>
+                                                    </td>
+                                                    <td class="p-2 text-center">
+                                                        <span class="font-size-12">
+                                                            @if (isCharacterFieldFocused('footer', 'message1', 'label')) {
+                                                                {{
+                                                                    getRemainingCharacters(
+                                                                        15,
+                                                                        customTemplate?.sections?.['footer']?.data?.['message1']?.label
+                                                                    )
+                                                                }}/{{ 15 }}
+                                                            }
+                                                        </span>
+                                                    </td>
+                                                </tr>
+                                                <tr id="message1Row1Content">
+                                                    <td class="p-2"></td>
+                                                    <td class="p-2"></td>
+                                                    <td class="p-2" [attr.colspan]="showSecondaryLabel ? 2 : 1">
+                                                        <!-- Content for Note 1 which show below Declaration: -->
+                                                        <mat-form-field appearance="outline" class="initial-height w-100 address-text">
+                                                            <mat-label>{{ primaryLabel }}</mat-label>
+                                                            <textarea
+                                                                matInput
+                                                                class="form-control"
+                                                                rows="3"
+                                                                [maxlength]="
+                                                                    customTemplate.sections['footer'].data['showNotesAtLastPage']?.display
+                                                                        ? null
+                                                                        : 200
+                                                                "
+                                                                [class.error-box]="
+                                                                    isCharacterLimitExceeded(
+                                                                        200,
+                                                                        customTemplate.sections['footer'].data['message1']?.value || ''
+                                                                    )
+                                                                "
+                                                                [placeholder]="localeData?.footer_text"
+                                                                [(ngModel)]="customTemplate.sections['footer'].data['message1'].value"
+                                                                name="msg11"
+                                                                (ngModelChange)="onChangeFieldVisibility()"
+                                                                [disabled]="!customTemplate.sections['footer'].data['message1']?.display"
+                                                                [appTributeMention]="{
+                                                                    trigger: '{',
+                                                                    suggestionPrefix: '{',
+                                                                    suggestionSuffix: '}',
+                                                                }"
+                                                                [appTributeMentionValues]="suggestionList"
+                                                                (focus)="onCharacterFieldFocus('footer', 'message1', 'value')"
+                                                                (blur)="onCharacterFieldBlur()"
+                                                                [attr.lang]="primaryLangCode"
+                                                                [attr.dir]="primaryLangDirection"
+                                                            ></textarea>
+                                                        </mat-form-field>
+                                                    </td>
+                                                    <td class="p-2 text-center">
+                                                        <span class="font-size-12">
+                                                            @if (isCharacterFieldFocused('footer', 'message1', 'value')) {
+                                                                {{
+                                                                    getRemainingCharacters(
+                                                                        200,
+                                                                        customTemplate.sections['footer'].data['message1']?.value
+                                                                    )
+                                                                }}/{{ 200 }}
+                                                            }
+                                                        </span>
+                                                    </td>
+                                                </tr>
+                                            }
 
                                             @if (!isThermalTemplate && showSecondaryLabel) {
                                                 <tr id="message1Row2Label">
@@ -2787,22 +2876,24 @@
                                                     <td class="p-2"></td>
                                                     <td class="p-2" [attr.colspan]="showSecondaryLabel ? 2 : 1">
                                                         <!-- Label for Note 1 (Declaration:) -->
-                                                        <div class="d-flex align-items-center column-gap-1">
-                                                            <ng-container
-                                                                *ngTemplateOutlet="
-                                                                    labelRowInput;
-                                                                    context: {
-                                                                        key: 'secondaryLabel',
-                                                                        showInputField: true,
-                                                                        section: 'footer',
-                                                                        field: 'message1',
-                                                                        name: 'message1SecondaryLabelonly',
-                                                                        maxLength: 15,
-                                                                        callbacks: [onChangeFieldVisibility],
-                                                                    }
-                                                                "
-                                                            ></ng-container>
-                                                        </div>
+                                                        @if (isTallyTemplate) {
+                                                            <div class="d-flex align-items-center column-gap-1">
+                                                                <ng-container
+                                                                    *ngTemplateOutlet="
+                                                                        labelRowInput;
+                                                                        context: {
+                                                                            key: 'secondaryLabel',
+                                                                            showInputField: true,
+                                                                            section: 'footer',
+                                                                            field: 'message1',
+                                                                            name: 'message1SecondaryLabelonly',
+                                                                            maxLength: 15,
+                                                                            callbacks: [onChangeFieldVisibility],
+                                                                        }
+                                                                    "
+                                                                ></ng-container>
+                                                            </div>
+                                                        }
                                                     </td>
                                                     <td class="p-2 text-center">
                                                         <span class="font-size-12">
@@ -2883,7 +2974,7 @@
                                                     labelRow;
                                                     context: {
                                                         rowId: 'showMessage2Row',
-                                                        showInputField: true,
+                                                        showInputField: isTallyTemplate,
                                                         showCheckbox: true,
                                                         section: 'footer',
                                                         field: 'showMessage2',
@@ -2891,7 +2982,7 @@
                                                         name: 'showMessage2',
                                                         label: localeData?.note_2,
                                                         maxLength: 20,
-                                                        showSecondaryLabel: showSecondaryLabel,
+                                                        showSecondaryLabel: isTallyTemplate,
                                                     }
                                                 "
                                             ></ng-container>

--- a/apps/web-giddh/src/app/vouchers/template/template-edit-filter/template-edit-filter.component.ts
+++ b/apps/web-giddh/src/app/vouchers/template/template-edit-filter/template-edit-filter.component.ts
@@ -678,7 +678,7 @@ export class TemplateEditFilterComponent implements OnInit {
                 return;
             }
             Object.keys(sectionData).forEach(key => {
-                if(key === 'message1') {
+                if (key === 'message1') {
                     sectionData[key].secondaryValue = sectionTranslations['message1Value'];
                     sectionData[key].secondaryLabel = sectionTranslations['message1Label'];
                     return;

--- a/apps/web-giddh/src/app/vouchers/template/template-edit-filter/template-edit-filter.component.ts
+++ b/apps/web-giddh/src/app/vouchers/template/template-edit-filter/template-edit-filter.component.ts
@@ -677,9 +677,9 @@ export class TemplateEditFilterComponent implements OnInit {
         // "gstin"/"shippingGstin"/"billingGstin" additionally depend on the company's country
         // (VAT/TRN/Sales Tax/GSTIN) and their primary label already reflects the correct text.
         const skipKeysBySection: { [section: string]: string[] } = {
-            header: ['gstin', 'shippingGstin', 'billingGstin', 'pan', 'displayLutNumber', 'showElectronicInvoiceIdentifier'],
-            footer: ['tds', 'tcs'],
-            table: ['hsnSac', 'taxBifurcationHsnSac', 'sacIndicator', 'hsnIndicator', 'eoe']
+            header: [],
+            footer: [],
+            table: ['eoe']
         };
         ['header', 'footer', 'table'].forEach(section => {
             const sectionData = template?.sections?.[section]?.data;
@@ -690,6 +690,11 @@ export class TemplateEditFilterComponent implements OnInit {
             const skipKeys = skipKeysBySection[section] || [];
             Object.keys(sectionData).forEach(key => {
                 if (skipKeys.includes(key)) {
+                    return;
+                }
+                if(key === 'message1') {
+                    sectionData[key].secondaryValue = sectionTranslations['message1Value'];
+                    sectionData[key].secondaryLabel = sectionTranslations['message1Label'];
                     return;
                 }
                 if (sectionTranslations[key] !== undefined) {
@@ -1298,7 +1303,7 @@ export class TemplateEditFilterComponent implements OnInit {
     public handleEnableSecondaryLanguage(): void {
         this.customTemplate.displayLanguage1 = true;
         this.customTemplate.displayLanguage2 = this.customTemplate.enableSecondaryLanguage;
-        this.customTemplate.secondaryLabelFirst = false;
+        this.customTemplate.showLanguage2DisplayedFirst = false;
         this.customTemplate.language1Code = "en";
         this.customTemplate.language2Code = null;
         this.resetSelectedLanguage();

--- a/apps/web-giddh/src/app/vouchers/template/template-edit-filter/template-edit-filter.component.ts
+++ b/apps/web-giddh/src/app/vouchers/template/template-edit-filter/template-edit-filter.component.ts
@@ -671,27 +671,13 @@ export class TemplateEditFilterComponent implements OnInit {
         }
 
         const template = cloneDeep(this.customTemplate);
-        // These fields are statutory abbreviations that stay identical across every language
-        // (e.g. GSTIN/PAN/HSN/SAC/TDS/TCS). Filling secondaryLabel for them would just show the
-        // exact same text twice (e.g. "TRN TRN", "HSN/SAC HSN/SAC"), so leave them untouched.
-        // "gstin"/"shippingGstin"/"billingGstin" additionally depend on the company's country
-        // (VAT/TRN/Sales Tax/GSTIN) and their primary label already reflects the correct text.
-        const skipKeysBySection: { [section: string]: string[] } = {
-            header: [],
-            footer: [],
-            table: ['eoe']
-        };
         ['header', 'footer', 'table'].forEach(section => {
             const sectionData = template?.sections?.[section]?.data;
             const sectionTranslations = translations?.[section];
             if (!sectionData || !sectionTranslations) {
                 return;
             }
-            const skipKeys = skipKeysBySection[section] || [];
             Object.keys(sectionData).forEach(key => {
-                if (skipKeys.includes(key)) {
-                    return;
-                }
                 if(key === 'message1') {
                     sectionData[key].secondaryValue = sectionTranslations['message1Value'];
                     sectionData[key].secondaryLabel = sectionTranslations['message1Label'];

--- a/apps/web-giddh/src/assets/locale/invoice/template-secondary-labels.json
+++ b/apps/web-giddh/src/assets/locale/invoice/template-secondary-labels.json
@@ -32,7 +32,10 @@
             "displayLutNumber": "LUT Number",
             "showElectronicInvoiceIdentifier": "IRN",
             "customerEmail": "البريد الإلكتروني",
-            "customerMobileNumber": "رقم الهاتف"
+            "customerMobileNumber": "رقم الهاتف",
+            "customField1": "حقل مخصص 1",
+            "customField2": "حقل مخصص 2",
+            "customField3": "حقل مخصص 3"
         },
         "footer": {
             "taxableAmount": "المبلغ الخاضع للضريبة",
@@ -116,7 +119,10 @@
             "displayLutNumber": "LUT Number",
             "showElectronicInvoiceIdentifier": "IRN",
             "customerEmail": "ईमेल",
-            "customerMobileNumber": "फ़ोन नंबर"
+            "customerMobileNumber": "फ़ोन नंबर",
+            "customField1": "कस्टम फ़ील्ड 1",
+            "customField2": "कस्टम फ़ील्ड 2",
+            "customField3": "कस्टम फ़ील्ड 3"
         },
         "footer": {
             "taxableAmount": "कर योग्य राशि",
@@ -200,7 +206,10 @@
             "displayLutNumber": "LUT Number",
             "showElectronicInvoiceIdentifier": "IRN",
             "customerEmail": "ईमेल",
-            "customerMobileNumber": "फोन नंबर"
+            "customerMobileNumber": "फोन नंबर",
+            "customField1": "कस्टम फील्ड 1",
+            "customField2": "कस्टम फील्ड 2",
+            "customField3": "कस्टम फील्ड 3"
         },
         "footer": {
             "taxableAmount": "करपात्र रक्कम",
@@ -284,7 +293,10 @@
             "displayLutNumber": "LUT Number",
             "showElectronicInvoiceIdentifier": "IRN",
             "customerEmail": "ઈમેઈલ",
-            "customerMobileNumber": "ફોન નંબર"
+            "customerMobileNumber": "ફોન નંબર",
+            "customField1": "કસ્ટમ ફીલ્ડ 1",
+            "customField2": "કસ્ટમ ફીલ્ડ 2",
+            "customField3": "કસ્ટમ ફીલ્ડ 3"
         },
         "footer": {
             "taxableAmount": "કરપાત્ર રકમ",
@@ -368,7 +380,10 @@
             "displayLutNumber": "LUT Number",
             "showElectronicInvoiceIdentifier": "IRN",
             "customerEmail": "ਈਮੇਲ",
-            "customerMobileNumber": "ਫੋਨ ਨੰਬਰ"
+            "customerMobileNumber": "ਫੋਨ ਨੰਬਰ",
+            "customField1": "ਕਸਟਮ ਫੀਲਡ 1",
+            "customField2": "ਕਸਟਮ ਫੀਲਡ 2",
+            "customField3": "ਕਸਟਮ ਫੀਲਡ 3"
         },
         "footer": {
             "taxableAmount": "ਟੈਕਸਯੋਗ ਰਕਮ",
@@ -452,7 +467,10 @@
             "displayLutNumber": "LUT Number",
             "showElectronicInvoiceIdentifier": "IRN",
             "customerEmail": "மின்னஞ்சல்",
-            "customerMobileNumber": "தொலைபேசி எண்"
+            "customerMobileNumber": "தொலைபேசி எண்",
+            "customField1": "தனிப்பயன் புலம் 1",
+            "customField2": "தனிப்பயன் புலம் 2",
+            "customField3": "தனிப்பயன் புலம் 3"
         },
         "footer": {
             "taxableAmount": "வரி விதிக்கத்தக்க தொகை",
@@ -536,7 +554,10 @@
             "displayLutNumber": "LUT Number",
             "showElectronicInvoiceIdentifier": "IRN",
             "customerEmail": "ఇమెయిల్",
-            "customerMobileNumber": "ఫోన్ నంబర్"
+            "customerMobileNumber": "ఫోన్ నంబర్",
+            "customField1": "కస్టమ్ ఫీల్డ్ 1",
+            "customField2": "కస్టమ్ ఫీల్డ్ 2",
+            "customField3": "కస్టమ్ ఫీల్డ్ 3"
         },
         "footer": {
             "taxableAmount": "పన్ను విధించదగిన మొత్తం",
@@ -620,7 +641,10 @@
             "displayLutNumber": "LUT Number",
             "showElectronicInvoiceIdentifier": "IRN",
             "customerEmail": "ಇಮೇಲ್",
-            "customerMobileNumber": "ಫೋನ್ ಸಂಖ್ಯೆ"
+            "customerMobileNumber": "ಫೋನ್ ಸಂಖ್ಯೆ",
+            "customField1": "ಕಸ್ಟಮ್ ಫೀಲ್ಡ್ 1",
+            "customField2": "ಕಸ್ಟಮ್ ಫೀಲ್ಡ್ 2",
+            "customField3": "ಕಸ್ಟಮ್ ಫೀಲ್ಡ್ 3"
         },
         "footer": {
             "taxableAmount": "ತೆರಿಗೆ ವಿಧಿಸಬಹುದಾದ ಮೊತ್ತ",
@@ -704,7 +728,10 @@
             "displayLutNumber": "LUT Number",
             "showElectronicInvoiceIdentifier": "IRN",
             "customerEmail": "ഇമെയിൽ",
-            "customerMobileNumber": "ഫോൺ നമ്പർ"
+            "customerMobileNumber": "ഫോൺ നമ്പർ",
+            "customField1": "കസ്റ്റം ഫീൽഡ് 1",
+            "customField2": "കസ്റ്റം ഫീൽഡ് 2",
+            "customField3": "കസ്റ്റം ഫീൽഡ് 3"
         },
         "footer": {
             "taxableAmount": "നികുതി വിധേയമായ തുക",
@@ -788,7 +815,10 @@
             "displayLutNumber": "LUT Number",
             "showElectronicInvoiceIdentifier": "IRN",
             "customerEmail": "ইমেইল",
-            "customerMobileNumber": "ফোন নম্বর"
+            "customerMobileNumber": "ফোন নম্বর",
+            "customField1": "কাস্টম ফিল্ড 1",
+            "customField2": "কাস্টম ফিল্ড 2",
+            "customField3": "কাস্টম ফিল্ড 3"
         },
         "footer": {
             "taxableAmount": "করযোগ্য পরিমাণ",
@@ -872,7 +902,10 @@
             "displayLutNumber": "LUT Number",
             "showElectronicInvoiceIdentifier": "IRN",
             "customerEmail": "ଇମେଲ୍",
-            "customerMobileNumber": "ଫୋନ୍ ନମ୍ବର"
+            "customerMobileNumber": "ଫୋନ୍ ନମ୍ବର",
+            "customField1": "କଷ୍ଟମ୍ ଫିଲ୍ଡ 1",
+            "customField2": "କଷ୍ଟମ୍ ଫିଲ୍ଡ 2",
+            "customField3": "କଷ୍ଟମ୍ ଫିଲ୍ଡ 3"
         },
         "footer": {
             "taxableAmount": "କରଯୋଗ୍ୟ ପରିମାଣ",
@@ -956,7 +989,10 @@
             "displayLutNumber": "LUT Number",
             "showElectronicInvoiceIdentifier": "IRN",
             "customerEmail": "ای میل",
-            "customerMobileNumber": "فون نمبر"
+            "customerMobileNumber": "فون نمبر",
+            "customField1": "حسب ضرورت فیلڈ 1",
+            "customField2": "حسب ضرورت فیلڈ 2",
+            "customField3": "حسب ضرورت فیلڈ 3"
         },
         "footer": {
             "taxableAmount": "ٹیکس کے قابل رقم",
@@ -1040,7 +1076,10 @@
             "displayLutNumber": "LUT Number",
             "showElectronicInvoiceIdentifier": "IRN",
             "customerEmail": "E-mail",
-            "customerMobileNumber": "Numéro de téléphone"
+            "customerMobileNumber": "Numéro de téléphone",
+            "customField1": "Champ personnalisé 1",
+            "customField2": "Champ personnalisé 2",
+            "customField3": "Champ personnalisé 3"
         },
         "footer": {
             "taxableAmount": "Montant imposable",
@@ -1124,7 +1163,10 @@
             "displayLutNumber": "LUT Number",
             "showElectronicInvoiceIdentifier": "IRN",
             "customerEmail": "E-Mail",
-            "customerMobileNumber": "Telefonnummer"
+            "customerMobileNumber": "Telefonnummer",
+            "customField1": "Benutzerdefiniertes Feld 1",
+            "customField2": "Benutzerdefiniertes Feld 2",
+            "customField3": "Benutzerdefiniertes Feld 3"
         },
         "footer": {
             "taxableAmount": "Steuerpflichtiger Betrag",
@@ -1208,7 +1250,10 @@
             "displayLutNumber": "LUT Number",
             "showElectronicInvoiceIdentifier": "IRN",
             "customerEmail": "Correo electrónico",
-            "customerMobileNumber": "Número de teléfono"
+            "customerMobileNumber": "Número de teléfono",
+            "customField1": "Campo personalizado 1",
+            "customField2": "Campo personalizado 2",
+            "customField3": "Campo personalizado 3"
         },
         "footer": {
             "taxableAmount": "Monto imponible",
@@ -1292,7 +1337,10 @@
             "displayLutNumber": "LUT Number",
             "showElectronicInvoiceIdentifier": "IRN",
             "customerEmail": "E-mail",
-            "customerMobileNumber": "Número de telefone"
+            "customerMobileNumber": "Número de telefone",
+            "customField1": "Campo personalizado 1",
+            "customField2": "Campo personalizado 2",
+            "customField3": "Campo personalizado 3"
         },
         "footer": {
             "taxableAmount": "Valor tributável",
@@ -1376,7 +1424,10 @@
             "displayLutNumber": "LUT Number",
             "showElectronicInvoiceIdentifier": "IRN",
             "customerEmail": "Email",
-            "customerMobileNumber": "Numero di telefono"
+            "customerMobileNumber": "Numero di telefono",
+            "customField1": "Campo personalizzato 1",
+            "customField2": "Campo personalizzato 2",
+            "customField3": "Campo personalizzato 3"
         },
         "footer": {
             "taxableAmount": "Importo imponibile",
@@ -1460,7 +1511,10 @@
             "displayLutNumber": "LUT Number",
             "showElectronicInvoiceIdentifier": "IRN",
             "customerEmail": "E-mail",
-            "customerMobileNumber": "Telefoonnummer"
+            "customerMobileNumber": "Telefoonnummer",
+            "customField1": "Aangepast veld 1",
+            "customField2": "Aangepast veld 2",
+            "customField3": "Aangepast veld 3"
         },
         "footer": {
             "taxableAmount": "Belastbaar bedrag",
@@ -1544,7 +1598,10 @@
             "displayLutNumber": "LUT Number",
             "showElectronicInvoiceIdentifier": "IRN",
             "customerEmail": "Электронная почта",
-            "customerMobileNumber": "Номер телефона"
+            "customerMobileNumber": "Номер телефона",
+            "customField1": "Пользовательское поле 1",
+            "customField2": "Пользовательское поле 2",
+            "customField3": "Пользовательское поле 3"
         },
         "footer": {
             "taxableAmount": "Налогооблагаемая сумма",
@@ -1628,7 +1685,10 @@
             "displayLutNumber": "LUT Number",
             "showElectronicInvoiceIdentifier": "IRN",
             "customerEmail": "E-posta",
-            "customerMobileNumber": "Telefon numarası"
+            "customerMobileNumber": "Telefon numarası",
+            "customField1": "Özel alan 1",
+            "customField2": "Özel alan 2",
+            "customField3": "Özel alan 3"
         },
         "footer": {
             "taxableAmount": "Vergiye Tabi Tutar",
@@ -1712,7 +1772,10 @@
             "displayLutNumber": "LUT Number",
             "showElectronicInvoiceIdentifier": "IRN",
             "customerEmail": "ایمیل",
-            "customerMobileNumber": "شماره تلفن"
+            "customerMobileNumber": "شماره تلفن",
+            "customField1": "فیلد سفارشی 1",
+            "customField2": "فیلد سفارشی 2",
+            "customField3": "فیلد سفارشی 3"
         },
         "footer": {
             "taxableAmount": "مبلغ مشمول مالیات",
@@ -1796,7 +1859,10 @@
             "displayLutNumber": "LUT Number",
             "showElectronicInvoiceIdentifier": "IRN",
             "customerEmail": "אימייל",
-            "customerMobileNumber": "מספר טלפון"
+            "customerMobileNumber": "מספר טלפון",
+            "customField1": "שדה מותאם אישית 1",
+            "customField2": "שדה מותאם אישית 2",
+            "customField3": "שדה מותאם אישית 3"
         },
         "footer": {
             "taxableAmount": "סכום חייב במס",
@@ -1880,7 +1946,10 @@
             "displayLutNumber": "LUT Number",
             "showElectronicInvoiceIdentifier": "IRN",
             "customerEmail": "电子邮件",
-            "customerMobileNumber": "电话号码"
+            "customerMobileNumber": "电话号码",
+            "customField1": "自定义字段 1",
+            "customField2": "自定义字段 2",
+            "customField3": "自定义字段 3"
         },
         "footer": {
             "taxableAmount": "应税金额",
@@ -1964,7 +2033,10 @@
             "displayLutNumber": "LUT Number",
             "showElectronicInvoiceIdentifier": "IRN",
             "customerEmail": "電子郵件",
-            "customerMobileNumber": "電話號碼"
+            "customerMobileNumber": "電話號碼",
+            "customField1": "自訂欄位 1",
+            "customField2": "自訂欄位 2",
+            "customField3": "自訂欄位 3"
         },
         "footer": {
             "taxableAmount": "應稅金額",
@@ -2048,7 +2120,10 @@
             "displayLutNumber": "LUT Number",
             "showElectronicInvoiceIdentifier": "IRN",
             "customerEmail": "メール",
-            "customerMobileNumber": "電話番号"
+            "customerMobileNumber": "電話番号",
+            "customField1": "カスタムフィールド 1",
+            "customField2": "カスタムフィールド 2",
+            "customField3": "カスタムフィールド 3"
         },
         "footer": {
             "taxableAmount": "課税対象額",
@@ -2132,7 +2207,10 @@
             "displayLutNumber": "LUT Number",
             "showElectronicInvoiceIdentifier": "IRN",
             "customerEmail": "이메일",
-            "customerMobileNumber": "전화번호"
+            "customerMobileNumber": "전화번호",
+            "customField1": "사용자 정의 필드 1",
+            "customField2": "사용자 정의 필드 2",
+            "customField3": "사용자 정의 필드 3"
         },
         "footer": {
             "taxableAmount": "과세 대상 금액",
@@ -2216,7 +2294,10 @@
             "displayLutNumber": "LUT Number",
             "showElectronicInvoiceIdentifier": "IRN",
             "customerEmail": "อีเมล",
-            "customerMobileNumber": "หมายเลขโทรศัพท์"
+            "customerMobileNumber": "หมายเลขโทรศัพท์",
+            "customField1": "ฟิลด์กำหนดเอง 1",
+            "customField2": "ฟิลด์กำหนดเอง 2",
+            "customField3": "ฟิลด์กำหนดเอง 3"
         },
         "footer": {
             "taxableAmount": "จำนวนเงินที่ต้องเสียภาษี",
@@ -2300,7 +2381,10 @@
             "displayLutNumber": "LUT Number",
             "showElectronicInvoiceIdentifier": "IRN",
             "customerEmail": "Email",
-            "customerMobileNumber": "Số điện thoại"
+            "customerMobileNumber": "Số điện thoại",
+            "customField1": "Trường tùy chỉnh 1",
+            "customField2": "Trường tùy chỉnh 2",
+            "customField3": "Trường tùy chỉnh 3"
         },
         "footer": {
             "taxableAmount": "Số tiền chịu thuế",
@@ -2384,7 +2468,10 @@
             "displayLutNumber": "LUT Number",
             "showElectronicInvoiceIdentifier": "IRN",
             "customerEmail": "Email",
-            "customerMobileNumber": "Nomor telepon"
+            "customerMobileNumber": "Nomor telepon",
+            "customField1": "Bidang kustom 1",
+            "customField2": "Bidang kustom 2",
+            "customField3": "Bidang kustom 3"
         },
         "footer": {
             "taxableAmount": "Jumlah Kena Pajak",
@@ -2468,7 +2555,10 @@
             "displayLutNumber": "LUT Number",
             "showElectronicInvoiceIdentifier": "IRN",
             "customerEmail": "E-mel",
-            "customerMobileNumber": "Nombor telefon"
+            "customerMobileNumber": "Nombor telefon",
+            "customField1": "Medan tersuai 1",
+            "customField2": "Medan tersuai 2",
+            "customField3": "Medan tersuai 3"
         },
         "footer": {
             "taxableAmount": "Jumlah Boleh Cukai",

--- a/apps/web-giddh/src/assets/locale/invoice/template-secondary-labels.json
+++ b/apps/web-giddh/src/assets/locale/invoice/template-secondary-labels.json
@@ -30,7 +30,9 @@
             "billingGstin": "GSTIN",
             "pan": "PAN",
             "displayLutNumber": "LUT Number",
-            "showElectronicInvoiceIdentifier": "IRN"
+            "showElectronicInvoiceIdentifier": "IRN",
+            "customerEmail": "البريد الإلكتروني",
+            "customerMobileNumber": "رقم الهاتف"
         },
         "footer": {
             "taxableAmount": "المبلغ الخاضع للضريبة",
@@ -41,9 +43,12 @@
             "totalInWordsInAccountsCurrency": "إجمالي الفاتورة (بالكلمات)",
             "totalTax": "إجمالي الضريبة*",
             "totalInWords": "إجمالي الفاتورة (بالكلمات)",
-            "message1": "نقر بأن هذه الفاتورة تظهر السعر الفعلي للخدمات المقدمة وأن جميع البيانات صحيحة ودقيقة.",
+            "message1Label": "تصريح:",
+            "message1Value": "نقر بأن هذه الفاتورة تظهر السعر الفعلي للخدمات المقدمة وأن جميع البيانات صحيحة ودقيقة.",
             "tds": "TDS",
-            "tcs": "TCS"
+            "tcs": "TCS",
+            "showMessage2": "ملاحظة:",
+            "thanks": "شكراً لتعاملكم معنا!"
         },
         "table": {
             "date": "التاريخ",
@@ -109,7 +114,9 @@
             "billingGstin": "GSTIN",
             "pan": "PAN",
             "displayLutNumber": "LUT Number",
-            "showElectronicInvoiceIdentifier": "IRN"
+            "showElectronicInvoiceIdentifier": "IRN",
+            "customerEmail": "ईमेल",
+            "customerMobileNumber": "फ़ोन नंबर"
         },
         "footer": {
             "taxableAmount": "कर योग्य राशि",
@@ -120,9 +127,12 @@
             "totalInWordsInAccountsCurrency": "चालान कुल (शब्दों में)",
             "totalTax": "कुल कर*",
             "totalInWords": "चालान कुल (शब्दों में)",
-            "message1": "हम घोषणा करते हैं कि यह चालान प्रदान की गई सेवाओं की वास्तविक कीमत दर्शाता है और सभी विवरण सत्य और सही हैं।",
             "tds": "TDS",
-            "tcs": "TCS"
+            "tcs": "TCS",
+            "message1Label": "घोषणा:",
+            "message1Value": "हम घोषणा करते हैं कि यह चालान प्रदान की गई सेवाओं की वास्तविक कीमत दर्शाता है और सभी विवरण सत्य और सही हैं।",
+            "showMessage2": "नोट:",
+            "thanks": "आपके व्यवसाय के लिए धन्यवाद!"
         },
         "table": {
             "date": "तिथि",
@@ -188,7 +198,9 @@
             "billingGstin": "GSTIN",
             "pan": "PAN",
             "displayLutNumber": "LUT Number",
-            "showElectronicInvoiceIdentifier": "IRN"
+            "showElectronicInvoiceIdentifier": "IRN",
+            "customerEmail": "ईमेल",
+            "customerMobileNumber": "फोन नंबर"
         },
         "footer": {
             "taxableAmount": "करपात्र रक्कम",
@@ -199,9 +211,12 @@
             "totalInWordsInAccountsCurrency": "बीजक एकूण (शब्दात)",
             "totalTax": "एकूण कर*",
             "totalInWords": "बीजक एकूण (शब्दात)",
-            "message1": "आम्ही घोषित करतो की हे बीजक प्रदान केलेल्या सेवांची वास्तविक किंमत दर्शवते आणि सर्व तपशील खरे व बरोबर आहेत.",
             "tds": "TDS",
-            "tcs": "TCS"
+            "tcs": "TCS",
+            "message1Label": "घोषणा:",
+            "message1Value": "आम्ही घोषित करतो की हे बीजक प्रदान केलेल्या सेवांची वास्तविक किंमत दर्शवते आणि सर्व तपशील खरे व बरोबर आहेत.",
+            "showMessage2": "टीप:",
+            "thanks": "तुमच्या व्यवसायाबद्दल धन्यवाद!"
         },
         "table": {
             "date": "तारीख",
@@ -267,7 +282,9 @@
             "billingGstin": "GSTIN",
             "pan": "PAN",
             "displayLutNumber": "LUT Number",
-            "showElectronicInvoiceIdentifier": "IRN"
+            "showElectronicInvoiceIdentifier": "IRN",
+            "customerEmail": "ઈમેઈલ",
+            "customerMobileNumber": "ફોન નંબર"
         },
         "footer": {
             "taxableAmount": "કરપાત્ર રકમ",
@@ -278,9 +295,12 @@
             "totalInWordsInAccountsCurrency": "ઇનવોઇસ કુલ (શબ્દોમાં)",
             "totalTax": "કુલ કર*",
             "totalInWords": "ઇનવોઇસ કુલ (શબ્દોમાં)",
-            "message1": "અમે જાહેર કરીએ છીએ કે આ ઇનવોઇસ પૂરી પાડવામાં આવેલી સેવાઓની વાસ્તવિક કિંમત દર્શાવે છે અને તમામ વિગતો સાચી અને સચોટ છે.",
             "tds": "TDS",
-            "tcs": "TCS"
+            "tcs": "TCS",
+            "message1Label": "ઘોષણા:",
+            "message1Value": "અમે જાહેર કરીએ છીએ કે આ ઇનવોઇસ પૂરી પાડવામાં આવેલી સેવાઓની વાસ્તવિક કિંમત દર્શાવે છે અને તમામ વિગતો સાચી અને સચોટ છે.",
+            "showMessage2": "નોંધ:",
+            "thanks": "તમારા વ્યવસાય માટે આભાર!"
         },
         "table": {
             "date": "તારીખ",
@@ -346,7 +366,9 @@
             "billingGstin": "GSTIN",
             "pan": "PAN",
             "displayLutNumber": "LUT Number",
-            "showElectronicInvoiceIdentifier": "IRN"
+            "showElectronicInvoiceIdentifier": "IRN",
+            "customerEmail": "ਈਮੇਲ",
+            "customerMobileNumber": "ਫੋਨ ਨੰਬਰ"
         },
         "footer": {
             "taxableAmount": "ਟੈਕਸਯੋਗ ਰਕਮ",
@@ -357,9 +379,12 @@
             "totalInWordsInAccountsCurrency": "ਇਨਵਾਇਸ ਕੁੱਲ (ਸ਼ਬਦਾਂ ਵਿੱਚ)",
             "totalTax": "ਕੁੱਲ ਟੈਕਸ*",
             "totalInWords": "ਇਨਵਾਇਸ ਕੁੱਲ (ਸ਼ਬਦਾਂ ਵਿੱਚ)",
-            "message1": "ਅਸੀਂ ਐਲਾਨ ਕਰਦੇ ਹਾਂ ਕਿ ਇਹ ਇਨਵਾਇਸ ਪ੍ਰਦਾਨ ਕੀਤੀਆਂ ਸੇਵਾਵਾਂ ਦੀ ਅਸਲ ਕੀਮਤ ਦਰਸਾਉਂਦਾ ਹੈ ਅਤੇ ਸਾਰੇ ਵੇਰਵੇ ਸਹੀ ਹਨ।",
             "tds": "TDS",
-            "tcs": "TCS"
+            "tcs": "TCS",
+            "message1Label": "ਘੋਸ਼ਣਾ:",
+            "message1Value": "ਅਸੀਂ ਐਲਾਨ ਕਰਦੇ ਹਾਂ ਕਿ ਇਹ ਇਨਵਾਇਸ ਪ੍ਰਦਾਨ ਕੀਤੀਆਂ ਸੇਵਾਵਾਂ ਦੀ ਅਸਲ ਕੀਮਤ ਦਰਸਾਉਂਦਾ ਹੈ ਅਤੇ ਸਾਰੇ ਵੇਰਵੇ ਸਹੀ ਹਨ।",
+            "showMessage2": "ਨੋਟ:",
+            "thanks": "ਤੁਹਾਡੇ ਕਾਰੋਬਾਰ ਲਈ ਧੰਨਵਾਦ!"
         },
         "table": {
             "date": "ਮਿਤੀ",
@@ -425,7 +450,9 @@
             "billingGstin": "GSTIN",
             "pan": "PAN",
             "displayLutNumber": "LUT Number",
-            "showElectronicInvoiceIdentifier": "IRN"
+            "showElectronicInvoiceIdentifier": "IRN",
+            "customerEmail": "மின்னஞ்சல்",
+            "customerMobileNumber": "தொலைபேசி எண்"
         },
         "footer": {
             "taxableAmount": "வரி விதிக்கத்தக்க தொகை",
@@ -436,9 +463,12 @@
             "totalInWordsInAccountsCurrency": "விலைப்பட்டியல் மொத்தம் (சொற்களில்)",
             "totalTax": "மொத்த வரி*",
             "totalInWords": "விலைப்பட்டியல் மொத்தம் (சொற்களில்)",
-            "message1": "வழங்கப்பட்ட சேவைகளின் உண்மையான விலையை இந்த விலைப்பட்டியல் காட்டுகிறது என்றும் அனைத்து விவரங்களும் உண்மையானவை மற்றும் சரியானவை என்றும் நாங்கள் அறிவிக்கிறோம்.",
             "tds": "TDS",
-            "tcs": "TCS"
+            "tcs": "TCS",
+            "message1Label": "அறிவிப்பு:",
+            "message1Value": "வழங்கப்பட்ட சேவைகளின் உண்மையான விலையை இந்த விலைப்பட்டியல் காட்டுகிறது என்றும் அனைத்து விவரங்களும் உண்மையானவை மற்றும் சரியானவை என்றும் நாங்கள் அறிவிக்கிறோம்.",
+            "showMessage2": "குறிப்பு:",
+            "thanks": "உங்கள் வணிகத்திற்கு நன்றி!"
         },
         "table": {
             "date": "தேதி",
@@ -504,7 +534,9 @@
             "billingGstin": "GSTIN",
             "pan": "PAN",
             "displayLutNumber": "LUT Number",
-            "showElectronicInvoiceIdentifier": "IRN"
+            "showElectronicInvoiceIdentifier": "IRN",
+            "customerEmail": "ఇమెయిల్",
+            "customerMobileNumber": "ఫోన్ నంబర్"
         },
         "footer": {
             "taxableAmount": "పన్ను విధించదగిన మొత్తం",
@@ -515,9 +547,12 @@
             "totalInWordsInAccountsCurrency": "ఇన్వాయిస్ మొత్తం (అక్షరాలలో)",
             "totalTax": "మొత్తం పన్ను*",
             "totalInWords": "ఇన్వాయిస్ మొత్తం (అక్షరాలలో)",
-            "message1": "ఈ ఇన్వాయిస్ అందించిన సేవల వాస్తవ ధరను చూపిస్తుందని మరియు అన్ని వివరాలు నిజమైనవి మరియు సరైనవని మేము ప్రకటిస్తున్నాము.",
             "tds": "TDS",
-            "tcs": "TCS"
+            "tcs": "TCS",
+            "message1Label": "ప్రకటన:",
+            "message1Value": "ఈ ఇన్వాయిస్ అందించిన సేవల వాస్తవ ధరను చూపిస్తుందని మరియు అన్ని వివరాలు నిజమైనవి మరియు సరైనవని మేము ప్రకటిస్తున్నాము.",
+            "showMessage2": "గమనిక:",
+            "thanks": "మీ వ్యాపారానికి ధన్యవాదాలు!"
         },
         "table": {
             "date": "తేదీ",
@@ -583,7 +618,9 @@
             "billingGstin": "GSTIN",
             "pan": "PAN",
             "displayLutNumber": "LUT Number",
-            "showElectronicInvoiceIdentifier": "IRN"
+            "showElectronicInvoiceIdentifier": "IRN",
+            "customerEmail": "ಇಮೇಲ್",
+            "customerMobileNumber": "ಫೋನ್ ಸಂಖ್ಯೆ"
         },
         "footer": {
             "taxableAmount": "ತೆರಿಗೆ ವಿಧಿಸಬಹುದಾದ ಮೊತ್ತ",
@@ -594,9 +631,12 @@
             "totalInWordsInAccountsCurrency": "ಇನ್ವಾಯ್ಸ್ ಒಟ್ಟು (ಪದಗಳಲ್ಲಿ)",
             "totalTax": "ಒಟ್ಟು ತೆರಿಗೆ*",
             "totalInWords": "ಇನ್ವಾಯ್ಸ್ ಒಟ್ಟು (ಪದಗಳಲ್ಲಿ)",
-            "message1": "ಈ ಇನ್ವಾಯ್ಸ್ ಒದಗಿಸಿದ ಸೇವೆಗಳ ನಿಜವಾದ ಬೆಲೆಯನ್ನು ತೋರಿಸುತ್ತದೆ ಮತ್ತು ಎಲ್ಲಾ ವಿವರಗಳು ನಿಜ ಮತ್ತು ಸರಿಯಾಗಿವೆ ಎಂದು ನಾವು ಘೋಷಿಸುತ್ತೇವೆ.",
             "tds": "TDS",
-            "tcs": "TCS"
+            "tcs": "TCS",
+            "message1Label": "ಘೋಷಣೆ:",
+            "message1Value": "ಈ ಇನ್ವಾಯ್ಸ್ ಒದಗಿಸಿದ ಸೇವೆಗಳ ನಿಜವಾದ ಬೆಲೆಯನ್ನು ತೋರಿಸುತ್ತದೆ ಮತ್ತು ಎಲ್ಲಾ ವಿವರಗಳು ನಿಜ ಮತ್ತು ಸರಿಯಾಗಿವೆ ಎಂದು ನಾವು ಘೋಷಿಸುತ್ತೇವೆ.",
+            "showMessage2": "ಟಿಪ್ಪಣಿ:",
+            "thanks": "ನಿಮ್ಮ ವ್ಯವಹಾರಕ್ಕೆ ಧನ್ಯವಾದಗಳು!"
         },
         "table": {
             "date": "ದಿನಾಂಕ",
@@ -662,7 +702,9 @@
             "billingGstin": "GSTIN",
             "pan": "PAN",
             "displayLutNumber": "LUT Number",
-            "showElectronicInvoiceIdentifier": "IRN"
+            "showElectronicInvoiceIdentifier": "IRN",
+            "customerEmail": "ഇമെയിൽ",
+            "customerMobileNumber": "ഫോൺ നമ്പർ"
         },
         "footer": {
             "taxableAmount": "നികുതി വിധേയമായ തുക",
@@ -673,9 +715,12 @@
             "totalInWordsInAccountsCurrency": "ഇൻവോയ്സ് ആകെ (വാക്കുകളിൽ)",
             "totalTax": "ആകെ നികുതി*",
             "totalInWords": "ഇൻവോയ്സ് ആകെ (വാക്കുകളിൽ)",
-            "message1": "നൽകിയ സേവനങ്ങളുടെ യഥാർത്ഥ വില ഈ ഇൻവോയ്സ് കാണിക്കുന്നുവെന്നും എല്ലാ വിവരങ്ങളും ശരിയും കൃത്യവുമാണെന്നും ഞങ്ങൾ പ്രഖ്യാപിക്കുന്നു.",
             "tds": "TDS",
-            "tcs": "TCS"
+            "tcs": "TCS",
+            "message1Label": "പ്രഖ്യാപനം:",
+            "message1Value": "നൽകിയ സേവനങ്ങളുടെ യഥാർത്ഥ വില ഈ ഇൻവോയ്സ് കാണിക്കുന്നുവെന്നും എല്ലാ വിവരങ്ങളും ശരിയും കൃത്യവുമാണെന്നും ഞങ്ങൾ പ്രഖ്യാപിക്കുന്നു.",
+            "showMessage2": "കുറിപ്പ്:",
+            "thanks": "നിങ്ങളുടെ ബിസിനസ്സിന് നന്ദി!"
         },
         "table": {
             "date": "തീയതി",
@@ -741,7 +786,9 @@
             "billingGstin": "GSTIN",
             "pan": "PAN",
             "displayLutNumber": "LUT Number",
-            "showElectronicInvoiceIdentifier": "IRN"
+            "showElectronicInvoiceIdentifier": "IRN",
+            "customerEmail": "ইমেইল",
+            "customerMobileNumber": "ফোন নম্বর"
         },
         "footer": {
             "taxableAmount": "করযোগ্য পরিমাণ",
@@ -752,9 +799,12 @@
             "totalInWordsInAccountsCurrency": "চালান মোট (কথায়)",
             "totalTax": "মোট কর*",
             "totalInWords": "চালান মোট (কথায়)",
-            "message1": "আমরা ঘোষণা করছি যে এই চালানটি প্রদত্ত পরিষেবার প্রকৃত মূল্য দেখায় এবং সমস্ত বিবরণ সত্য এবং সঠিক।",
             "tds": "TDS",
-            "tcs": "TCS"
+            "tcs": "TCS",
+            "message1Label": "ঘোষণা:",
+            "message1Value": "আমরা ঘোষণা করছি যে এই চালানটি প্রদত্ত পরিষেবার প্রকৃত মূল্য দেখায় এবং সমস্ত বিবরণ সত্য এবং সঠিক।",
+            "showMessage2": "নোট:",
+            "thanks": "আপনার ব্যবসার জন্য ধন্যবাদ!"
         },
         "table": {
             "date": "তারিখ",
@@ -820,7 +870,9 @@
             "billingGstin": "GSTIN",
             "pan": "PAN",
             "displayLutNumber": "LUT Number",
-            "showElectronicInvoiceIdentifier": "IRN"
+            "showElectronicInvoiceIdentifier": "IRN",
+            "customerEmail": "ଇମେଲ୍",
+            "customerMobileNumber": "ଫୋନ୍ ନମ୍ବର"
         },
         "footer": {
             "taxableAmount": "କରଯୋଗ୍ୟ ପରିମାଣ",
@@ -831,9 +883,12 @@
             "totalInWordsInAccountsCurrency": "ଇନଭଏସ୍ ମୋଟ (ଶବ୍ଦରେ)",
             "totalTax": "ମୋଟ କର*",
             "totalInWords": "ଇନଭଏସ୍ ମୋଟ (ଶବ୍ଦରେ)",
-            "message1": "ଆମେ ଘୋଷଣା କରୁଛୁ ଯେ ଏହି ଇନଭଏସ୍ ପ୍ରଦତ୍ତ ସେବାର ପ୍ରକୃତ ମୂଲ୍ୟ ଦର୍ଶାଏ ଏବଂ ସମସ୍ତ ବିବରଣୀ ସତ୍ୟ ଏବଂ ସଠିକ୍।",
             "tds": "TDS",
-            "tcs": "TCS"
+            "tcs": "TCS",
+            "message1Label": "ଘୋଷଣା:",
+            "message1Value": "ଆମେ ଘୋଷଣା କରୁଛୁ ଯେ ଏହି ଇନଭଏସ୍ ପ୍ରଦତ୍ତ ସେବାର ପ୍ରକୃତ ମୂଲ୍ୟ ଦର୍ଶାଏ ଏବଂ ସମସ୍ତ ବିବରଣୀ ସତ୍ୟ ଏବଂ ସଠିକ୍।",
+            "showMessage2": "ନୋଟ୍:",
+            "thanks": "ଆପଣଙ୍କ ବ୍ୟବସାୟ ପାଇଁ ଧନ୍ୟବାଦ!"
         },
         "table": {
             "date": "ତାରିଖ",
@@ -899,7 +954,9 @@
             "billingGstin": "GSTIN",
             "pan": "PAN",
             "displayLutNumber": "LUT Number",
-            "showElectronicInvoiceIdentifier": "IRN"
+            "showElectronicInvoiceIdentifier": "IRN",
+            "customerEmail": "ای میل",
+            "customerMobileNumber": "فون نمبر"
         },
         "footer": {
             "taxableAmount": "ٹیکس کے قابل رقم",
@@ -910,9 +967,12 @@
             "totalInWordsInAccountsCurrency": "انوائس کل (الفاظ میں)",
             "totalTax": "کل ٹیکس*",
             "totalInWords": "انوائس کل (الفاظ میں)",
-            "message1": "ہم اعلان کرتے ہیں کہ یہ انوائس فراہم کردہ خدمات کی اصل قیمت ظاہر کرتا ہے اور تمام تفصیلات درست اور صحیح ہیں۔",
             "tds": "TDS",
-            "tcs": "TCS"
+            "tcs": "TCS",
+            "message1Label": "اعلان:",
+            "message1Value": "ہم اعلان کرتے ہیں کہ یہ انوائس فراہم کردہ خدمات کی اصل قیمت ظاہر کرتا ہے اور تمام تفصیلات درست اور صحیح ہیں۔",
+            "showMessage2": "نوٹ:",
+            "thanks": "آپ کے کاروبار کا شکریہ!"
         },
         "table": {
             "date": "تاریخ",
@@ -978,7 +1038,9 @@
             "billingGstin": "GSTIN",
             "pan": "PAN",
             "displayLutNumber": "LUT Number",
-            "showElectronicInvoiceIdentifier": "IRN"
+            "showElectronicInvoiceIdentifier": "IRN",
+            "customerEmail": "E-mail",
+            "customerMobileNumber": "Numéro de téléphone"
         },
         "footer": {
             "taxableAmount": "Montant imposable",
@@ -989,9 +1051,12 @@
             "totalInWordsInAccountsCurrency": "Total de la facture (en lettres)",
             "totalTax": "Taxe totale*",
             "totalInWords": "Total de la facture (en lettres)",
-            "message1": "Nous déclarons que cette facture indique le prix réel des services rendus et que toutes les informations sont vraies et exactes.",
             "tds": "TDS",
-            "tcs": "TCS"
+            "tcs": "TCS",
+            "message1Label": "Déclaration :",
+            "message1Value": "Nous déclarons que cette facture indique le prix réel des services rendus et que toutes les informations sont vraies et exactes.",
+            "showMessage2": "Remarque :",
+            "thanks": "Merci pour votre confiance !"
         },
         "table": {
             "date": "Date",
@@ -1057,7 +1122,9 @@
             "billingGstin": "GSTIN",
             "pan": "PAN",
             "displayLutNumber": "LUT Number",
-            "showElectronicInvoiceIdentifier": "IRN"
+            "showElectronicInvoiceIdentifier": "IRN",
+            "customerEmail": "E-Mail",
+            "customerMobileNumber": "Telefonnummer"
         },
         "footer": {
             "taxableAmount": "Steuerpflichtiger Betrag",
@@ -1068,9 +1135,12 @@
             "totalInWordsInAccountsCurrency": "Rechnungssumme (in Worten)",
             "totalTax": "Gesamtsteuer*",
             "totalInWords": "Rechnungssumme (in Worten)",
-            "message1": "Wir erklären, dass diese Rechnung den tatsächlichen Preis der erbrachten Dienstleistungen zeigt und alle Angaben wahr und korrekt sind.",
             "tds": "TDS",
-            "tcs": "TCS"
+            "tcs": "TCS",
+            "message1Label": "Erklärung:",
+            "message1Value": "Wir erklären, dass diese Rechnung den tatsächlichen Preis der erbrachten Dienstleistungen zeigt und alle Angaben wahr und korrekt sind.",
+            "showMessage2": "Hinweis:",
+            "thanks": "Vielen Dank für Ihr Vertrauen!"
         },
         "table": {
             "date": "Datum",
@@ -1136,7 +1206,9 @@
             "billingGstin": "GSTIN",
             "pan": "PAN",
             "displayLutNumber": "LUT Number",
-            "showElectronicInvoiceIdentifier": "IRN"
+            "showElectronicInvoiceIdentifier": "IRN",
+            "customerEmail": "Correo electrónico",
+            "customerMobileNumber": "Número de teléfono"
         },
         "footer": {
             "taxableAmount": "Monto imponible",
@@ -1147,9 +1219,12 @@
             "totalInWordsInAccountsCurrency": "Total de la factura (en palabras)",
             "totalTax": "Impuesto total*",
             "totalInWords": "Total de la factura (en palabras)",
-            "message1": "Declaramos que esta factura muestra el precio real de los servicios prestados y que todos los datos son verdaderos y correctos.",
             "tds": "TDS",
-            "tcs": "TCS"
+            "tcs": "TCS",
+            "message1Label": "Declaración:",
+            "message1Value": "Declaramos que esta factura muestra el precio real de los servicios prestados y que todos los datos son verdaderos y correctos.",
+            "showMessage2": "Nota:",
+            "thanks": "¡Gracias por su negocio!"
         },
         "table": {
             "date": "Fecha",
@@ -1215,7 +1290,9 @@
             "billingGstin": "GSTIN",
             "pan": "PAN",
             "displayLutNumber": "LUT Number",
-            "showElectronicInvoiceIdentifier": "IRN"
+            "showElectronicInvoiceIdentifier": "IRN",
+            "customerEmail": "E-mail",
+            "customerMobileNumber": "Número de telefone"
         },
         "footer": {
             "taxableAmount": "Valor tributável",
@@ -1226,9 +1303,12 @@
             "totalInWordsInAccountsCurrency": "Total da fatura (por extenso)",
             "totalTax": "Imposto total*",
             "totalInWords": "Total da fatura (por extenso)",
-            "message1": "Declaramos que esta fatura mostra o preço real dos serviços prestados e que todos os detalhes são verdadeiros e corretos.",
             "tds": "TDS",
-            "tcs": "TCS"
+            "tcs": "TCS",
+            "message1Label": "Declaração:",
+            "message1Value": "Declaramos que esta fatura mostra o preço real dos serviços prestados e que todos os detalhes são verdadeiros e corretos.",
+            "showMessage2": "Nota:",
+            "thanks": "Obrigado pelo seu negócio!"
         },
         "table": {
             "date": "Data",
@@ -1294,7 +1374,9 @@
             "billingGstin": "GSTIN",
             "pan": "PAN",
             "displayLutNumber": "LUT Number",
-            "showElectronicInvoiceIdentifier": "IRN"
+            "showElectronicInvoiceIdentifier": "IRN",
+            "customerEmail": "Email",
+            "customerMobileNumber": "Numero di telefono"
         },
         "footer": {
             "taxableAmount": "Importo imponibile",
@@ -1305,9 +1387,12 @@
             "totalInWordsInAccountsCurrency": "Totale fattura (in lettere)",
             "totalTax": "Imposta totale*",
             "totalInWords": "Totale fattura (in lettere)",
-            "message1": "Dichiariamo che questa fattura mostra il prezzo reale dei servizi resi e che tutti i dettagli sono veri e corretti.",
             "tds": "TDS",
-            "tcs": "TCS"
+            "tcs": "TCS",
+            "message1Label": "Dichiarazione:",
+            "message1Value": "Dichiariamo che questa fattura mostra il prezzo reale dei servizi resi e che tutti i dettagli sono veri e corretti.",
+            "showMessage2": "Nota:",
+            "thanks": "Grazie per la vostra fiducia!"
         },
         "table": {
             "date": "Data",
@@ -1373,7 +1458,9 @@
             "billingGstin": "GSTIN",
             "pan": "PAN",
             "displayLutNumber": "LUT Number",
-            "showElectronicInvoiceIdentifier": "IRN"
+            "showElectronicInvoiceIdentifier": "IRN",
+            "customerEmail": "E-mail",
+            "customerMobileNumber": "Telefoonnummer"
         },
         "footer": {
             "taxableAmount": "Belastbaar bedrag",
@@ -1384,9 +1471,12 @@
             "totalInWordsInAccountsCurrency": "Totaal factuur (in woorden)",
             "totalTax": "Totale belasting*",
             "totalInWords": "Totaal factuur (in woorden)",
-            "message1": "Wij verklaren dat deze factuur de werkelijke prijs van de geleverde diensten toont en dat alle gegevens waar en correct zijn.",
             "tds": "TDS",
-            "tcs": "TCS"
+            "tcs": "TCS",
+            "message1Label": "Verklaring:",
+            "message1Value": "Wij verklaren dat deze factuur de werkelijke prijs van de geleverde diensten toont en dat alle gegevens waar en correct zijn.",
+            "showMessage2": "Opmerking:",
+            "thanks": "Bedankt voor uw zaken!"
         },
         "table": {
             "date": "Datum",
@@ -1452,7 +1542,9 @@
             "billingGstin": "GSTIN",
             "pan": "PAN",
             "displayLutNumber": "LUT Number",
-            "showElectronicInvoiceIdentifier": "IRN"
+            "showElectronicInvoiceIdentifier": "IRN",
+            "customerEmail": "Электронная почта",
+            "customerMobileNumber": "Номер телефона"
         },
         "footer": {
             "taxableAmount": "Налогооблагаемая сумма",
@@ -1463,9 +1555,12 @@
             "totalInWordsInAccountsCurrency": "Итого по счету (прописью)",
             "totalTax": "Общий налог*",
             "totalInWords": "Итого по счету (прописью)",
-            "message1": "Мы заявляем, что данный счет отражает фактическую цену оказанных услуг, и все данные являются достоверными и точными.",
             "tds": "TDS",
-            "tcs": "TCS"
+            "tcs": "TCS",
+            "message1Label": "Заявление:",
+            "message1Value": "Мы заявляем, что данный счет отражает фактическую цену оказанных услуг, и все данные являются достоверными и точными.",
+            "showMessage2": "Примечание:",
+            "thanks": "Спасибо за ваш бизнес!"
         },
         "table": {
             "date": "Дата",
@@ -1531,7 +1626,9 @@
             "billingGstin": "GSTIN",
             "pan": "PAN",
             "displayLutNumber": "LUT Number",
-            "showElectronicInvoiceIdentifier": "IRN"
+            "showElectronicInvoiceIdentifier": "IRN",
+            "customerEmail": "E-posta",
+            "customerMobileNumber": "Telefon numarası"
         },
         "footer": {
             "taxableAmount": "Vergiye Tabi Tutar",
@@ -1542,9 +1639,12 @@
             "totalInWordsInAccountsCurrency": "Fatura Toplamı (yazıyla)",
             "totalTax": "Toplam Vergi*",
             "totalInWords": "Fatura Toplamı (yazıyla)",
-            "message1": "Bu faturanın verilen hizmetlerin gerçek fiyatını gösterdiğini ve tüm bilgilerin doğru ve eksiksiz olduğunu beyan ederiz.",
             "tds": "TDS",
-            "tcs": "TCS"
+            "tcs": "TCS",
+            "message1Label": "Beyan:",
+            "message1Value": "Bu faturanın verilen hizmetlerin gerçek fiyatını gösterdiğini ve tüm bilgilerin doğru ve eksiksiz olduğunu beyan ederiz.",
+            "showMessage2": "Not:",
+            "thanks": "İşiniz için teşekkürler!"
         },
         "table": {
             "date": "Tarih",
@@ -1610,7 +1710,9 @@
             "billingGstin": "GSTIN",
             "pan": "PAN",
             "displayLutNumber": "LUT Number",
-            "showElectronicInvoiceIdentifier": "IRN"
+            "showElectronicInvoiceIdentifier": "IRN",
+            "customerEmail": "ایمیل",
+            "customerMobileNumber": "شماره تلفن"
         },
         "footer": {
             "taxableAmount": "مبلغ مشمول مالیات",
@@ -1621,9 +1723,12 @@
             "totalInWordsInAccountsCurrency": "جمع کل فاکتور (به حروف)",
             "totalTax": "مجموع مالیات*",
             "totalInWords": "جمع کل فاکتور (به حروف)",
-            "message1": "ما اعلام می‌کنیم که این فاکتور قیمت واقعی خدمات ارائه‌شده را نشان می‌دهد و تمام جزئیات صحیح و دقیق است.",
             "tds": "TDS",
-            "tcs": "TCS"
+            "tcs": "TCS",
+            "message1Label": "اعلام:",
+            "message1Value": "ما اعلام می‌کنیم که این فاکتور قیمت واقعی خدمات ارائه‌شده را نشان می‌دهد و تمام جزئیات صحیح و دقیق است.",
+            "showMessage2": "یادداشت:",
+            "thanks": "از همکاری شما سپاسگزاریم!"
         },
         "table": {
             "date": "تاریخ",
@@ -1689,7 +1794,9 @@
             "billingGstin": "GSTIN",
             "pan": "PAN",
             "displayLutNumber": "LUT Number",
-            "showElectronicInvoiceIdentifier": "IRN"
+            "showElectronicInvoiceIdentifier": "IRN",
+            "customerEmail": "אימייל",
+            "customerMobileNumber": "מספר טלפון"
         },
         "footer": {
             "taxableAmount": "סכום חייב במס",
@@ -1700,9 +1807,12 @@
             "totalInWordsInAccountsCurrency": "סה״כ חשבונית (במילים)",
             "totalTax": "סה״כ מס*",
             "totalInWords": "סה״כ חשבונית (במילים)",
-            "message1": "אנו מצהירים כי חשבונית זו מציגה את המחיר האמיתי של השירותים שניתנו וכי כל הפרטים נכונים ומדויקים.",
             "tds": "TDS",
-            "tcs": "TCS"
+            "tcs": "TCS",
+            "message1Label": "הצהרה:",
+            "message1Value": "אנו מצהירים כי חשבונית זו מציגה את המחיר האמיתי של השירותים שניתנו וכי כל הפרטים נכונים ומדויקים.",
+            "showMessage2": "הערה:",
+            "thanks": "תודה על העסקים שלכם!"
         },
         "table": {
             "date": "תאריך",
@@ -1768,7 +1878,9 @@
             "billingGstin": "GSTIN",
             "pan": "PAN",
             "displayLutNumber": "LUT Number",
-            "showElectronicInvoiceIdentifier": "IRN"
+            "showElectronicInvoiceIdentifier": "IRN",
+            "customerEmail": "电子邮件",
+            "customerMobileNumber": "电话号码"
         },
         "footer": {
             "taxableAmount": "应税金额",
@@ -1779,9 +1891,12 @@
             "totalInWordsInAccountsCurrency": "发票总额（大写）",
             "totalTax": "总税额*",
             "totalInWords": "发票总额（大写）",
-            "message1": "我们声明本发票所示为所提供服务的实际价格，所有信息均真实准确。",
             "tds": "TDS",
-            "tcs": "TCS"
+            "tcs": "TCS",
+            "message1Label": "声明：",
+            "message1Value": "我们声明本发票所示为所提供服务的实际价格，所有信息均真实准确。",
+            "showMessage2": "备注：",
+            "thanks": "感谢您的惠顾！"
         },
         "table": {
             "date": "日期",
@@ -1847,7 +1962,9 @@
             "billingGstin": "GSTIN",
             "pan": "PAN",
             "displayLutNumber": "LUT Number",
-            "showElectronicInvoiceIdentifier": "IRN"
+            "showElectronicInvoiceIdentifier": "IRN",
+            "customerEmail": "電子郵件",
+            "customerMobileNumber": "電話號碼"
         },
         "footer": {
             "taxableAmount": "應稅金額",
@@ -1858,9 +1975,12 @@
             "totalInWordsInAccountsCurrency": "發票總額（大寫）",
             "totalTax": "總稅額*",
             "totalInWords": "發票總額（大寫）",
-            "message1": "我們聲明本發票所示為所提供服務的實際價格，所有資訊均真實準確。",
             "tds": "TDS",
-            "tcs": "TCS"
+            "tcs": "TCS",
+            "message1Label": "聲明：",
+            "message1Value": "我們聲明本發票所示為所提供服務的實際價格，所有資訊均真實準確。",
+            "showMessage2": "備註：",
+            "thanks": "感謝您的惠顧！"
         },
         "table": {
             "date": "日期",
@@ -1926,7 +2046,9 @@
             "billingGstin": "GSTIN",
             "pan": "PAN",
             "displayLutNumber": "LUT Number",
-            "showElectronicInvoiceIdentifier": "IRN"
+            "showElectronicInvoiceIdentifier": "IRN",
+            "customerEmail": "メール",
+            "customerMobileNumber": "電話番号"
         },
         "footer": {
             "taxableAmount": "課税対象額",
@@ -1937,9 +2059,12 @@
             "totalInWordsInAccountsCurrency": "請求書合計(大字)",
             "totalTax": "合計税額*",
             "totalInWords": "請求書合計(大字)",
-            "message1": "本請求書は提供されたサービスの実際の価格を示しており、すべての詳細が真実かつ正確であることを宣言します。",
             "tds": "TDS",
-            "tcs": "TCS"
+            "tcs": "TCS",
+            "message1Label": "宣言：",
+            "message1Value": "本請求書は提供されたサービスの実際の価格を示しており、すべての詳細が真実かつ正確であることを宣言します。",
+            "showMessage2": "注記：",
+            "thanks": "ご利用ありがとうございます！"
         },
         "table": {
             "date": "日付",
@@ -2005,7 +2130,9 @@
             "billingGstin": "GSTIN",
             "pan": "PAN",
             "displayLutNumber": "LUT Number",
-            "showElectronicInvoiceIdentifier": "IRN"
+            "showElectronicInvoiceIdentifier": "IRN",
+            "customerEmail": "이메일",
+            "customerMobileNumber": "전화번호"
         },
         "footer": {
             "taxableAmount": "과세 대상 금액",
@@ -2016,9 +2143,12 @@
             "totalInWordsInAccountsCurrency": "송장 총액(문자로)",
             "totalTax": "총 세금*",
             "totalInWords": "송장 총액(문자로)",
-            "message1": "본 송장은 제공된 서비스의 실제 가격을 나타내며 모든 세부 사항이 사실이고 정확함을 선언합니다.",
             "tds": "TDS",
-            "tcs": "TCS"
+            "tcs": "TCS",
+            "message1Label": "선언:",
+            "message1Value": "본 송장은 제공된 서비스의 실제 가격을 나타내며 모든 세부 사항이 사실이고 정확함을 선언합니다.",
+            "showMessage2": "참고:",
+            "thanks": "이용해 주셔서 감사합니다!"
         },
         "table": {
             "date": "날짜",
@@ -2084,7 +2214,9 @@
             "billingGstin": "GSTIN",
             "pan": "PAN",
             "displayLutNumber": "LUT Number",
-            "showElectronicInvoiceIdentifier": "IRN"
+            "showElectronicInvoiceIdentifier": "IRN",
+            "customerEmail": "อีเมล",
+            "customerMobileNumber": "หมายเลขโทรศัพท์"
         },
         "footer": {
             "taxableAmount": "จำนวนเงินที่ต้องเสียภาษี",
@@ -2095,9 +2227,12 @@
             "totalInWordsInAccountsCurrency": "ยอดรวมใบแจ้งหนี้ (ตัวอักษร)",
             "totalTax": "ภาษีรวม*",
             "totalInWords": "ยอดรวมใบแจ้งหนี้ (ตัวอักษร)",
-            "message1": "เราขอรับรองว่าใบแจ้งหนี้นี้แสดงราคาจริงของบริการที่ให้และรายละเอียดทั้งหมดเป็นความจริงและถูกต้อง",
             "tds": "TDS",
-            "tcs": "TCS"
+            "tcs": "TCS",
+            "message1Label": "คำประกาศ:",
+            "message1Value": "เราขอรับรองว่าใบแจ้งหนี้นี้แสดงราคาจริงของบริการที่ให้และรายละเอียดทั้งหมดเป็นความจริงและถูกต้อง",
+            "showMessage2": "หมายเหตุ:",
+            "thanks": "ขอบคุณสำหรับธุรกิจของคุณ!"
         },
         "table": {
             "date": "วันที่",
@@ -2163,7 +2298,9 @@
             "billingGstin": "GSTIN",
             "pan": "PAN",
             "displayLutNumber": "LUT Number",
-            "showElectronicInvoiceIdentifier": "IRN"
+            "showElectronicInvoiceIdentifier": "IRN",
+            "customerEmail": "Email",
+            "customerMobileNumber": "Số điện thoại"
         },
         "footer": {
             "taxableAmount": "Số tiền chịu thuế",
@@ -2174,9 +2311,12 @@
             "totalInWordsInAccountsCurrency": "Tổng hóa đơn (bằng chữ)",
             "totalTax": "Tổng thuế*",
             "totalInWords": "Tổng hóa đơn (bằng chữ)",
-            "message1": "Chúng tôi tuyên bố rằng hóa đơn này thể hiện giá thực tế của các dịch vụ đã cung cấp và tất cả các thông tin chi tiết là đúng và chính xác.",
             "tds": "TDS",
-            "tcs": "TCS"
+            "tcs": "TCS",
+            "message1Label": "Tuyên bố:",
+            "message1Value": "Chúng tôi tuyên bố rằng hóa đơn này thể hiện giá thực tế của các dịch vụ đã cung cấp và tất cả các thông tin chi tiết là đúng và chính xác.",
+            "showMessage2": "Ghi chú:",
+            "thanks": "Cảm ơn quý khách đã hợp tác!"
         },
         "table": {
             "date": "Ngày",
@@ -2242,7 +2382,9 @@
             "billingGstin": "GSTIN",
             "pan": "PAN",
             "displayLutNumber": "LUT Number",
-            "showElectronicInvoiceIdentifier": "IRN"
+            "showElectronicInvoiceIdentifier": "IRN",
+            "customerEmail": "Email",
+            "customerMobileNumber": "Nomor telepon"
         },
         "footer": {
             "taxableAmount": "Jumlah Kena Pajak",
@@ -2253,9 +2395,12 @@
             "totalInWordsInAccountsCurrency": "Total Faktur (Terbilang)",
             "totalTax": "Total Pajak*",
             "totalInWords": "Total Faktur (Terbilang)",
-            "message1": "Kami menyatakan bahwa faktur ini menunjukkan harga sebenarnya dari layanan yang diberikan dan semua detail adalah benar dan akurat.",
             "tds": "TDS",
-            "tcs": "TCS"
+            "tcs": "TCS",
+            "message1Label": "Pernyataan:",
+            "message1Value": "Kami menyatakan bahwa faktur ini menunjukkan harga sebenarnya dari layanan yang diberikan dan semua detail adalah benar dan akurat.",
+            "showMessage2": "Catatan:",
+            "thanks": "Terima kasih atas bisnis Anda!"
         },
         "table": {
             "date": "Tanggal",
@@ -2321,7 +2466,9 @@
             "billingGstin": "GSTIN",
             "pan": "PAN",
             "displayLutNumber": "LUT Number",
-            "showElectronicInvoiceIdentifier": "IRN"
+            "showElectronicInvoiceIdentifier": "IRN",
+            "customerEmail": "E-mel",
+            "customerMobileNumber": "Nombor telefon"
         },
         "footer": {
             "taxableAmount": "Jumlah Boleh Cukai",
@@ -2332,9 +2479,12 @@
             "totalInWordsInAccountsCurrency": "Jumlah Invois (Dalam Perkataan)",
             "totalTax": "Jumlah Cukai*",
             "totalInWords": "Jumlah Invois (Dalam Perkataan)",
-            "message1": "Kami mengisytiharkan bahawa invois ini menunjukkan harga sebenar perkhidmatan yang diberikan dan semua butiran adalah benar dan tepat.",
             "tds": "TDS",
-            "tcs": "TCS"
+            "tcs": "TCS",
+            "message1Label": "Pengisytiharan:",
+            "message1Value": "Kami mengisytiharkan bahawa invois ini menunjukkan harga sebenar perkhidmatan yang diberikan dan semua butiran adalah benar dan tepat.",
+            "showMessage2": "Nota:",
+            "thanks": "Terima kasih atas perniagaan anda!"
         },
         "table": {
             "date": "Tarikh",


### PR DESCRIPTION
## **User description**
https://app.clickup.com/t/3687137/86d3wcku6

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect printed invoice labels and multilingual template data across many locales; removing skip-keys for secondary labels may duplicate statutory abbreviations, and the new `showLanguage2DisplayedFirst` field must stay aligned with API/preview rendering.
> 
> **Overview**
> Improves **invoice template secondary-language** setup and fixes **Arabic/UAE** label coverage in the template editor.
> 
> **Design tab:** The secondary language dropdown is moved **above** the primary/secondary display checkboxes, and the “show secondary first” option now binds to **`showLanguage2DisplayedFirst`** (replacing **`secondaryLabelFirst`** in the form and when resetting language settings).
> 
> **Content tab:** A configurable **table date** row is added for non-thermal templates. Several table/footer label rows gain a **15-character** limit. **Note 1 (message1)** editing is split by template family—Template A and thermal templates edit declaration **body** in one row; Tally keeps separate **label** and **content** rows (secondary label row only for Tally). **Note 2** label/secondary-label editing is limited to **Tally** templates.
> 
> **Secondary label auto-fill:** Selecting a language no longer skips statutory keys (GSTIN, PAN, HSN, etc.); **`message1`** is filled from **`message1Label`** / **`message1Value`** into **`secondaryLabel`** / **`secondaryValue`**. **`template-secondary-labels.json`** adds translations for customer email/mobile, custom fields, thanks, note 2, and splits declaration text into label vs value across supported languages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae711f1085c736066d26c0c22c42b9999f8a5dca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
Expand secondary-language support and correct localized template fields

### What Changed
- Users can choose a secondary language directly from the template label settings.
- Secondary translations now populate customer email, mobile number, invoice date, notes, greetings, and declaration labels and text across supported languages.
- Declaration text is handled separately from its label, so translated notes display correctly in UAE company templates.
- Date and additional invoice summary fields can now be configured with secondary labels, while template-specific note controls are shown only where supported.
- The secondary-label display setting now uses its updated name and resets correctly when language support is enabled.

### Impact
`✅ Correct Arabic and multilingual invoice labels`
`✅ Localized declaration and note text`
`✅ Easier secondary-language template setup`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added date field configuration for non-thermal invoice template tables.
  * Added localized customer email, mobile number, footer message, and thank-you labels across supported languages.
  * Added improved secondary-language controls for template labels.

* **Improvements**
  * Enhanced footer message display for GST, Thermal, and Tally templates.
  * Limited message 2 entry and secondary-label display to supported Tally templates.
  * Applied 15-character limits to selected table labels for clearer layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->