### PR TITLE
Ankit | Test | Text limit is not defined for secondary language on Note 1

### DIFF
--- a/apps/web-giddh/src/app/contact/contact.component.html
+++ b/apps/web-giddh/src/app/contact/contact.component.html
@@ -186,8 +186,8 @@
                                             <span class="icon-arrow-down"></span>
                                         </button>
                                         <mat-menu #downloadCsvEmail="matMenu">
-                                            <button mat-menu-item (click)="downloadCSV()" aria-label="download csv">
-                                                {{ commonLocaleData?.app_download_csv }}
+                                            <button mat-menu-item (click)="downloadXlsx()" aria-label="download xlsx">
+                                                {{ commonLocaleData?.app_download_excel }}
                                             </button>
                                             <button
                                                 mat-menu-item

--- a/apps/web-giddh/src/app/contact/contact.component.ts
+++ b/apps/web-giddh/src/app/contact/contact.component.ts
@@ -1137,11 +1137,11 @@ export class ContactComponent implements OnInit, OnDestroy {
     }
 
     /**
-     * Save CSV File with data from Table
+     * Save XLSX file with data from Table
      *
      * @memberof ContactComponent
      */
-    public downloadCSV() {
+    public downloadXlsx() {
         if (this.moduleType === ContactsModule.customer) {
             this.groupUniqueName = "sundrydebtors";
         } else {
@@ -1167,8 +1167,8 @@ export class ContactComponent implements OnInit, OnDestroy {
         this.companyServices.downloadCSV(request).pipe(takeUntil(this.destroyed$)).subscribe((res) => {
             this.searchLoader$ = observableOf(false);
             if (res?.status === "success") {
-                let blobData = this.generalService.base64ToBlob(res?.body, "text/csv", 512);
-                return saveAs(blobData, `${this.groupUniqueName}.csv`);
+                let blobData = this.generalService.base64ToBlob(res?.body, "text/xlsx", 512);
+                return saveAs(blobData, `${this.groupUniqueName}.xlsx`);
             }
         });
 

--- a/apps/web-giddh/src/app/models/interfaces/stock-aging-report.interface.ts
+++ b/apps/web-giddh/src/app/models/interfaces/stock-aging-report.interface.ts
@@ -13,6 +13,7 @@ export interface StockAgingRow {
     totalQty: number;
     totalAmount: number;
     buckets: StockAgingBucket[];
+    hasVariants?: boolean;
 }
 
 /** One variant row returned by the per-stock variants API. */

--- a/apps/web-giddh/src/app/new-inventory/component/stock-aging-report/stock-aging-report.component.html
+++ b/apps/web-giddh/src/app/new-inventory/component/stock-aging-report/stock-aging-report.component.html
@@ -213,21 +213,25 @@
                 <ng-container matColumnDef="stockName">
                     <th mat-header-cell *matHeaderCellDef [style.width.%]="columnWidths.stockName">{{ localeData.item_name }}</th>
                     <td mat-cell *matCellDef="let item" [style.width.%]="columnWidths.stockName" class="text-ellipsis">
-                        <a
-                            href="javascript:void(0);"
-                            class="sar-stock-name-link text-color-inherit overflow-hidden d-flex align-items-center justify-content-between column-gap-05 w-100"
-                            [attr.aria-expanded]="isStockExpanded(item)"
-                            [attr.aria-label]="localeData.variant_type + ' ' + item?.stockName"
-                            (click)="toggleStockDetails(item)"
-                        >
+                        @if (item?.hasVariants) {
+                            <a
+                                href="javascript:void(0);"
+                                class="sar-stock-name-link text-color-inherit overflow-hidden d-flex align-items-center justify-content-between column-gap-05 w-100"
+                                [attr.aria-expanded]="isStockExpanded(item)"
+                                [attr.aria-label]="localeData.variant_type + ' ' + item?.stockName"
+                                (click)="toggleStockDetails(item)"
+                            >
+                                <span class="text-ellipsis" [matTooltip]="item?.stockName" matTooltipPosition="above">{{ item?.stockName }}</span>
+                                <span
+                                    class="icon-arrow-down font-size-12 flex-shrink-0 hover-target"
+                                    [ngClass]="{ 'rotate-180': isStockExpanded(item) }"
+                                    [matTooltip]="localeData.variant_type"
+                                    matTooltipPosition="above"
+                                ></span>
+                            </a>
+                        } @else {
                             <span class="text-ellipsis" [matTooltip]="item?.stockName" matTooltipPosition="above">{{ item?.stockName }}</span>
-                            <span
-                                class="icon-arrow-down font-size-12 flex-shrink-0 hover-target"
-                                [ngClass]="{ 'rotate-180': isStockExpanded(item) }"
-                                [matTooltip]="localeData.variant_type"
-                                matTooltipPosition="above"
-                            ></span>
-                        </a>
+                        }
                     </td>
                     <td mat-footer-cell *matFooterCellDef class="font-weight-semibold" [style.width.%]="columnWidths.stockName">
                         {{ commonLocaleData?.app_total }}
@@ -359,19 +363,6 @@
                                                 <col [style.width.%]="columnWidths.base" />
                                             }
                                         </colgroup>
-                                        <!-- <thead>
-                                            <tr>
-                                                <th class="text-center">{{ localeData.sr }}</th>
-                                                <th class="text-left">{{ localeData.variant_name }}</th>
-                                                <th class="text-left">{{ localeData.uom }}</th>
-                                                @for (col of bucketCols; track col.range) {
-                                                    <th class="text-right">{{ commonLocaleData?.app_quantity }}</th>
-                                                    <th class="text-right">{{ commonLocaleData?.app_value }}</th>
-                                                }
-                                                <th class="text-right">{{ localeData.total_qty }}</th>
-                                                <th class="text-right">{{ localeData.total_value }}</th>
-                                            </tr>
-                                        </thead> -->
                                         <tbody>
                                             @for (variant of variantRows; track variant.variantUniqueName; let i = $index; let last = $last) {
                                                 <tr [class.sar-detail-table__row--last]="last">
@@ -489,9 +480,6 @@
                                             </tr>
                                         </table>
                                     </div>
-                                }
-                                @if (isVariantLoading) {
-                                    <div class="sar-detail-panel__loading font-size-12 border-top text-center py-1">{{ commonLocaleData?.app_loading }}</div>
                                 }
                             </div>
                         }

--- a/apps/web-giddh/src/app/new-inventory/component/stock-aging-report/stock-aging-report.component.ts
+++ b/apps/web-giddh/src/app/new-inventory/component/stock-aging-report/stock-aging-report.component.ts
@@ -678,6 +678,9 @@ export class StockAgingReportComponent implements OnInit, AfterViewChecked, OnDe
      * @memberof StockAgingReportComponent
      */
     public toggleStockDetails(item: StockAgingRow): void {
+        if (!item?.hasVariants) {
+            return;
+        }
         const stockCode = this.getStockCode(item);
         if (!stockCode || this.expandedStockCode === stockCode) {
             this.collapseStockDetails();
@@ -699,6 +702,9 @@ export class StockAgingReportComponent implements OnInit, AfterViewChecked, OnDe
      * @memberof StockAgingReportComponent
      */
     public isStockExpanded(item: StockAgingRow): boolean {
+        if (!item?.hasVariants) {
+            return false;
+        }
         const stockCode = this.getStockCode(item);
         return !!stockCode && this.expandedStockCode === stockCode;
     }
@@ -1092,6 +1098,7 @@ export class StockAgingReportComponent implements OnInit, AfterViewChecked, OnDe
         // <age-range-editor> via the [vendorCustomerType] input. We only
         // refetch the report so the backend can regroup by the new buckets.
         this.getReport();
+        this.getReportTotals();
         this.onAgingRangeClose();
     }
 
@@ -1120,7 +1127,7 @@ export class StockAgingReportComponent implements OnInit, AfterViewChecked, OnDe
             `0-${a} days`,
             `${a + 1}-${b} days`,
             `${b + 1}-${c} days`,
-            `${c + 1}+ days`,
+            `${c}+ days`,
         ];
     }
 

--- a/apps/web-giddh/src/app/reports/components/purchase-register-component/purchase.register.component.html
+++ b/apps/web-giddh/src/app/reports/components/purchase-register-component/purchase.register.component.html
@@ -109,35 +109,33 @@
                     </div>
                 }
                 @if (reportForm?.get('groupBy')?.value === groupByEnum.SalesPerson) {
-                    @if ((salesPersonList$ | async)?.length) {
-                        <div class="dropdown-width">
-                            <mat-form-field appearance="outline" class="w-100">
-                                <mat-label>{{ commonLocaleData?.app_sales_person }}</mat-label>
-                                <mat-select
-                                    panelClass="py-0"
-                                    name="salesPerson"
-                                    [multiple]="true"
-                                    (selectionChange)="getPurchaseRegister(dateRange.from, dateRange.to)"
-                                    (closed)="!filteredSalesPersonList()?.length ? salesPerson.reset() : null"
-                                    formControlName="salesPersonUniqueNames"
+                    <div class="dropdown-width">
+                        <mat-form-field appearance="outline" class="w-100">
+                            <mat-label>{{ commonLocaleData?.app_sales_person }}</mat-label>
+                            <mat-select
+                                panelClass="py-0"
+                                name="salesPerson"
+                                [multiple]="true"
+                                (selectionChange)="getPurchaseRegister(dateRange.from, dateRange.to)"
+                                (closed)="!filteredSalesPersonList()?.length ? salesPerson.reset() : null"
+                                formControlName="salesPersonUniqueNames"
+                            >
+                                <ngx-mat-select-search
+                                    [placeholderLabel]="commonLocaleData?.app_sales_person_placeholder"
+                                    [noEntriesFoundLabel]="commonLocaleData?.app_no_result_found"
+                                    [formControl]="salesPerson"
+                                    [clearSearchInput]="false"
                                 >
-                                    <ngx-mat-select-search
-                                        [placeholderLabel]="commonLocaleData?.app_sales_person_placeholder"
-                                        [noEntriesFoundLabel]="commonLocaleData?.app_no_result_found"
-                                        [formControl]="salesPerson"
-                                        [clearSearchInput]="false"
-                                    >
-                                        <i class="icon-cross" ngxMatSelectSearchClear></i>
-                                    </ngx-mat-select-search>
-                                    @for (salesPerson of filteredSalesPersonList(); track salesPerson?.value) {
-                                        <mat-option [value]="salesPerson?.value">
-                                            {{ salesPerson?.label }}
-                                        </mat-option>
-                                    }
-                                </mat-select>
-                            </mat-form-field>
-                        </div>
-                    }
+                                    <i class="icon-cross" ngxMatSelectSearchClear></i>
+                                </ngx-mat-select-search>
+                                @for (salesPerson of filteredSalesPersonList(); track salesPerson?.value) {
+                                    <mat-option [value]="salesPerson?.value">
+                                        {{ salesPerson?.label }}
+                                    </mat-option>
+                                }
+                            </mat-select>
+                        </mat-form-field>
+                    </div>
                 }
                 @if (reportForm?.get('groupBy')?.value === groupByEnum.State) {
                     <div class="dropdown-width">
@@ -151,7 +149,7 @@
                             [required]="true"
                         ></reactive-dropdown-field>
                     </div>
-                    @if (reportForm?.get('countryCode')?.value && stateList()?.length) {
+                    @if (reportForm?.get('countryCode')?.value) {
                         <div class="dropdown-width">
                             <mat-form-field appearance="outline" class="w-100">
                                 <mat-label>{{ commonLocaleData?.app_state }}</mat-label>

--- a/apps/web-giddh/src/app/reports/components/purchase-register-component/purchase.register.component.ts
+++ b/apps/web-giddh/src/app/reports/components/purchase-register-component/purchase.register.component.ts
@@ -265,7 +265,7 @@ constructor(
 
         this.getSalesPersonList();
         this.salesPersonList$.pipe(skip(1), take(1), filter(Boolean)).subscribe(res => {
-            this.allOptions.salesPerson = (res as IOption[]) ?? [];
+            this.allOptions.salesPerson = this.withOtherSalesPerson(res as IOption[]);
             this.filteredSalesPersonList.set(this.withOtherSalesPerson(res as IOption[]));
         });
 
@@ -334,7 +334,7 @@ constructor(
                     label: state.name,
                     value: state.code
                 })));
-                this.allOptions.state = this.stateList();
+                this.allOptions.state = this.withOtherState(this.stateList());
                 this.filteredStateList.set(this.withOtherState(this.stateList()));
             }
         });

--- a/apps/web-giddh/src/app/reports/components/purchase-register-component/purchase.register.component.ts
+++ b/apps/web-giddh/src/app/reports/components/purchase-register-component/purchase.register.component.ts
@@ -266,7 +266,7 @@ constructor(
         this.getSalesPersonList();
         this.salesPersonList$.pipe(skip(1), take(1), filter(Boolean)).subscribe(res => {
             this.allOptions.salesPerson = (res as IOption[]) ?? [];
-            this.filteredSalesPersonList.set(res as IOption[]);
+            this.filteredSalesPersonList.set(this.withOtherSalesPerson(res as IOption[]));
         });
 
         this.accountList$.pipe(takeUntil(this.destroyed$)).subscribe((res: any) => {
@@ -278,11 +278,13 @@ constructor(
             takeUntil(this.destroyed$), distinctUntilChanged()).subscribe((search: string) => {
                 if (!search) {
                     this.salesPersonList$.pipe(take(1)).subscribe(res => {
-                        this.filteredSalesPersonList.set(res as IOption[]);
+                        this.filteredSalesPersonList.set(this.withOtherSalesPerson(res as IOption[]));
                     });
                 } else {
                     this.salesPersonList$.pipe(take(1)).subscribe(res => {
-                        this.filteredSalesPersonList.set(res?.filter(salesPerson => salesPerson?.label?.toLowerCase()?.includes(search?.toLowerCase())) as IOption[]);
+                        this.filteredSalesPersonList.set(this.withOtherSalesPerson(
+                            res?.filter(salesPerson => salesPerson?.label?.toLowerCase()?.includes(search?.toLowerCase())) as IOption[]
+                        ));
                     });
                 }
             });
@@ -311,9 +313,11 @@ constructor(
         this.stateSearch.valueChanges.pipe(debounceTime(200),
             takeUntil(this.destroyed$), distinctUntilChanged()).subscribe((search: string) => {
                 if (!search) {
-                    this.filteredStateList.set(this.stateList());
+                    this.filteredStateList.set(this.withOtherState(this.stateList()));
                 } else {
-                    this.filteredStateList.set(this.stateList()?.filter(state => state?.label?.toLowerCase()?.includes(search?.toLowerCase())));
+                    this.filteredStateList.set(this.withOtherState(
+                        this.stateList()?.filter(state => state?.label?.toLowerCase()?.includes(search?.toLowerCase()))
+                    ));
                 }
             });
 
@@ -331,7 +335,7 @@ constructor(
                     value: state.code
                 })));
                 this.allOptions.state = this.stateList();
-                this.filteredStateList.set(this.stateList());
+                this.filteredStateList.set(this.withOtherState(this.stateList()));
             }
         });
 
@@ -341,7 +345,7 @@ constructor(
                 this.loadStates(countryCode);
             } else {
                 this.stateList.set([]);
-                this.filteredStateList.set([]);
+                this.filteredStateList.set(this.withOtherState([]));
             }
         });
 
@@ -900,6 +904,30 @@ constructor(
     public openSalesPersonDialog(): void {
         const dialogRef = this.dialog.open(SalesPersonComponent, ASIDE_PANE_CONFIG);
         dialogRef.afterClosed().pipe(filter(Boolean), take(1), tap(() => this.getSalesPersonList())).subscribe();
+    }
+
+    /**
+     * Prepends the Other sales person option used by the dropdown.
+     *
+     * @private
+     * @param {IOption[]} list Sales person options from the API
+     * @returns {IOption[]} List with Other first
+     * @memberof PurchaseRegisterComponent
+     */
+    private withOtherSalesPerson(list: IOption[]): IOption[] {
+        return [{ label: 'Other', value: 'OTHER_SALES_PERSON' }, ...(list ?? [])];
+    }
+
+    /**
+     * Prepends the Other state option used by the dropdown.
+     *
+     * @private
+     * @param {IOption[]} list State options from the API
+     * @returns {IOption[]} List with Other first
+     * @memberof PurchaseRegisterComponent
+     */
+    private withOtherState(list: IOption[]): IOption[] {
+        return [{ label: 'Other', value: 'OTHER_STATE' }, ...(list ?? [])];
     }
 
     /**

--- a/apps/web-giddh/src/app/reports/components/report-details-components/report.details.component.html
+++ b/apps/web-giddh/src/app/reports/components/report-details-components/report.details.component.html
@@ -107,35 +107,33 @@
                     </div>
                 }
                 @if (reportForm?.get('groupBy')?.value === groupByEnum.SalesPerson) {
-                    @if ((salesPersonList$ | async)?.length) {
-                        <div class="dropdown-width">
-                            <mat-form-field appearance="outline" class="w-100">
-                                <mat-label>{{ commonLocaleData?.app_sales_person }}</mat-label>
-                                <mat-select
-                                    panelClass="py-0"
-                                    name="salesPerson"
-                                    [multiple]="true"
-                                    (selectionChange)="saveSalesPersonFilter()"
-                                    (closed)="!filteredSalesPersonList()?.length ? salesPerson.reset() : null"
-                                    formControlName="salesPersonUniqueNames"
+                    <div class="dropdown-width">
+                        <mat-form-field appearance="outline" class="w-100">
+                            <mat-label>{{ commonLocaleData?.app_sales_person }}</mat-label>
+                            <mat-select
+                                panelClass="py-0"
+                                name="salesPerson"
+                                [multiple]="true"
+                                (selectionChange)="saveSalesPersonFilter()"
+                                (closed)="!filteredSalesPersonList()?.length ? salesPerson.reset() : null"
+                                formControlName="salesPersonUniqueNames"
+                            >
+                                <ngx-mat-select-search
+                                    [placeholderLabel]="commonLocaleData?.app_sales_person_placeholder"
+                                    [noEntriesFoundLabel]="commonLocaleData?.app_no_result_found"
+                                    [formControl]="salesPerson"
+                                    [clearSearchInput]="false"
                                 >
-                                    <ngx-mat-select-search
-                                        [placeholderLabel]="commonLocaleData?.app_sales_person_placeholder"
-                                        [noEntriesFoundLabel]="commonLocaleData?.app_no_result_found"
-                                        [formControl]="salesPerson"
-                                        [clearSearchInput]="false"
-                                    >
-                                        <i class="icon-cross" ngxMatSelectSearchClear></i>
-                                    </ngx-mat-select-search>
-                                    @for (salesPerson of filteredSalesPersonList(); track salesPerson?.value) {
-                                        <mat-option [value]="salesPerson?.value">
-                                            {{ salesPerson?.label }}
-                                        </mat-option>
-                                    }
-                                </mat-select>
-                            </mat-form-field>
-                        </div>
-                    }
+                                    <i class="icon-cross" ngxMatSelectSearchClear></i>
+                                </ngx-mat-select-search>
+                                @for (salesPerson of filteredSalesPersonList(); track salesPerson?.value) {
+                                    <mat-option [value]="salesPerson?.value">
+                                        {{ salesPerson?.label }}
+                                    </mat-option>
+                                }
+                            </mat-select>
+                        </mat-form-field>
+                    </div>
                 }
                 @if (reportForm?.get('groupBy')?.value === groupByEnum.State) {
                     <div class="dropdown-width">
@@ -149,7 +147,7 @@
                             [required]="true"
                         ></reactive-dropdown-field>
                     </div>
-                    @if (reportForm?.get('countryCode')?.value && stateList()?.length) {
+                    @if (reportForm?.get('countryCode')?.value) {
                         <div class="dropdown-width">
                             <mat-form-field appearance="outline" class="w-100">
                                 <mat-label>{{ commonLocaleData?.app_state }}</mat-label>

--- a/apps/web-giddh/src/app/reports/components/report-details-components/report.details.component.ts
+++ b/apps/web-giddh/src/app/reports/components/report-details-components/report.details.component.ts
@@ -262,8 +262,8 @@ constructor(
 
         this.getSalesPersonList();
         this.salesPersonList$.pipe(skip(1), take(1), filter(Boolean)).subscribe(res => {
-            this.allOptions.salesPerson = (res as IOption[]) ?? [];
-            this.filteredSalesPersonList.set(res as IOption[]);
+            this.allOptions.salesPerson = this.withOtherSalesPerson(res as IOption[]);
+            this.filteredSalesPersonList.set(this.withOtherSalesPerson(res as IOption[]));
         });
 
         this.accountList$.pipe(takeUntil(this.destroyed$)).subscribe((res: any) => {
@@ -275,11 +275,13 @@ constructor(
             takeUntil(this.destroyed$), distinctUntilChanged()).subscribe((search: string) => {
                 if (!search) {
                     this.salesPersonList$.pipe(take(1)).subscribe(res => {
-                        this.filteredSalesPersonList.set(res as IOption[]);
+                        this.filteredSalesPersonList.set(this.withOtherSalesPerson(res as IOption[]));
                     });
                 } else {
                     this.salesPersonList$.pipe(take(1)).subscribe(res => {
-                        this.filteredSalesPersonList.set(res?.filter(salesPerson => salesPerson?.label?.toLowerCase()?.includes(search?.toLowerCase())) as IOption[]);
+                        this.filteredSalesPersonList.set(this.withOtherSalesPerson(
+                            res?.filter(salesPerson => salesPerson?.label?.toLowerCase()?.includes(search?.toLowerCase())) as IOption[]
+                        ));
                     });
                 }
             });
@@ -308,9 +310,11 @@ constructor(
         this.stateSearch.valueChanges.pipe(debounceTime(200),
             takeUntil(this.destroyed$), distinctUntilChanged()).subscribe((search: string) => {
                 if (!search) {
-                    this.filteredStateList.set(this.stateList());
+                    this.filteredStateList.set(this.withOtherState(this.stateList()));
                 } else {
-                    this.filteredStateList.set(this.stateList()?.filter(state => state?.label?.toLowerCase()?.includes(search?.toLowerCase())));
+                    this.filteredStateList.set(this.withOtherState(
+                        this.stateList()?.filter(state => state?.label?.toLowerCase()?.includes(search?.toLowerCase()))
+                    ));
                 }
             });
 
@@ -320,8 +324,8 @@ constructor(
                     label: state.name,
                     value: state.code
                 })));
-                this.allOptions.state = this.stateList();
-                this.filteredStateList.set(this.stateList());
+                this.allOptions.state = this.withOtherState(this.stateList());
+                this.filteredStateList.set(this.withOtherState(this.stateList()));
             }
         });
 
@@ -331,7 +335,7 @@ constructor(
                 this.loadStates(countryCode);
             } else {
                 this.stateList.set([]);
-                this.filteredStateList.set([]);
+                this.filteredStateList.set(this.withOtherState([]));
             }
         });
     }
@@ -918,6 +922,30 @@ constructor(
     public openSalesPersonDialog(): void {
         const dialogRef = this.dialog.open(SalesPersonComponent, ASIDE_PANE_CONFIG);
         dialogRef.afterClosed().pipe(filter(Boolean), take(1), tap(() => this.getSalesPersonList())).subscribe();
+    }
+
+    /**
+     * Prepends the Other sales person option used by the dropdown.
+     *
+     * @private
+     * @param {IOption[]} list Sales person options from the API
+     * @returns {IOption[]} List with Other first
+     * @memberof ReportsDetailsComponent
+     */
+    private withOtherSalesPerson(list: IOption[]): IOption[] {
+        return [{ label: 'Other', value: 'OTHER_SALES_PERSON' }, ...(list ?? [])];
+    }
+
+    /**
+     * Prepends the Other state option used by the dropdown.
+     *
+     * @private
+     * @param {IOption[]} list State options from the API
+     * @returns {IOption[]} List with Other first
+     * @memberof ReportsDetailsComponent
+     */
+    private withOtherState(list: IOption[]): IOption[] {
+        return [{ label: 'Other', value: 'OTHER_STATE' }, ...(list ?? [])];
     }
 
     /**

--- a/apps/web-giddh/src/app/search/components/search-filter/search-filter.component.html
+++ b/apps/web-giddh/src/app/search/components/search-filter/search-filter.component.html
@@ -123,7 +123,7 @@
             {{ commonLocaleData?.app_reset }}
         </button>
         <button class="ml-auto" type="button" matButton="filled" *ngIf="showDownloadCsv" (click)="createCSV()">
-            {{ commonLocaleData?.app_download_xlsx }}
+            {{ commonLocaleData?.app_download_excel }}
         </button>
     </div>
 </section>

--- a/apps/web-giddh/src/app/vouchers/template-edit-dialog/template-edit-dialog.component.html
+++ b/apps/web-giddh/src/app/vouchers/template-edit-dialog/template-edit-dialog.component.html
@@ -6,9 +6,9 @@
             class="ml-auto"
             matButton="filled"
             matBadgeColor="warn"
-            [matBadge]="message1CharacterLimitErrorCount"
-            [matBadgeHidden]="!message1CharacterLimitErrorCount"
-            [matTooltip]="message1CharacterLimitErrorCount ? localeData?.message1_character_limit_exceeded : ''"
+            [matBadge]="templateSaveErrorCount"
+            [matBadgeHidden]="!templateSaveErrorCount"
+            [matTooltip]="templateSaveErrorTooltip"
             [matTooltipPosition]="'left'"
             (click)="templateData?.mode === templateModeEnum.Create ? createTemplate() : updateTemplate()"
         >

--- a/apps/web-giddh/src/app/vouchers/template-edit-dialog/template-edit-dialog.component.ts
+++ b/apps/web-giddh/src/app/vouchers/template-edit-dialog/template-edit-dialog.component.ts
@@ -93,6 +93,45 @@ export class TemplateEditDialogComponent implements OnInit, OnDestroy {
   }
 
   /**
+   * True when the template name is empty.
+   *
+   * @readonly
+   * @type {boolean}
+   * @memberof TemplateEditDialogComponent
+   */
+  public get isTemplateNameMissing(): boolean {
+    return !this.customTemplate?.name?.trim();
+  }
+
+  /**
+   * Total validation errors shown on the save button badge (name + Note 1).
+   *
+   * @readonly
+   * @type {number}
+   * @memberof TemplateEditDialogComponent
+   */
+  public get templateSaveErrorCount(): number {
+    return (this.isTemplateNameMissing ? 1 : 0) + this.message1CharacterLimitErrorCount;
+  }
+
+  /**
+   * Tooltip listing the current save-blocking errors.
+   *
+   * @readonly
+   * @type {string}
+   * @memberof TemplateEditDialogComponent
+   */
+  public get templateSaveErrorTooltip(): string {
+    const errors: string[] = [];
+    if (this.isTemplateNameMissing) {
+      errors.push(this.localeData?.please_enter_template_name);
+    } else if (this.message1CharacterLimitErrorCount) {
+      errors.push(this.localeData?.message1_character_limit_exceeded);
+    }
+    return errors.join(', ');
+  }
+
+  /**
    * Closes the dialog.
    *
    * @memberof TemplateEditDialogComponent
@@ -126,6 +165,10 @@ export class TemplateEditDialogComponent implements OnInit, OnDestroy {
     let copiedTemplate = cloneDeep(data);
     if (!data.name) {
       this.toasty.errorToast(this.localeData?.please_enter_template_name);
+      return;
+    }
+    if (this.message1CharacterLimitErrorCount) {
+      this.toasty.errorToast(this.localeData?.message1_character_limit_exceeded);
       return;
     }
 
@@ -237,6 +280,11 @@ export class TemplateEditDialogComponent implements OnInit, OnDestroy {
       this.toasty.errorToast(this.localeData?.please_enter_template_name);
       return;
     }
+    if (this.message1CharacterLimitErrorCount) {
+      this.toasty.errorToast(this.localeData?.message1_character_limit_exceeded);
+      return;
+    }
+
     data.updatedAt = null;
     data.updatedBy = null;
     if (data?.sections?.header?.data?.['address']) {

--- a/apps/web-giddh/src/assets/locale/en.json
+++ b/apps/web-giddh/src/assets/locale/en.json
@@ -450,7 +450,7 @@
     "app_schedule_now": "Schedule Now",
     "app_reset": "Reset",
     "app_download_csv": "Download CSV",
-    "app_download_xlsx": "Download Excel",
+    "app_download_excel": "Download Excel",
     "app_show": "Show",
     "app_report": "Report",
     "app_tcs": "TCS",

--- a/apps/web-giddh/src/assets/locale/hi.json
+++ b/apps/web-giddh/src/assets/locale/hi.json
@@ -450,7 +450,7 @@
     "app_schedule_now": "अब शेड्यूल करें",
     "app_reset": "रीसेट",
     "app_download_csv": "सीएसव्ही डाउनलोड करें",
-    "app_download_xlsx": "एक्सेल डाउनलोड करें",
+    "app_download_excel": "एक्सेल डाउनलोड करें",
     "app_show": "प्रदर्शन",
     "app_report": "रिपोर्ट",
     "app_tcs": "टीसीएस",

--- a/apps/web-giddh/src/assets/locale/mr.json
+++ b/apps/web-giddh/src/assets/locale/mr.json
@@ -450,7 +450,7 @@
     "app_schedule_now": "आता वेळापत्रक",
     "app_reset": "रीसेट करा",
     "app_download_csv": "सीएसव्ही डाउनलोड करा",
-    "app_download_xlsx": "एक्सेल डाउनलोड करा",
+    "app_download_excel": "एक्सेल डाउनलोड करा",
     "app_show": "दाखवा",
     "app_report": "अहवाल द्या",
     "app_tcs": "टीसीएस",


### PR DESCRIPTION
## **User description**
https://app.clickup.com/t/3687137/86d3y3ffe
https://app.clickup.com/t/3687137/86d420q7r
https://app.clickup.com/t/3687137/86d40rar4
https://app.clickup.com/t/3687137/86d3xnqf1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are mostly UI labels, filter options, and client-side validation; no auth or payment logic. Verify backend accepts the new Other filter codes and still returns XLSX for contact download.
> 
> **Overview**
> **Voucher templates** now block create/update when Note 1 (primary or secondary language) exceeds the character limit, with the save button badge and tooltip reflecting missing name plus Note 1 errors—not only primary Note 1.
> 
> **Contacts and search** switch download actions to Excel labeling (`app_download_excel`) and contact export saves an `.xlsx` blob instead of CSV.
> 
> **Stock aging** only shows expandable variant rows when `hasVariants` is true, refreshes totals after saving custom age ranges, adjusts the open-ended bucket label to `${c}+ days`, and drops the inline variant loading row.
> 
> **Sales and purchase register** reports always show sales-person and state multi-selects (even when API lists are empty), prepend **Other** options (`OTHER_SALES_PERSON`, `OTHER_STATE`), and show the state filter whenever a country is selected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b45d33c5779c575ddbb810f2c4ee180cdbbc3067. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
Export contacts as Excel files and make report filters, stock details, and template validation clearer and more reliable

### What Changed
- Contact downloads now produce `.xlsx` Excel files with updated download labels.
- Stock aging rows only show expandable variant details when variants are available, and updated age ranges refresh both report data and totals.
- Purchase register filters always include an “Other” option for sales people and states, including during searches; sales-person and state filters remain available when their lists are empty.
- Template saving now identifies missing names and oversized note text on the save button, blocks invalid saves, and displays the relevant error message.
- Search download actions use the consistent “Download Excel” label across supported languages.

### Impact
`✅ Excel contact exports`
`✅ Fewer empty stock-detail expansions`
`✅ Clearer template save errors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
