### PR TITLE
Ankit | Test | Prod - cursor/value reverts to an earlier state while typing on company profile > update company name in company profile page

### DIFF
--- a/apps/web-giddh/src/app/settings/personal-information/personal-information.component.html
+++ b/apps/web-giddh/src/app/settings/personal-information/personal-information.component.html
@@ -10,7 +10,8 @@
                             [type]="'text'"
                             [name]="'companyName'"
                             [label]="localeData?.company_name"
-                            (onBlurEvent)="profileUpdated('name')"
+                            (onBlurEvent)="onNameBlur()"
+                            (input)="onNameInput()"
                         ></input-field>
                         <input-field
                             *ngIf="organizationType === 'BRANCH' || isConsolidatedBranch"

--- a/apps/web-giddh/src/app/settings/personal-information/personal-information.component.ts
+++ b/apps/web-giddh/src/app/settings/personal-information/personal-information.component.ts
@@ -1,5 +1,5 @@
 import { Component, EventEmitter, Inject, Input, OnChanges, OnDestroy, OnInit, Output, SimpleChanges } from '@angular/core';
-import { ReplaySubject, Subject } from 'rxjs';
+import { BehaviorSubject, combineLatest, ReplaySubject, Subject } from 'rxjs';
 import { debounceTime, takeUntil, pairwise, filter } from 'rxjs/operators';
 import { OrganizationType } from '../../models/user-login-state';
 import { CurrencyDisplayFormat, OrganizationProfile } from '../constants/settings.constant';
@@ -57,6 +57,8 @@ export class PersonalInformationComponent implements OnInit, OnChanges, OnDestro
     @Output() public saveProfile: EventEmitter<any> = new EventEmitter();
     /** Subject to release subscriptions */
     private destroyed$: ReplaySubject<boolean> = new ReplaySubject(1);
+    /** True when a typed name change should be saved after the debounce */
+    private shouldDebounceNameUpdate$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
     /** Portal Domain name validation with regex pattern */
     public isValidDomain: boolean;
     /** Stores the voucher API version of company */
@@ -98,6 +100,21 @@ export class PersonalInformationComponent implements OnInit, OnChanges, OnDestro
                 this.saveProfile.emit(this.updatedData);
             }
         });
+
+        if (this.organizationType === 'COMPANY') {
+            combineLatest([
+                this.profileForm?.get('name')?.valueChanges,
+                this.shouldDebounceNameUpdate$
+            ]).pipe(
+                takeUntil(this.destroyed$),
+                debounceTime(2000)
+            ).subscribe(([, shouldUpdate]) => {
+                if (shouldUpdate) {
+                    this.profileUpdated('name');
+                    this.shouldDebounceNameUpdate$.next(false);
+                }
+            });
+        }
     }
 
     /**
@@ -200,8 +217,31 @@ export class PersonalInformationComponent implements OnInit, OnChanges, OnDestro
      * @memberof PersonalInformationComponent
      */
     public ngOnDestroy(): void {
+        this.shouldDebounceNameUpdate$.complete();
         this.destroyed$.next(true);
         this.destroyed$.complete();
+    }
+
+    /**
+     * Enables the debounced update when the user types a company name.
+     *
+     * @memberof PersonalInformationComponent
+     */
+    public onNameInput(): void {
+        this.shouldDebounceNameUpdate$.next(true);
+    }
+
+    /**
+     * Saves the company name on blur only when it differs from the last saved value.
+     *
+     * @memberof PersonalInformationComponent
+     */
+    public onNameBlur(): void {
+        this.shouldDebounceNameUpdate$.next(false);
+        const currentName = this.profileForm?.get('name')?.value;
+        if (currentName !== this.profileData?.name) {
+            this.profileUpdated('name');
+        }
     }
 
     /**


### PR DESCRIPTION
## **User description**
https://app.clickup.com/t/3687137/86d3zyaee

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UX change to company profile name saving in one component; no auth or API contract changes.
> 
> **Overview**
> Fixes company name edits reverting while typing on the company profile page by changing how the **name** field triggers saves.
> 
> The company name field no longer saves immediately on blur. Typing sets a flag and a **2 second** debounced pipeline (combined with `name` `valueChanges`) calls `profileUpdated('name')` after the user pauses. On blur, any pending debounced save is cancelled; the name is saved only if it still differs from `profileData.name`.
> 
> This matches the debounced pattern used for other profile fields (e.g. aliases, portal domain) instead of saving on every blur.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b06433a6a23081ce8a1496302503de30978bfb9f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
Prevent company names from reverting while typing

### What Changed
- Company name edits are saved after the user stops typing for two seconds
- Leaving the field saves any unsaved name change immediately
- Unchanged names are not saved again when the field loses focus
- Branch and consolidated branch name behavior remains unchanged

### Impact
`✅ Company names no longer revert during typing`
`✅ Fewer unnecessary profile saves`
`✅ Company name changes are saved reliably`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
