### PR TITLE
Divyanshu | Test | QA - Support of Arabic language in template for UAE companies.

### DIFF
--- a/apps/web-giddh/src/app/vouchers/template/template-edit-filter/template-edit-filter.component.html
+++ b/apps/web-giddh/src/app/vouchers/template/template-edit-filter/template-edit-filter.component.html
@@ -343,12 +343,14 @@
                                     name="showLanguage2DisplayedFirst"
                                     [(ngModel)]="customTemplate.showLanguage2DisplayedFirst"
                                     (ngModelChange)="
-                                        onChangeDesignFieldVisibility('showLanguage2DisplayedFirst', customTemplate?.showLanguage2DisplayedFirst)
+                                        onChangeDesignFieldVisibility(
+                                            'showLanguage2DisplayedFirst',
+                                            customTemplate?.showLanguage2DisplayedFirst
+                                        )
                                     "
                                 >
                                     {{ localeData?.show_secondary_label_first }}
                                 </mat-checkbox>
-
                             }
                         </div>
                     </mat-expansion-panel>
@@ -1624,7 +1626,7 @@
                                                             callbacks: [onChangeFieldVisibility],
                                                             name: 'tabledate',
                                                             label: commonLocaleData?.app_date,
-                                                            showSecondaryLabel: showSecondaryLabel
+                                                            showSecondaryLabel: showSecondaryLabel,
                                                         }
                                                     "
                                                 ></ng-container>
@@ -2081,6 +2083,7 @@
                                                                     callbacks: [onChangeFieldVisibility],
                                                                     name: 'tableTaxBifurcationHsnSac',
                                                                     label: localeData?.tax_bifurcation_hsn_sac,
+                                                                    maxLength: 15,
                                                                     showSecondaryLabel: showSecondaryLabel,
                                                                 }
                                                             "
@@ -2101,6 +2104,7 @@
                                                                     callbacks: [onChangeFieldVisibility],
                                                                     name: 'tabletaxBifurcationTaxableValue',
                                                                     label: localeData?.tax_bifurcation_taxable_value,
+                                                                    maxLength: 15,
                                                                     showSecondaryLabel: showSecondaryLabel,
                                                                 }
                                                             "
@@ -2121,6 +2125,7 @@
                                                                     callbacks: [onChangeFieldVisibility],
                                                                     name: 'tabletaxBifurcationRate',
                                                                     label: localeData?.tax_bifurcation_rate,
+                                                                    maxLength: 15,
                                                                     showSecondaryLabel: showSecondaryLabel,
                                                                 }
                                                             "
@@ -2141,6 +2146,7 @@
                                                                     callbacks: [onChangeFieldVisibility],
                                                                     name: 'tabletaxBifurcationAmount',
                                                                     label: localeData?.tax_bifurcation_amount,
+                                                                    maxLength: 15,
                                                                     showSecondaryLabel: showSecondaryLabel,
                                                                 }
                                                             "
@@ -2161,6 +2167,7 @@
                                                                     callbacks: [onChangeFieldVisibility],
                                                                     name: 'tabletaxBifurcationTotalTaxAmount',
                                                                     label: localeData?.tax_bifurcation_total_tax_amount,
+                                                                    maxLength: 15,
                                                                     showSecondaryLabel: showSecondaryLabel,
                                                                 }
                                                             "
@@ -2181,6 +2188,7 @@
                                                                     callbacks: [onChangeFieldVisibility],
                                                                     name: 'tabletaxBifurcationTotal',
                                                                     label: localeData?.tax_bifurcation_total,
+                                                                    maxLength: 15,
                                                                     showSecondaryLabel: showSecondaryLabel,
                                                                 }
                                                             "
@@ -2982,7 +2990,7 @@
                                                         name: 'showMessage2',
                                                         label: localeData?.note_2,
                                                         maxLength: 20,
-                                                        showSecondaryLabel: isTallyTemplate,
+                                                        showSecondaryLabel: showSecondaryLabel && isTallyTemplate,
                                                     }
                                                 "
                                             ></ng-container>


### PR DESCRIPTION
## **User description**
https://app.clickup.com/t/3687137/86d3wcku6

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only changes in the template edit form with no auth, API, or persistence logic changes beyond existing label configuration.
> 
> **Overview**
> Tweaks the voucher **template content editor** so secondary-language (e.g. Arabic) label fields behave consistently with `enableSecondaryLanguage`, and tax bifurcation custom labels get explicit length limits.
> 
> For **footer note 2** on Tally templates, the secondary-language label column now appears only when secondary language is enabled (`showSecondaryLabel && isTallyTemplate`), instead of whenever the template is Tally.
> 
> **Tax bifurcation** table fields (HSN/SAC, taxable value, rate, amount, total tax amount, total) now pass **`maxLength: 15`** into the shared `labelRow` template so primary/secondary label inputs are capped like other short label fields.
> 
> Includes minor formatting (callback argument wrapping, trailing comma on the table date `labelRow` context).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8d9f8f3c87f7e8ad4f8037c735e0dff83ec3097. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
Limit tax bifurcation labels and show secondary labels only when supported

### What Changed
- Tax bifurcation table labels now accept up to 15 characters in template settings
- The second footer note shows its secondary-language label only when secondary labels are enabled and the template supports them

### Impact
`✅ Consistent tax label lengths`
`✅ Fewer oversized tax labels`
`✅ Clearer secondary-language template settings`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Secondary-language labels in voucher templates now appear only when enabled globally and supported by Tally templates.
  * Improved formatting for voucher template fields and visibility settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->