### PR TITLE
Ankit | Test | Test - Unable to check the transactions of data coming on Aging report page

### DIFF
--- a/apps/web-giddh/src/app/new-inventory/component/stock-aging-report/stock-aging-report.component.html
+++ b/apps/web-giddh/src/app/new-inventory/component/stock-aging-report/stock-aging-report.component.html
@@ -296,7 +296,7 @@
                             {{ commonLocaleData?.app_quantity }}
                         </th>
                         <td mat-cell *matCellDef="let item" class="text-right">
-                            <span class="sar-qty-link cursor-pointer" (click)="openDetailsAside(item); $event.stopPropagation()">
+                            <span class="sar-qty-link cursor-pointer" (click)="openDetailsAside(item, undefined, i); $event.stopPropagation()">
                                 <amount-field
                                     [amount]="getBucket(item?.buckets, i)?.quantity"
                                     [currencySymbol]="false"
@@ -318,7 +318,7 @@
                             {{ commonLocaleData?.app_value }}
                         </th>
                         <td mat-cell *matCellDef="let item" class="text-right">
-                            <span class="sar-qty-link cursor-pointer" (click)="openDetailsAside(item); $event.stopPropagation()">
+                            <span class="sar-qty-link cursor-pointer" (click)="openDetailsAside(item, undefined, i); $event.stopPropagation()">
                                 <amount-field
                                     [amount]="getBucket(item?.buckets, i)?.value"
                                     [currencySymbol]="false"
@@ -373,7 +373,7 @@
                                                     <td class="text-left">{{ variant?.stockUnitCode }}</td>
                                                     @for (col of bucketCols; track col.range; let bucketIndex = $index) {
                                                         <td class="text-right">
-                                                            <span class="sar-qty-link cursor-pointer" (click)="openDetailsAside(item, variant)">
+                                                            <span class="sar-qty-link cursor-pointer" (click)="openDetailsAside(item, variant, bucketIndex)">
                                                                 <amount-field
                                                                     [amount]="getBucket(variant?.buckets, bucketIndex)?.quantity"
                                                                     [currencySymbol]="false"
@@ -382,7 +382,7 @@
                                                             </span>
                                                         </td>
                                                         <td class="text-right">
-                                                            <span class="sar-qty-link cursor-pointer" (click)="openDetailsAside(item, variant)">
+                                                            <span class="sar-qty-link cursor-pointer" (click)="openDetailsAside(item, variant, bucketIndex)">
                                                                 <amount-field
                                                                     [amount]="getBucket(variant?.buckets, bucketIndex)?.value"
                                                                     [currencySymbol]="false"

--- a/apps/web-giddh/src/app/new-inventory/component/stock-aging-report/stock-aging-report.component.ts
+++ b/apps/web-giddh/src/app/new-inventory/component/stock-aging-report/stock-aging-report.component.ts
@@ -191,13 +191,15 @@ export class StockAgingReportComponent implements OnInit, AfterViewChecked, OnDe
     /** Total details pages reported by the details API. */
     private detailTotalPages: number = 0;
     /** Transactions requested per details page. */
-    private readonly detailCount: number = 10;
+    private readonly detailCount: number = PAGINATION_LIMIT;
     /** Distance in px from the bottom of a scroll list at which the next page is fetched. */
     private readonly detailScrollThreshold: number = 40;
     /** Stock unique name whose transactions are open in the aside. */
     private asideStockCode: string = '';
     /** Variant unique name sent with the details API when opened from a variant row. */
     private asideVariantUniqueName: string = '';
+    /** Aging interval (`first`…`fourth`) sent with the details API when opened from a bucket cell. */
+    private asideInterval: string = '';
     /** Scroll container of the aside transaction list. */
     @ViewChild('detailScroll') private detailScrollRef?: ElementRef<HTMLElement>;
     /** Aside template for the stock / variant transaction breakup. */
@@ -850,16 +852,18 @@ export class StockAgingReportComponent implements OnInit, AfterViewChecked, OnDe
      * Open the transaction-details aside for a stock row, or a variant row when `variant` is passed.
      * @param item Parent stock row.
      * @param variant Variant row when the click came from the expand table.
+     * @param intervalIndex 0-based bucket index when the click came from a Qty/Value cell.
      * @returns void
      * @memberof StockAgingReportComponent
      */
-    public openDetailsAside(item: StockAgingRow, variant?: StockAgingVariantRow): void {
+    public openDetailsAside(item: StockAgingRow, variant?: StockAgingVariantRow, intervalIndex?: number): void {
         const stockCode = this.getStockCode(item);
         if (!stockCode) {
             return;
         }
         this.asideStockCode = stockCode;
         this.asideVariantUniqueName = variant?.variantUniqueName ?? '';
+        this.asideInterval = intervalIndex != null ? (this.intervalOrdinals[intervalIndex] ?? '') : '';
         this.detailData = null;
         this.detailTransactions = [];
         this.detailPage = 1;
@@ -875,6 +879,7 @@ export class StockAgingReportComponent implements OnInit, AfterViewChecked, OnDe
                 this.stockDetailsAsideRef = undefined;
                 this.asideStockCode = '';
                 this.asideVariantUniqueName = '';
+                this.asideInterval = '';
                 this.detailData = null;
                 this.detailTransactions = [];
             });
@@ -939,6 +944,9 @@ export class StockAgingReportComponent implements OnInit, AfterViewChecked, OnDe
         const payload: any = this.buildFilterPayload();
         if (this.asideVariantUniqueName) {
             payload.variantUniqueName = this.asideVariantUniqueName;
+        }
+        if (this.asideInterval) {
+            payload.interval = this.asideInterval;
         }
         this.inventoryService.getStockAgingReportDetails(stockCode, payload, page, this.detailCount)
             .pipe(takeUntil(this.destroyed$))
@@ -1127,7 +1135,7 @@ export class StockAgingReportComponent implements OnInit, AfterViewChecked, OnDe
             `0-${a} days`,
             `${a + 1}-${b} days`,
             `${b + 1}-${c} days`,
-            `${c}+ days`,
+            `${c + 1}+ days`,
         ];
     }
 


### PR DESCRIPTION
## **User description**
https://app.clickup.com/t/3687137/86d40e9d4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how aging drill-down calls the details API and alters displayed bucket labels for custom ranges; behavior depends on backend interval handling but is limited to the aging report UI.
> 
> **Overview**
> Fixes the stock aging **transaction aside** so clicks on a specific aging bucket’s quantity or value load transactions for that interval, not the full stock total.
> 
> **Bucket drill-down:** `openDetailsAside` now accepts an optional bucket index; main and variant bucket cells pass that index. The details request includes `interval` (`first`–`fourth` via `intervalOrdinals`) when opened from a bucket cell; total qty/value clicks still omit it. State is cleared when the aside closes.
> 
> **Other tweaks:** Details pagination page size uses shared `PAGINATION_LIMIT` instead of a hardcoded 10. Locally built fourth bucket label changes from `${c}+ days` to `${c + 1}+ days` so it matches the day-after-third-boundary pattern used for the other ranges.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4083789ba99b1d5148a2e2b337068ce37dcf27b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
Show transactions for the selected aging bucket

### What Changed
- Clicking a quantity or value in an aging bucket now opens transactions for that specific bucket instead of all aging periods
- Bucket selections work for both stock rows and expanded variant rows
- The final aging range now starts at the day after the previous boundary, preventing overlapping ranges
- Details pages use the report’s standard transaction page size

### Impact
`✅ Accurate bucket-level transaction details`
`✅ Correct variant transaction filtering`
`✅ Non-overlapping aging ranges`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
