### PR TITLE
Ankit | Test | Prod - Entry amount is coming zero when opening in update flow

### DIFF
--- a/apps/web-giddh/src/app/financial-reports/components/export/profit-loss/export-xls/export-xls.component.html
+++ b/apps/web-giddh/src/app/financial-reports/components/export/profit-loss/export-xls/export-xls.component.html
@@ -7,10 +7,19 @@
     <a
         href="javascript:void(0);"
         aria-label="download"
-        (click)="downloadPlXls()"
         *ngIf="enableDownload"
+        [matMenuTriggerFor]="downloadMenu"
         class="cursor-pointer new-icon-img"
     >
         <img [src]="imgPath" alt="download img" />
     </a>
+    <!-- Menu -->
+    <mat-menu #downloadMenu="matMenu" xPosition="before" yPosition="below">
+        <button mat-menu-item (click)="downloadPlXls(false)" aria-label="group report">
+            {{ localeData?.xls?.main_group_report }}
+        </button>
+        <button mat-menu-item (click)="downloadPlXls(true)" aria-label="complete report">
+            {{ localeData?.xls?.complete_report }}
+        </button>
+    </mat-menu>
 </div>

--- a/apps/web-giddh/src/app/financial-reports/components/export/profit-loss/export-xls/export-xls.component.ts
+++ b/apps/web-giddh/src/app/financial-reports/components/export/profit-loss/export-xls/export-xls.component.ts
@@ -17,7 +17,6 @@ selector: 'profit-loss-export-xls',
 export class ProfitLossExportXlsComponent implements OnInit {
     @Input() public fy: number;
     @Input() public filters: any = {};
-    @Input() public view: ProfitLossExportView = ProfitLossExportView.Collapsed;
     public enableDownload: boolean = true;
     public imgPath: string = '';
     @Output() public plBsExportPdfEvent = new EventEmitter<boolean>();
@@ -31,8 +30,8 @@ export class ProfitLossExportXlsComponent implements OnInit {
 
     }
 
-    public downloadPlXls() {
-        let request = { from: this.filters.from, to: this.filters.to, branchUniqueName: this.filters.branchUniqueName, filename: this.localeData?.xls.profit_loss.download_filename, view: this.view };
+    public downloadPlXls(value: boolean): void {
+        let request = { from: this.filters.from, to: this.filters.to, branchUniqueName: this.filters.branchUniqueName, filename: this.localeData?.xls.profit_loss.download_filename, view: (value === true) ? ProfitLossExportView.Expanded : ProfitLossExportView.Collapsed };
         this.store.dispatch(this.tbPlActions.DownloadProfitLossExcel(request));
     }
 

--- a/apps/web-giddh/src/app/financial-reports/components/filter/filter.component.html
+++ b/apps/web-giddh/src/app/financial-reports/components/filter/filter.component.html
@@ -201,7 +201,6 @@
                             *ngIf="plBsExportXLS"
                             [fy]="filterForm.controls['fy']?.value"
                             [filters]="filterForm?.value"
-                            [view]="expandAll ? profitLossExportView.Expanded : profitLossExportView.Collapsed"
                             class="pull-right"
                         ></profit-loss-export-xls>
                         <balance-sheet-export-xls

--- a/apps/web-giddh/src/app/financial-reports/components/filter/filter.component.ts
+++ b/apps/web-giddh/src/app/financial-reports/components/filter/filter.component.ts
@@ -24,7 +24,6 @@ import { FinancialReportsComponentStore } from '../../financial-reports.store';
 import { NewConfirmationModalComponent } from '../../../theme/new-confirmation-modal/confirmation-modal.component';
 import { TlPlService } from '../../../services/tl-pl.service';
 import { cloneDeep, find, findIndex, get, map, orderBy } from '../../../lodash-optimized';
-import { ProfitLossExportView } from '../export/profit-loss/export-xls/export-xls.component';
 
 @Component({
 selector: 'financial-filter',
@@ -62,8 +61,6 @@ export class FinancialReportsFilterComponent implements OnInit, OnDestroy {
     public dateOptions: IOption[] = [];
     public imgPath: string;
     public universalDateICurrent: boolean = false;
-    /** Export view enum for template access */
-    public profitLossExportView = ProfitLossExportView;
     /** Observable to store the branches of current company */
     public currentCompanyBranches$: Observable<any>;
     /** Stores the branch list of a company */

--- a/apps/web-giddh/src/app/ledger/components/update-ledger-entry-panel/update-ledger.vm.ts
+++ b/apps/web-giddh/src/app/ledger/components/update-ledger-entry-panel/update-ledger.vm.ts
@@ -407,7 +407,7 @@ export class UpdateLedgerVm {
         this.selectedLedger.tcsCalculationMethod = modal.tcsCalculationMethod;
         this.selectedLedger.otherTaxesSum = giddhRoundOff((this.selectedLedger.tdsTcsTaxesSum), this.giddhBalanceDecimalPlaces);
 
-        if ((this.showNewEntryPanel || this.isAdvanceReceipt) && this.selectedLedger.voucher.shortCode !== 'jr') {
+        if (this.shouldShowTaxDiscountPanel()) {
             // Refresh the per-row amount of the other-tax (TDS / TCS) transaction
             this.rebuildOtherTaxTransactions();
         }
@@ -615,8 +615,20 @@ export class UpdateLedgerVm {
         this.generateCompoundTotal();
     }
 
+    /**
+     * True when the amount / discount / tax panel is shown
+     * (same condition as the update-ledger template).
+     *
+     * @private
+     * @returns {boolean}
+     * @memberof UpdateLedgerVm
+     */
+    private shouldShowTaxDiscountPanel(): boolean {
+        return (this.showNewEntryPanel || this.isAdvanceReceipt) && this.selectedLedger?.voucher?.shortCode !== 'jr';
+    }
+
     private rebuildOtherTaxTransactions(): void {
-        if (!this.selectedLedger?.transactions?.length) {
+        if (!this.shouldShowTaxDiscountPanel() || !this.selectedLedger?.transactions?.length) {
             return;
         }
 
@@ -692,7 +704,7 @@ export class UpdateLedgerVm {
         // Source of truth: CommonTaxComponent; fall back to this.selectedTaxes before view init.
         const selectedTaxes: any[] = this.taxComponent?.selectedTaxes?.() || this.selectedTaxes;
 
-        if (!this.selectedLedger?.transactions?.length) {
+        if (!this.shouldShowTaxDiscountPanel() || !this.selectedLedger?.transactions?.length) {
             return;
         }
 

--- a/apps/web-giddh/src/app/reports/components/purchase-register-component/purchase.register.component.ts
+++ b/apps/web-giddh/src/app/reports/components/purchase-register-component/purchase.register.component.ts
@@ -817,7 +817,7 @@ constructor(
         exportBodyRequest.from = startDate;
         exportBodyRequest.to = endDate;
         exportBodyRequest.exportType = "PURCHASE_REGISTER_OVERVIEW_EXPORT";
-        exportBodyRequest.fileType = "CSV";
+        exportBodyRequest.fileType = "XLSX";
         exportBodyRequest.branchUniqueName = this.currentBranch?.uniqueName;
         this.applyOverviewGroupByFilters(exportBodyRequest);
         this.ledgerService.exportData(exportBodyRequest).pipe(takeUntil(this.destroyed$)).subscribe(response => {

--- a/apps/web-giddh/src/app/reports/components/purchase-register-expand-component/purchase.register.expand.component.ts
+++ b/apps/web-giddh/src/app/reports/components/purchase-register-expand-component/purchase.register.expand.component.ts
@@ -526,7 +526,7 @@ export class PurchaseRegisterExpandComponent implements OnInit, OnDestroy {
             from: this.from,
             to: this.to,
             exportType: "PURCHASE_REGISTER_DETAILED_EXPORT",
-            fileType: "CSV",
+            fileType: "XLSX",
             isExpanded: this.expand,
             q: this.voucherNumberInput?.value,
             branchUniqueName: this.getDetailedPurchaseRequestFilter?.branchUniqueName,

--- a/apps/web-giddh/src/app/reports/components/report-details-components/report.details.component.ts
+++ b/apps/web-giddh/src/app/reports/components/report-details-components/report.details.component.ts
@@ -835,7 +835,7 @@ constructor(
         exportBodyRequest.from = startDate;
         exportBodyRequest.to = endDate;
         exportBodyRequest.exportType = "SALES_REGISTER_OVERVIEW_EXPORT";
-        exportBodyRequest.fileType = "CSV";
+        exportBodyRequest.fileType = "XLSX";
         exportBodyRequest.branchUniqueName = this.currentBranch?.uniqueName;
         this.applyOverviewGroupByFilters(exportBodyRequest);
         this.ledgerService.exportData(exportBodyRequest).pipe(takeUntil(this.destroyed$)).subscribe(response => {

--- a/apps/web-giddh/src/app/reports/components/sales-register-expand-component/sales.register.expand.component.ts
+++ b/apps/web-giddh/src/app/reports/components/sales-register-expand-component/sales.register.expand.component.ts
@@ -489,7 +489,7 @@ public voucherNumberInput: UntypedFormControl = new UntypedFormControl();
             from: this.from,
             to: this.to,
             exportType: "SALES_REGISTER_DETAILED_EXPORT",
-            fileType: "CSV",
+            fileType: "XLSX",
             isExpanded: this.expand,
             q: this.voucherNumberInput?.value,
             branchUniqueName: this.getDetailedsalesRequestFilter?.branchUniqueName,

--- a/apps/web-giddh/src/app/search/components/search-filter/search-filter.component.html
+++ b/apps/web-giddh/src/app/search/components/search-filter/search-filter.component.html
@@ -123,7 +123,7 @@
             {{ commonLocaleData?.app_reset }}
         </button>
         <button class="ml-auto" type="button" matButton="filled" *ngIf="showDownloadCsv" (click)="createCSV()">
-            {{ commonLocaleData?.app_download_csv }}
+            {{ commonLocaleData?.app_download_xlsx }}
         </button>
     </div>
 </section>

--- a/apps/web-giddh/src/app/search/components/search-grid/search-grid.component.ts
+++ b/apps/web-giddh/src/app/search/components/search-grid/search-grid.component.ts
@@ -332,8 +332,8 @@ export class SearchGridComponent implements OnInit, OnDestroy {
                 this.companyServices.downloadCSV(request).pipe(takeUntil(this.destroyed$)).subscribe((res) => {
                     this.searchLoader$ = of(false);
                     if (res?.status === 'success') {
-                        let blobData = this.generalService.base64ToBlob(res?.body, 'text/csv', 512);
-                        return saveAs(blobData, `${p.groupName}.csv`);
+                        let blobData = this.generalService.base64ToBlob(res?.body, 'text/xlsx', 512);
+                        return saveAs(blobData, `${p.groupName}.xlsx`);
                     }
                 });
 

--- a/apps/web-giddh/src/app/settings/personal-information/personal-information.component.html
+++ b/apps/web-giddh/src/app/settings/personal-information/personal-information.component.html
@@ -10,6 +10,7 @@
                             [type]="'text'"
                             [name]="'companyName'"
                             [label]="localeData?.company_name"
+                            (onBlurEvent)="profileUpdated('name')"
                         ></input-field>
                         <input-field
                             *ngIf="organizationType === 'BRANCH' || isConsolidatedBranch"

--- a/apps/web-giddh/src/app/settings/personal-information/personal-information.component.ts
+++ b/apps/web-giddh/src/app/settings/personal-information/personal-information.component.ts
@@ -123,15 +123,6 @@ export class PersonalInformationComponent implements OnInit, OnChanges, OnDestro
             }
 
             if (this.organizationType === 'COMPANY') {
-                this.profileForm?.get('name')?.valueChanges?.pipe(
-                    takeUntil(this.destroyed$),
-                    debounceTime(700),
-                    pairwise(), // Emits [previousValue, currentValue]
-                    filter(([prev, curr]) => prev !== curr) // Only proceed if values are different
-                ).subscribe(([prev, curr]) => {
-                    this.profileUpdated('name');
-                });
-
                 this.profileForm?.get('portalDomain')?.valueChanges?.pipe(
                     takeUntil(this.destroyed$),
                     debounceTime(700),

--- a/apps/web-giddh/src/app/vouchers/create/create.component.ts
+++ b/apps/web-giddh/src/app/vouchers/create/create.component.ts
@@ -2163,7 +2163,7 @@ export class VoucherCreateComponent implements OnInit, OnDestroy, AfterViewInit 
                     this.useCustomVoucherNumber = true;
                 } else if (this.voucherType === VoucherTypeEnum.debitNote) {
                     this.applyRoundOff = settings.invoiceSettings.debitNoteRoundOff;
-                    this.useCustomVoucherNumber = settings.invoiceSettings?.useCustomDebitNoteNumber;
+                    this.useCustomVoucherNumber = true;
                 } else if (this.voucherType === VoucherTypeEnum.creditNote) {
                     this.applyRoundOff = settings.invoiceSettings.creditNoteRoundOff;
                     this.useCustomVoucherNumber = settings.invoiceSettings?.useCustomCreditNoteNumber;

--- a/apps/web-giddh/src/app/vouchers/template-edit-dialog/template-edit-dialog.component.html
+++ b/apps/web-giddh/src/app/vouchers/template-edit-dialog/template-edit-dialog.component.html
@@ -5,6 +5,11 @@
         <button
             class="ml-auto"
             matButton="filled"
+            matBadgeColor="warn"
+            [matBadge]="message1CharacterLimitErrorCount"
+            [matBadgeHidden]="!message1CharacterLimitErrorCount"
+            [matTooltip]="message1CharacterLimitErrorCount ? localeData?.message1_character_limit_exceeded : ''"
+            [matTooltipPosition]="'left'"
             (click)="templateData?.mode === templateModeEnum.Create ? createTemplate() : updateTemplate()"
         >
             {{ templateData?.mode === templateModeEnum.Create ? localeData?.create_template : localeData?.update_template }}

--- a/apps/web-giddh/src/app/vouchers/template-edit-dialog/template-edit-dialog.component.scss
+++ b/apps/web-giddh/src/app/vouchers/template-edit-dialog/template-edit-dialog.component.scss
@@ -2,6 +2,7 @@
     .sticky-header {
         z-index: 10;
         box-shadow: 0 2px 4px var(--color-shadow-light);
+        overflow: visible;
     }
 
     .scrollable-content {

--- a/apps/web-giddh/src/app/vouchers/template-edit-dialog/template-edit-dialog.component.ts
+++ b/apps/web-giddh/src/app/vouchers/template-edit-dialog/template-edit-dialog.component.ts
@@ -35,6 +35,8 @@ export class TemplateEditDialogComponent implements OnInit, OnDestroy {
   public readonly templateModeEnum = TemplateModeEnum;
   /* This will hold the value if Gst Composition will show/hide */
   public showGstComposition: boolean = false;
+  /** Maximum allowed characters for footer message1 value and secondaryValue */
+  private readonly message1MaxLength: number = 200;
 
   constructor(
     public dialog: MatDialog,
@@ -67,10 +69,34 @@ export class TemplateEditDialogComponent implements OnInit, OnDestroy {
   }
 
   /**
-  * Closes the dialog.
-  *
-  * @memberof TemplateEditDialogComponent
-  */
+   * Number of Note 1 fields that exceed the strict 200 character limit.
+   * Strict length applies only when notes are not shown on the last page.
+   *
+   * @readonly
+   * @type {number}
+   * @memberof TemplateEditDialogComponent
+   */
+  public get message1CharacterLimitErrorCount(): number {
+    const footerData = this.customTemplate?.sections?.['footer']?.data;
+    if (footerData?.['showNotesAtLastPage']?.display || !footerData?.['message1']?.display) {
+      return 0;
+    }
+    const message1 = footerData?.['message1'];
+    let errorCount = 0;
+    if (this.isCharacterLimitExceeded(message1?.value)) {
+      errorCount++;
+    }
+    if (this.customTemplate?.enableSecondaryLanguage && this.isCharacterLimitExceeded(message1?.secondaryValue)) {
+      errorCount++;
+    }
+    return errorCount;
+  }
+
+  /**
+   * Closes the dialog.
+   *
+   * @memberof TemplateEditDialogComponent
+   */
   public closeDialog(): void {
     const dialogRef = this.dialog.open(ConfirmModalComponent, {
       panelClass: ['mat-dialog-sm'],
@@ -252,6 +278,18 @@ export class TemplateEditDialogComponent implements OnInit, OnDestroy {
       data.fontDefault = data.fontSize;
       data.fontMedium = data.fontSize - 2;
     }
+  }
+
+  /**
+   * Checks whether the given string exceeds the Note 1 character limit.
+   *
+   * @private
+   * @param {string} value Field value
+   * @returns {boolean} True if the value is over the limit
+   * @memberof TemplateEditDialogComponent
+   */
+  private isCharacterLimitExceeded(value: string): boolean {
+    return (value?.length || 0) > this.message1MaxLength;
   }
 
   /**

--- a/apps/web-giddh/src/app/vouchers/template/template-edit-filter/template-edit-filter.component.html
+++ b/apps/web-giddh/src/app/vouchers/template/template-edit-filter/template-edit-filter.component.html
@@ -2721,7 +2721,11 @@
                                                     </td>
                                                     <td class="p-2" [attr.colspan]="showSecondaryLabel ? 2 : 1">
                                                         <!-- Content for Note 1 which show below Declaration: -->
-                                                        <mat-form-field appearance="outline" class="initial-height w-100 address-text">
+                                                        <mat-form-field
+                                                            appearance="outline"
+                                                            class="initial-height w-100 address-text"
+                                                            [ngClass]="{ 'error-box': isMessage1ContentOverLimit('value') }"
+                                                        >
                                                             <mat-label>{{ primaryLabel }}</mat-label>
                                                             <textarea
                                                                 matInput
@@ -2731,12 +2735,6 @@
                                                                     customTemplate.sections['footer'].data['showNotesAtLastPage']?.display
                                                                         ? null
                                                                         : 200
-                                                                "
-                                                                [class.error-box]="
-                                                                    isCharacterLimitExceeded(
-                                                                        200,
-                                                                        customTemplate.sections['footer'].data['message1']?.value || ''
-                                                                    )
                                                                 "
                                                                 [placeholder]="localeData?.footer_text"
                                                                 [(ngModel)]="customTemplate.sections['footer'].data['message1'].value"
@@ -2758,7 +2756,7 @@
                                                     </td>
                                                     <td class="p-2 text-center">
                                                         <span class="font-size-12">
-                                                            @if (isCharacterFieldFocused('footer', 'message1', 'value')) {
+                                                            @if (!customTemplate.sections['footer'].data['showNotesAtLastPage']?.display && isCharacterFieldFocused('footer', 'message1', 'value')) {
                                                                 {{
                                                                     getRemainingCharacters(
                                                                         200,
@@ -2820,7 +2818,11 @@
                                                     <td class="p-2"></td>
                                                     <td class="p-2" [attr.colspan]="showSecondaryLabel ? 2 : 1">
                                                         <!-- Content for Note 1 which show below Declaration: -->
-                                                        <mat-form-field appearance="outline" class="initial-height w-100 address-text">
+                                                        <mat-form-field
+                                                            appearance="outline"
+                                                            class="initial-height w-100 address-text"
+                                                            [ngClass]="{ 'error-box': isMessage1ContentOverLimit('value') }"
+                                                        >
                                                             <mat-label>{{ primaryLabel }}</mat-label>
                                                             <textarea
                                                                 matInput
@@ -2830,12 +2832,6 @@
                                                                     customTemplate.sections['footer'].data['showNotesAtLastPage']?.display
                                                                         ? null
                                                                         : 200
-                                                                "
-                                                                [class.error-box]="
-                                                                    isCharacterLimitExceeded(
-                                                                        200,
-                                                                        customTemplate.sections['footer'].data['message1']?.value || ''
-                                                                    )
                                                                 "
                                                                 [placeholder]="localeData?.footer_text"
                                                                 [(ngModel)]="customTemplate.sections['footer'].data['message1'].value"
@@ -2857,7 +2853,7 @@
                                                     </td>
                                                     <td class="p-2 text-center">
                                                         <span class="font-size-12">
-                                                            @if (isCharacterFieldFocused('footer', 'message1', 'value')) {
+                                                            @if (!customTemplate.sections['footer'].data['showNotesAtLastPage']?.display && isCharacterFieldFocused('footer', 'message1', 'value')) {
                                                                 {{
                                                                     getRemainingCharacters(
                                                                         200,
@@ -2914,7 +2910,11 @@
                                                     <td class="p-2"></td>
                                                     <td class="p-2" [attr.colspan]="showSecondaryLabel ? 2 : 1">
                                                         <!-- Content for Note 1 which show below Declaration: -->
-                                                        <mat-form-field appearance="outline" class="initial-height w-100 address-text">
+                                                        <mat-form-field
+                                                            appearance="outline"
+                                                            class="initial-height w-100 address-text"
+                                                            [ngClass]="{ 'error-box': isMessage1ContentOverLimit('secondaryValue') }"
+                                                        >
                                                             <mat-label>{{ secondaryLabel }}</mat-label>
                                                             <textarea
                                                                 matInput
@@ -2924,13 +2924,6 @@
                                                                     customTemplate.sections['footer'].data['showNotesAtLastPage']?.display
                                                                         ? null
                                                                         : 200
-                                                                "
-                                                                [class.error-box]="
-                                                                    isCharacterLimitExceeded(
-                                                                        200,
-                                                                        customTemplate.sections['footer'].data['message1']
-                                                                            ?.secondaryLabel || ''
-                                                                    )
                                                                 "
                                                                 [placeholder]="localeData?.footer_text"
                                                                 [(ngModel)]="
@@ -2954,7 +2947,7 @@
                                                     </td>
                                                     <td class="p-2 text-center">
                                                         <span class="font-size-12">
-                                                            @if (isCharacterFieldFocused('footer', 'message1', 'secondaryValue')) {
+                                                            @if (!customTemplate.sections['footer'].data['showNotesAtLastPage']?.display && isCharacterFieldFocused('footer', 'message1', 'secondaryValue')) {
                                                                 {{
                                                                     getRemainingCharacters(
                                                                         200,

--- a/apps/web-giddh/src/app/vouchers/template/template-edit-filter/template-edit-filter.component.scss
+++ b/apps/web-giddh/src/app/vouchers/template/template-edit-filter/template-edit-filter.component.scss
@@ -102,3 +102,11 @@
 .swatch ul li:nth-child(18) {
     background: var(--color-dark-gray);
 }
+
+:host ::ng-deep .address-text.error-box {
+    .mdc-notched-outline .mdc-notched-outline__leading,
+    .mdc-notched-outline .mdc-notched-outline__notch,
+    .mdc-notched-outline .mdc-notched-outline__trailing {
+        border-color: var(--color-red) !important;
+    }
+}

--- a/apps/web-giddh/src/app/vouchers/template/template-edit-filter/template-edit-filter.component.ts
+++ b/apps/web-giddh/src/app/vouchers/template/template-edit-filter/template-edit-filter.component.ts
@@ -275,6 +275,25 @@ export class TemplateEditFilterComponent implements OnInit {
     }
 
     /**
+     * True when Note 1 value/secondaryValue exceeds 200 characters and strict length is enabled
+     * (notes are not shown on the last page).
+     *
+     * @param {('value' | 'secondaryValue')} key Note 1 content key
+     * @returns {boolean} True if the field is over the strict character limit
+     * @memberof TemplateEditFilterComponent
+     */
+    public isMessage1ContentOverLimit(key: 'value' | 'secondaryValue'): boolean {
+        const footerData = this.customTemplate?.sections?.['footer']?.data;
+        if (footerData?.['showNotesAtLastPage']?.display || !footerData?.['message1']?.display) {
+            return false;
+        }
+        if (key === 'secondaryValue' && !this.customTemplate?.enableSecondaryLanguage) {
+            return false;
+        }
+        return this.isCharacterLimitExceeded(200, footerData?.['message1']?.[key] || '');
+    }
+
+    /**
      * Angular lifecycle hook that is called after data-bound properties are initialized.
      *
      * @memberof TemplateEditFilterComponent

--- a/apps/web-giddh/src/assets/locale/en.json
+++ b/apps/web-giddh/src/assets/locale/en.json
@@ -450,6 +450,7 @@
     "app_schedule_now": "Schedule Now",
     "app_reset": "Reset",
     "app_download_csv": "Download CSV",
+    "app_download_xlsx": "Download Excel",
     "app_show": "Show",
     "app_report": "Report",
     "app_tcs": "TCS",

--- a/apps/web-giddh/src/assets/locale/hi.json
+++ b/apps/web-giddh/src/assets/locale/hi.json
@@ -450,6 +450,7 @@
     "app_schedule_now": "अब शेड्यूल करें",
     "app_reset": "रीसेट",
     "app_download_csv": "सीएसव्ही डाउनलोड करें",
+    "app_download_xlsx": "एक्सेल डाउनलोड करें",
     "app_show": "प्रदर्शन",
     "app_report": "रिपोर्ट",
     "app_tcs": "टीसीएस",

--- a/apps/web-giddh/src/assets/locale/mr.json
+++ b/apps/web-giddh/src/assets/locale/mr.json
@@ -450,6 +450,7 @@
     "app_schedule_now": "आता वेळापत्रक",
     "app_reset": "रीसेट करा",
     "app_download_csv": "सीएसव्ही डाउनलोड करा",
+    "app_download_xlsx": "एक्सेल डाउनलोड करा",
     "app_show": "दाखवा",
     "app_report": "अहवाल द्या",
     "app_tcs": "टीसीएस",

--- a/apps/web-giddh/src/assets/locale/vouchers/preview/en.json
+++ b/apps/web-giddh/src/assets/locale/vouchers/preview/en.json
@@ -484,6 +484,7 @@
     "destination_of_supply": "Destination of Supply",
     "failed_to_get_template_preview": "Failed to get template preview",
     "please_enter_template_name": "Please enter template name.",
+    "message1_character_limit_exceeded": "Note 1 exceeds the 200 character limit.",
     "template_saved_successfully": "Template Saved Successfully.",
     "template_updated_successfully": "Template Updated Successfully.",
     "template_deleted_successfully": "Template Deleted Successfully.",

--- a/apps/web-giddh/src/assets/locale/vouchers/preview/hi.json
+++ b/apps/web-giddh/src/assets/locale/vouchers/preview/hi.json
@@ -484,6 +484,7 @@
     "destination_of_supply": "आपूर्ति का गंतव्य",
     "failed_to_get_template_preview": "टेम्पलेट पूर्वावलोकन उपलब्ध नहीं है",
     "please_enter_template_name": "कृपया टेम्पलेट नाम दर्ज करें।",
+    "message1_character_limit_exceeded": "नोट 1, 200 वर्णों की सीमा से अधिक है।",
     "template_saved_successfully": "टेम्पलेट सफलतापूर्वक सहायक बनाया गया।",
     "template_updated_successfully": "टेम्पलेट सफलतापूर्वक सहायक बनाया गया।",
     "template_deleted_successfully": "टेम्पलेट सफलतापूर्वक हटा दिया गया।",

--- a/apps/web-giddh/src/assets/locale/vouchers/preview/mr.json
+++ b/apps/web-giddh/src/assets/locale/vouchers/preview/mr.json
@@ -484,6 +484,7 @@
     "destination_of_supply": "पुरवठ्याचे गंतव्य",
     "failed_to_get_template_preview": "टेम्पलेट पूर्वावलोकन उपलब्ध नहीं है",
     "please_enter_template_name": "कृपया टेम्पलेट नाव प्रविष्ट करा",
+    "message1_character_limit_exceeded": "नोंद 1, 200 वर्णांच्या मर्यादेपेक्षा जास्त आहे.",
     "template_saved_successfully": "टेम्पलेट सफलतापूर्वक सहायक बनाया गया।",
     "template_updated_successfully": "टेम्पलेट सफलतापूर्वक सहायक बनाया गया।",
     "template_deleted_successfully": "टेम्पलेट सफलतापूर्वक हटा दिया गया।",


### PR DESCRIPTION
## **User description**
https://app.clickup.com/t/3687137/86d40ax3k
https://app.clickup.com/t/3687137/86d3xnqf1
https://app.clickup.com/t/3687137/86d3wcku6
https://app.clickup.com/t/3687137/86d3ymn0r
https://app.clickup.com/t/3687137/86d3w7r64
https://app.clickup.com/t/3687137/86d3zyaee

<!-- CURSOR_SUMMARY -->

> [!NOTE]
> **Medium Risk**
> Changes ledger update totals and tax row logic in production voucher flows; debit note numbering behavior changes for all debit notes regardless of the settings toggle.
> 
> **Overview**
> Fixes **zero entry amounts** when opening vouchers in the **update ledger** flow by stopping tax and other-tax (TDS/TCS) transaction rebuilds when the amount/discount/tax UI is not shown.
> 
> A shared **`shouldShowTaxDiscountPanel()`** helper mirrors the update-ledger template: rebuild runs only when `(showNewEntryPanel || isAdvanceReceipt)` and the voucher is not a journal (`shortCode !== 'jr'`). **`rebuildTaxTransactions`**, **`rebuildOtherTaxTransactions`**, and the other-tax modal path now bail out early when that panel would be hidden, so totals are not cleared or rewritten incorrectly on load.
> 
> In **voucher create**, **debit note** now sets **`useCustomVoucherNumber = true`** unconditionally (aligned with purchase/cash bill), instead of reading **`useCustomDebitNoteNumber`** from invoice settings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58d11cd68ccc443822bbaad433d889dd3964b514. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented tax and discount calculations from appearing or being rebuilt when processing is unavailable.
  * Excluded journal entries from tax and discount processing to ensure accurate ledger transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Fix voucher updates and expand Excel export options

### What Changed
- Voucher amounts and tax rows remain intact when opening entries where the tax and discount panel is hidden
- Debit Note voucher numbers always use the custom numbering field
- Sales and purchase register exports, plus search downloads, now download as Excel files
- Profit and Loss exports offer separate group and complete report options
- Template editors flag Note 1 when it exceeds 200 characters, unless notes are shown on the last page
- Company name changes are saved when the field loses focus

### Impact
`✅ Correct amounts when editing vouchers`
`✅ Excel downloads for register and search reports`
`✅ Clearer template length warnings`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
